### PR TITLE
feat: add pluggable state backend with LOCAL and BUCKET_STORE

### DIFF
--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -1,13 +1,6 @@
 import { deployStack } from '../stack';
-import {
-  getContext,
-  getIacLocation,
-  logger,
-  setContext,
-  setIac,
-  withLock,
-  getStatePath,
-} from '../common';
+import { getContext, getIacLocation, logger, setContext, setIac } from '../common';
+import { createStateBackend } from '../common/stateBackend';
 import { parseYaml, revalYaml } from '../parser';
 import { lang } from '../lang';
 
@@ -42,10 +35,9 @@ export const deploy = async (
 
   logger.info(lang.__('DEPLOYING_STACK'));
 
-  // Acquire lock for the deployment operation
-  const statePath = getStatePath();
-  await withLock(statePath, 'deploy', async () => {
-    await deployStack(stackName, iac);
+  const backend = createStateBackend(iac.backend, context);
+  await backend.withLock('deploy', async () => {
+    await deployStack(stackName, iac, backend);
   });
 
   logger.info(lang.__('STACK_DEPLOYED'));

--- a/src/commands/destroy.ts
+++ b/src/commands/destroy.ts
@@ -1,13 +1,5 @@
-import {
-  getContext,
-  getIacLocation,
-  logger,
-  setContext,
-  setIac,
-  ProviderEnum,
-  withLock,
-  getStatePath,
-} from '../common';
+import { getContext, getIacLocation, logger, setContext, setIac, ProviderEnum } from '../common';
+import { createStateBackend } from '../common/stateBackend';
 import { parseYaml, revalYaml } from '../parser';
 import { lang } from '../lang';
 import { destroyTencentStack } from '../stack/scfStack';
@@ -45,13 +37,12 @@ export const destroyStack = async (
     }),
   );
 
-  // Acquire lock for the destroy operation
-  const statePath = getStatePath();
-  await withLock(statePath, 'destroy', async () => {
+  const backend = createStateBackend(iac.backend, context);
+  await backend.withLock('destroy', async () => {
     if (iac.provider.name === ProviderEnum.TENCENT) {
-      await destroyTencentStack();
+      await destroyTencentStack(backend);
     } else if (iac.provider.name === ProviderEnum.ALIYUN) {
-      await destroyAliyunStack();
+      await destroyAliyunStack(backend);
     } else {
       throw new Error(`Unsupported provider: ${iac.provider.name}`);
     }

--- a/src/commands/forceUnlock.ts
+++ b/src/commands/forceUnlock.ts
@@ -1,12 +1,9 @@
 import readline from 'node:readline';
-import {
-  getStatePath,
-  forceUnlock,
-  readLockFileForCommand,
-  formatLockInfo,
-  logger,
-} from '../common';
+import { getIacLocation, formatLockInfo, logger, setContext, getContext } from '../common';
+import { createStateBackend } from '../common/stateBackend';
+import { createLocalStateBackend } from '../common/stateBackend/localStateBackend';
 import { lang } from '../lang';
+import { parseYaml, revalYaml } from '../parser';
 
 const askConfirmation = (question: string): Promise<boolean> => {
   const rl = readline.createInterface({
@@ -22,11 +19,33 @@ const askConfirmation = (question: string): Promise<boolean> => {
   });
 };
 
-export const forceUnlockCommand = async (lockId: string): Promise<void> => {
-  const statePath = getStatePath();
+export const forceUnlockCommand = async (
+  lockId: string,
+  options: {
+    location?: string;
+    stage?: string;
+    region?: string;
+    provider?: string;
+    accessKeyId?: string;
+    accessKeySecret?: string;
+    securityToken?: string;
+  } = {},
+): Promise<void> => {
+  let backend;
+
+  if (options.location) {
+    const iacLocation = getIacLocation(options.location);
+    const rawIac = parseYaml(iacLocation);
+    await setContext({ ...options, iacProvider: rawIac.provider, stages: rawIac.stages }, false);
+    const context = getContext();
+    const iac = revalYaml(iacLocation, context);
+    backend = createStateBackend(iac.backend, context);
+  } else {
+    backend = createLocalStateBackend();
+  }
 
   // Check if lock exists
-  const existingLock = readLockFileForCommand(statePath);
+  const existingLock = await backend.readLock();
   if (!existingLock) {
     logger.error(lang.__('NO_LOCK_FOUND'));
     throw new Error(lang.__('NO_LOCK_FOUND'));
@@ -62,7 +81,7 @@ export const forceUnlockCommand = async (lockId: string): Promise<void> => {
   }
 
   // Force unlock
-  const success = forceUnlock(statePath, lockId);
+  const success = await backend.forceUnlock(lockId);
   if (success) {
     logger.info(lang.__('LOCK_RELEASED'));
   } else {

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -228,10 +228,31 @@ program
 program
   .command('force-unlock <lockId>')
   .description('manually remove a stuck lock (use with caution)')
+  .option('-f, --file <path>', 'specify the yaml file (required for remote backends)')
+  .option('-s, --stage <stage>', 'specify the stage')
+  .option('-r, --region <region>', 'specify the region')
+  .option('-v, --provider <provider>', 'specify the provider')
+  .option('-k, --accessKeyId <accessKeyId>', 'specify the AccessKeyId')
+  .option('-x, --accessKeySecret <accessKeySecret>', 'specify the AccessKeySecret')
+  .option('-n, --securityToken <securityToken>', 'specify the SecurityToken')
   .action(
-    actionWrapper('force-unlock', async (lockId) => {
-      await forceUnlockCommand(lockId);
-    }),
+    actionWrapper(
+      'force-unlock',
+      async (
+        lockId,
+        { file, stage, region, provider, accessKeyId, accessKeySecret, securityToken },
+      ) => {
+        await forceUnlockCommand(lockId, {
+          location: file,
+          stage,
+          region,
+          provider,
+          accessKeyId,
+          accessKeySecret,
+          securityToken,
+        });
+      },
+    ),
   );
 
 program.parse();

--- a/src/commands/plan.ts
+++ b/src/commands/plan.ts
@@ -1,4 +1,5 @@
 import { getIacLocation, logger, setContext, setIac, ProviderEnum, getContext } from '../common';
+import { createStateBackend } from '../common/stateBackend';
 import { parseYaml, revalYaml } from '../parser';
 import { generateTencentPlan, displayPlan } from '../stack/scfStack';
 import { generateAliyunPlan } from '../stack/aliyunStack';
@@ -34,12 +35,13 @@ export const plan = async (
 
   logger.info(lang.__('GENERATING_PLAN_FOR_SCF'));
 
+  const backend = createStateBackend(iac.backend, context);
   let planResult;
 
   if (iac.provider.name === ProviderEnum.TENCENT) {
-    planResult = await generateTencentPlan(iac);
+    planResult = await generateTencentPlan(iac, backend);
   } else if (iac.provider.name === ProviderEnum.ALIYUN) {
-    planResult = await generateAliyunPlan(iac);
+    planResult = await generateAliyunPlan(iac, backend);
   } else {
     logger.error(lang.__('PLAN_COMMAND_NOT_SUPPORTED'));
     throw new Error(lang.__('PLAN_COMMAND_NOT_SUPPORTED'));

--- a/src/common/lockManager.ts
+++ b/src/common/lockManager.ts
@@ -133,7 +133,7 @@ const sleep = (ms: number): Promise<void> => {
   return new Promise((resolve) => setTimeout(resolve, ms));
 };
 
-const acquireLockInternal = async (
+export const acquireLockInternal = async (
   statePath: string,
   operation: string,
   options: LockOptions = {},
@@ -198,7 +198,7 @@ const acquireLockInternal = async (
   );
 };
 
-const releaseLockInternal = (statePath: string, lockId: string): void => {
+export const releaseLockInternal = (statePath: string, lockId: string): void => {
   const lockPath = getLockPath(statePath);
   const existingLock = readLockFile(lockPath);
 

--- a/src/common/stateBackend/cosStateBackend.ts
+++ b/src/common/stateBackend/cosStateBackend.ts
@@ -1,0 +1,237 @@
+import COS from 'cos-nodejs-sdk-v5';
+import crypto from 'node:crypto';
+import os from 'node:os';
+import { execSync } from 'node:child_process';
+import { StateFile, LockOptions, LockMetadata, CURRENT_STATE_VERSION } from '../../types';
+import { DEFAULT_LOCK_TIMEOUT, DEFAULT_LOCK_RETRY_DELAY, STALE_LOCK_THRESHOLD } from '../constants';
+import { LockError, formatLockInfo } from '../lockManager';
+import { StateBackend } from './types';
+
+type CosBackendConfig = {
+  bucket: string;
+  key: string;
+  region: string;
+  accessKeyId: string;
+  accessKeySecret: string;
+  securityToken?: string;
+};
+
+const LOCK_KEY_SUFFIX = '.si-lock';
+
+const getUserEmail = (): string => {
+  try {
+    const email = execSync('git config user.email', {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'ignore'],
+    }).trim();
+    if (email) return email;
+  } catch {
+    // noop
+  }
+  const username = os.userInfo().username || 'unknown';
+  const hostname = os.hostname() || 'unknown';
+  return `${username}@${hostname}`;
+};
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+const isLockStale = (lock: LockMetadata): boolean => {
+  const acquiredAt = new Date(lock.acquiredAt).getTime();
+  return Date.now() - acquiredAt > STALE_LOCK_THRESHOLD;
+};
+
+const promisifyGet = (
+  cosClient: COS,
+  bucket: string,
+  region: string,
+  key: string,
+): Promise<Buffer | null> => {
+  return new Promise((resolve, reject) => {
+    cosClient.getObject({ Bucket: bucket, Region: region, Key: key }, (err, data) => {
+      if (err) {
+        if (err.statusCode === 404) {
+          resolve(null);
+        } else {
+          reject(err);
+        }
+      } else {
+        resolve(data.Body as Buffer);
+      }
+    });
+  });
+};
+
+const promisifyPut = (
+  cosClient: COS,
+  bucket: string,
+  region: string,
+  key: string,
+  body: string,
+): Promise<void> => {
+  return new Promise((resolve, reject) => {
+    cosClient.putObject({ Bucket: bucket, Region: region, Key: key, Body: body }, (err) => {
+      if (err) reject(err);
+      else resolve();
+    });
+  });
+};
+
+const promisifyDelete = (
+  cosClient: COS,
+  bucket: string,
+  region: string,
+  key: string,
+): Promise<void> => {
+  return new Promise((resolve, reject) => {
+    cosClient.deleteObject({ Bucket: bucket, Region: region, Key: key }, (err) => {
+      if (err && err.statusCode !== 404) reject(err);
+      else resolve();
+    });
+  });
+};
+
+export const createCosStateBackend = (config: CosBackendConfig): StateBackend => {
+  const cosClient = new COS({
+    SecretId: config.accessKeyId,
+    SecretKey: config.accessKeySecret,
+    SecurityToken: config.securityToken,
+  });
+
+  const lockKey = `${config.key}${LOCK_KEY_SUFFIX}`;
+
+  const readObject = async <T>(key: string): Promise<T | null> => {
+    const body = await promisifyGet(cosClient, config.bucket, config.region, key);
+    if (!body) return null;
+    return JSON.parse(body.toString('utf-8')) as T;
+  };
+
+  const writeObject = async (key: string, data: unknown): Promise<void> => {
+    await promisifyPut(cosClient, config.bucket, config.region, key, JSON.stringify(data, null, 2));
+  };
+
+  const deleteObject = async (key: string): Promise<void> => {
+    await promisifyDelete(cosClient, config.bucket, config.region, key);
+  };
+
+  const readLockObject = async (): Promise<LockMetadata | null> => {
+    return readObject<LockMetadata>(lockKey);
+  };
+
+  const acquireLockObject = async (
+    operation: string,
+    options: LockOptions = {},
+  ): Promise<LockMetadata> => {
+    const timeout = options.timeout ?? DEFAULT_LOCK_TIMEOUT;
+    const retryDelay = options.retryDelay ?? DEFAULT_LOCK_RETRY_DELAY;
+    const maxRetries = options.maxRetries ?? Math.ceil(timeout / retryDelay);
+
+    const metadata: LockMetadata = {
+      id: crypto.randomBytes(16).toString('hex'),
+      user: getUserEmail(),
+      processId: process.pid,
+      hostname: os.hostname(),
+      operation,
+      acquiredAt: new Date().toISOString(),
+      path: `cos://${config.bucket}/${config.key}`,
+    };
+
+    const startTime = Date.now();
+    let attempt = 0;
+
+    while (attempt <= maxRetries) {
+      const existingLock = await readLockObject();
+
+      if (!existingLock) {
+        await writeObject(lockKey, metadata);
+        const verify = await readLockObject();
+        if (verify && verify.id === metadata.id) {
+          return metadata;
+        }
+      } else {
+        if (isLockStale(existingLock)) {
+          throw new LockError(
+            `State is currently locked (stale lock detected).\n${formatLockInfo(existingLock)}\nThis lock appears to be stale. If you are certain no other operation is running, use:\n  si force-unlock ${existingLock.id}`,
+            existingLock,
+          );
+        }
+        if (Date.now() - startTime >= timeout) {
+          throw new LockError(
+            `Failed to acquire lock after ${timeout / 1000} seconds.\n${formatLockInfo(existingLock)}\nIf you are certain no other operation is running, use:\n  si force-unlock ${existingLock.id}`,
+            existingLock,
+          );
+        }
+      }
+
+      const delay = Math.min(retryDelay * Math.pow(2, attempt), 30000);
+      await sleep(delay);
+      attempt++;
+    }
+
+    const existingLock = await readLockObject();
+    throw new LockError(
+      `Failed to acquire lock.\n${existingLock ? formatLockInfo(existingLock) : ''}\nIf you are certain no other operation is running, use:\n  si force-unlock ${existingLock?.id || 'unknown'}`,
+      existingLock || undefined,
+    );
+  };
+
+  return {
+    loadState: async (provider: string): Promise<StateFile> => {
+      const state = await readObject<StateFile>(config.key);
+      if (state) return state;
+      return { version: CURRENT_STATE_VERSION, provider, resources: {} };
+    },
+
+    saveState: async (state: StateFile): Promise<void> => {
+      const stateToSave: StateFile = { ...state, version: CURRENT_STATE_VERSION };
+      await writeObject(config.key, stateToSave);
+    },
+
+    acquireLock: async (operation: string, options?: LockOptions): Promise<string> => {
+      const meta = await acquireLockObject(operation, options);
+      return meta.id;
+    },
+
+    releaseLock: async (lockId: string): Promise<void> => {
+      const existing = await readLockObject();
+      if (existing && existing.id === lockId) {
+        await deleteObject(lockKey);
+      }
+    },
+
+    forceUnlock: async (lockId: string): Promise<boolean> => {
+      const existing = await readLockObject();
+      if (!existing) return false;
+      if (existing.id !== lockId) {
+        throw new Error(
+          `Lock ID mismatch. Current lock ID is ${existing.id}, but you provided ${lockId}`,
+        );
+      }
+      await deleteObject(lockKey);
+      return true;
+    },
+
+    readLock: async (): Promise<LockMetadata | null> => {
+      return readLockObject();
+    },
+
+    withLock: async <T>(
+      operation: string,
+      fn: () => Promise<T>,
+      options?: LockOptions,
+    ): Promise<T> => {
+      let lockId: string | null = null;
+      try {
+        const meta = await acquireLockObject(operation, options);
+        lockId = meta.id;
+        return await fn();
+      } finally {
+        if (lockId) {
+          const existing = await readLockObject();
+          if (existing && existing.id === lockId) {
+            await deleteObject(lockKey);
+          }
+        }
+      }
+    },
+  };
+};

--- a/src/common/stateBackend/index.ts
+++ b/src/common/stateBackend/index.ts
@@ -1,0 +1,55 @@
+import { BackendConfig, StateBackendType, BucketStoreBackendConfig } from '../../types';
+import { ProviderEnum } from '../providerEnum';
+import { StateBackend } from './types';
+import { createLocalStateBackend } from './localStateBackend';
+import { createOssStateBackend } from './ossStateBackend';
+import { createCosStateBackend } from './cosStateBackend';
+
+export * from './types';
+export * from './localStateBackend';
+export * from './ossStateBackend';
+export * from './cosStateBackend';
+
+type BackendContext = {
+  provider: string;
+  region: string;
+  accessKeyId: string;
+  accessKeySecret: string;
+  securityToken?: string;
+  baseDir?: string;
+};
+
+export const createStateBackend = (
+  backendConfig: BackendConfig | undefined,
+  context: BackendContext,
+): StateBackend => {
+  if (!backendConfig || backendConfig.type === StateBackendType.LOCAL) {
+    return createLocalStateBackend(context.baseDir);
+  }
+
+  const bucketConfig = backendConfig as BucketStoreBackendConfig;
+  const region = bucketConfig.region ?? context.region;
+  const accessKeyId = bucketConfig.accessKeyId ?? context.accessKeyId;
+  const accessKeySecret = bucketConfig.accessKeySecret ?? context.accessKeySecret;
+  const securityToken = bucketConfig.securityToken ?? context.securityToken;
+
+  if (context.provider === ProviderEnum.TENCENT) {
+    return createCosStateBackend({
+      bucket: bucketConfig.bucket,
+      key: bucketConfig.key,
+      region,
+      accessKeyId,
+      accessKeySecret,
+      securityToken,
+    });
+  }
+
+  return createOssStateBackend({
+    bucket: bucketConfig.bucket,
+    key: bucketConfig.key,
+    region,
+    accessKeyId,
+    accessKeySecret,
+    securityToken,
+  });
+};

--- a/src/common/stateBackend/localStateBackend.ts
+++ b/src/common/stateBackend/localStateBackend.ts
@@ -1,0 +1,49 @@
+import { StateFile, LockOptions } from '../../types';
+import { loadState as fsLoadState, saveState as fsSaveState, getStatePath } from '../stateManager';
+import {
+  withLock as fsWithLock,
+  forceUnlock as fsForceUnlock,
+  readLockFileForCommand,
+  acquireLockInternal,
+  releaseLockInternal,
+} from '../lockManager';
+import { StateBackend, LockMetadata } from './types';
+
+export const createLocalStateBackend = (baseDir: string = process.cwd()): StateBackend => {
+  const statePath = getStatePath(baseDir);
+
+  return {
+    loadState: async (provider: string): Promise<StateFile> => {
+      return fsLoadState(provider, baseDir);
+    },
+
+    saveState: async (state: StateFile): Promise<void> => {
+      fsSaveState(state, baseDir);
+    },
+
+    acquireLock: async (operation: string, options?: LockOptions): Promise<string> => {
+      const lockMeta = await acquireLockInternal(statePath, operation, options);
+      return lockMeta.id;
+    },
+
+    releaseLock: async (lockId: string): Promise<void> => {
+      releaseLockInternal(statePath, lockId);
+    },
+
+    forceUnlock: async (lockId: string): Promise<boolean> => {
+      return fsForceUnlock(statePath, lockId);
+    },
+
+    readLock: async (): Promise<LockMetadata | null> => {
+      return readLockFileForCommand(statePath);
+    },
+
+    withLock: async <T>(
+      operation: string,
+      fn: () => Promise<T>,
+      options?: LockOptions,
+    ): Promise<T> => {
+      return fsWithLock(statePath, operation, fn, options);
+    },
+  };
+};

--- a/src/common/stateBackend/ossStateBackend.ts
+++ b/src/common/stateBackend/ossStateBackend.ts
@@ -1,0 +1,204 @@
+import OSS from 'ali-oss';
+import crypto from 'node:crypto';
+import os from 'node:os';
+import { execSync } from 'node:child_process';
+import { StateFile, LockOptions, LockMetadata, CURRENT_STATE_VERSION } from '../../types';
+import { DEFAULT_LOCK_TIMEOUT, DEFAULT_LOCK_RETRY_DELAY, STALE_LOCK_THRESHOLD } from '../constants';
+import { LockError, formatLockInfo } from '../lockManager';
+import { StateBackend } from './types';
+
+type OssBackendConfig = {
+  bucket: string;
+  key: string;
+  region: string;
+  accessKeyId: string;
+  accessKeySecret: string;
+  securityToken?: string;
+};
+
+const LOCK_KEY_SUFFIX = '.si-lock';
+
+const getUserEmail = (): string => {
+  try {
+    const email = execSync('git config user.email', {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'ignore'],
+    }).trim();
+    if (email) return email;
+  } catch {
+    // noop
+  }
+  const username = os.userInfo().username || 'unknown';
+  const hostname = os.hostname() || 'unknown';
+  return `${username}@${hostname}`;
+};
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+const isLockStale = (lock: LockMetadata): boolean => {
+  const acquiredAt = new Date(lock.acquiredAt).getTime();
+  return Date.now() - acquiredAt > STALE_LOCK_THRESHOLD;
+};
+
+export const createOssStateBackend = (config: OssBackendConfig): StateBackend => {
+  const ossClient = new OSS({
+    accessKeyId: config.accessKeyId,
+    accessKeySecret: config.accessKeySecret,
+    region: `oss-${config.region}`,
+    bucket: config.bucket,
+    stsToken: config.securityToken,
+  });
+
+  const lockKey = `${config.key}${LOCK_KEY_SUFFIX}`;
+
+  const readObject = async <T>(key: string): Promise<T | null> => {
+    try {
+      const result = await ossClient.get(key);
+      const content = result.content.toString('utf-8');
+      return JSON.parse(content) as T;
+    } catch (err: unknown) {
+      if (err && typeof err === 'object' && 'code' in err) {
+        const code = (err as { code: string }).code;
+        if (code === 'NoSuchKey' || code === 'NoSuchBucket') {
+          return null;
+        }
+      }
+      throw err;
+    }
+  };
+
+  const writeObject = async (key: string, data: unknown): Promise<void> => {
+    const content = JSON.stringify(data, null, 2);
+    await ossClient.put(key, Buffer.from(content, 'utf-8'));
+  };
+
+  const deleteObject = async (key: string): Promise<void> => {
+    try {
+      await ossClient.delete(key);
+    } catch {
+      // noop
+    }
+  };
+
+  const readLockObject = async (): Promise<LockMetadata | null> => {
+    return readObject<LockMetadata>(lockKey);
+  };
+
+  const acquireLockObject = async (
+    operation: string,
+    options: LockOptions = {},
+  ): Promise<LockMetadata> => {
+    const timeout = options.timeout ?? DEFAULT_LOCK_TIMEOUT;
+    const retryDelay = options.retryDelay ?? DEFAULT_LOCK_RETRY_DELAY;
+    const maxRetries = options.maxRetries ?? Math.ceil(timeout / retryDelay);
+
+    const metadata: LockMetadata = {
+      id: crypto.randomBytes(16).toString('hex'),
+      user: getUserEmail(),
+      processId: process.pid,
+      hostname: os.hostname(),
+      operation,
+      acquiredAt: new Date().toISOString(),
+      path: `oss://${config.bucket}/${config.key}`,
+    };
+
+    const startTime = Date.now();
+    let attempt = 0;
+
+    while (attempt <= maxRetries) {
+      const existingLock = await readLockObject();
+
+      if (!existingLock) {
+        await writeObject(lockKey, metadata);
+        const verify = await readLockObject();
+        if (verify && verify.id === metadata.id) {
+          return metadata;
+        }
+      } else {
+        if (isLockStale(existingLock)) {
+          throw new LockError(
+            `State is currently locked (stale lock detected).\n${formatLockInfo(existingLock)}\nThis lock appears to be stale. If you are certain no other operation is running, use:\n  si force-unlock ${existingLock.id}`,
+            existingLock,
+          );
+        }
+        if (Date.now() - startTime >= timeout) {
+          throw new LockError(
+            `Failed to acquire lock after ${timeout / 1000} seconds.\n${formatLockInfo(existingLock)}\nIf you are certain no other operation is running, use:\n  si force-unlock ${existingLock.id}`,
+            existingLock,
+          );
+        }
+      }
+
+      const delay = Math.min(retryDelay * Math.pow(2, attempt), 30000);
+      await sleep(delay);
+      attempt++;
+    }
+
+    const existingLock = await readLockObject();
+    throw new LockError(
+      `Failed to acquire lock.\n${existingLock ? formatLockInfo(existingLock) : ''}\nIf you are certain no other operation is running, use:\n  si force-unlock ${existingLock?.id || 'unknown'}`,
+      existingLock || undefined,
+    );
+  };
+
+  return {
+    loadState: async (provider: string): Promise<StateFile> => {
+      const state = await readObject<StateFile>(config.key);
+      if (state) return state;
+      return { version: CURRENT_STATE_VERSION, provider, resources: {} };
+    },
+
+    saveState: async (state: StateFile): Promise<void> => {
+      const stateToSave: StateFile = { ...state, version: CURRENT_STATE_VERSION };
+      await writeObject(config.key, stateToSave);
+    },
+
+    acquireLock: async (operation: string, options?: LockOptions): Promise<string> => {
+      const meta = await acquireLockObject(operation, options);
+      return meta.id;
+    },
+
+    releaseLock: async (lockId: string): Promise<void> => {
+      const existing = await readLockObject();
+      if (existing && existing.id === lockId) {
+        await deleteObject(lockKey);
+      }
+    },
+
+    forceUnlock: async (lockId: string): Promise<boolean> => {
+      const existing = await readLockObject();
+      if (!existing) return false;
+      if (existing.id !== lockId) {
+        throw new Error(
+          `Lock ID mismatch. Current lock ID is ${existing.id}, but you provided ${lockId}`,
+        );
+      }
+      await deleteObject(lockKey);
+      return true;
+    },
+
+    readLock: async (): Promise<LockMetadata | null> => {
+      return readLockObject();
+    },
+
+    withLock: async <T>(
+      operation: string,
+      fn: () => Promise<T>,
+      options?: LockOptions,
+    ): Promise<T> => {
+      let lockId: string | null = null;
+      try {
+        const meta = await acquireLockObject(operation, options);
+        lockId = meta.id;
+        return await fn();
+      } finally {
+        if (lockId) {
+          const existing = await readLockObject();
+          if (existing && existing.id === lockId) {
+            await deleteObject(lockKey);
+          }
+        }
+      }
+    },
+  };
+};

--- a/src/common/stateBackend/types.ts
+++ b/src/common/stateBackend/types.ts
@@ -1,0 +1,13 @@
+import { StateFile, LockOptions, LockMetadata } from '../../types';
+
+export type StateBackend = {
+  loadState: (provider: string) => Promise<StateFile>;
+  saveState: (state: StateFile) => Promise<void>;
+  acquireLock: (operation: string, options?: LockOptions) => Promise<string>;
+  releaseLock: (lockId: string) => Promise<void>;
+  forceUnlock: (lockId: string) => Promise<boolean>;
+  readLock: () => Promise<LockMetadata | null>;
+  withLock: <T>(operation: string, fn: () => Promise<T>, options?: LockOptions) => Promise<T>;
+};
+
+export type { LockMetadata };

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -1,5 +1,12 @@
 import { existsSync, readFileSync } from 'node:fs';
-import { ServerlessIac, ServerlessIacRaw, Context } from '../types';
+import {
+  ServerlessIac,
+  ServerlessIacRaw,
+  Context,
+  BackendConfig,
+  BackendConfigRaw,
+  StateBackendType,
+} from '../types';
 import { parseFunction } from './functionParser';
 import { parseEvent } from './eventParser';
 import { parseDatabase } from './databaseParser';
@@ -16,6 +23,29 @@ const validateExistence = (path: string) => {
   }
 };
 
+const parseBackend = (raw: BackendConfigRaw | undefined): BackendConfig | undefined => {
+  if (!raw) return undefined;
+
+  const type = raw.type?.toUpperCase();
+
+  if (type === StateBackendType.BUCKET_STORE) {
+    if (!raw.bucket || !raw.key) {
+      throw new Error('Backend type BUCKET_STORE requires both "bucket" and "key" fields');
+    }
+    return {
+      type: StateBackendType.BUCKET_STORE,
+      bucket: raw.bucket,
+      key: raw.key,
+      region: raw.region,
+      accessKeyId: raw.accessKeyId,
+      accessKeySecret: raw.accessKeySecret,
+      securityToken: raw.securityToken,
+    };
+  }
+
+  return { type: StateBackendType.LOCAL };
+};
+
 const transformYaml = (iacJson: ServerlessIacRaw): ServerlessIac => {
   return {
     service: iacJson.service,
@@ -23,6 +53,7 @@ const transformYaml = (iacJson: ServerlessIacRaw): ServerlessIac => {
     provider: iacJson.provider,
     vars: iacJson.vars,
     stages: iacJson.stages,
+    backend: parseBackend(iacJson.backend),
     functions: parseFunction(iacJson.functions),
     events: parseEvent(iacJson.events),
     databases: parseDatabase(iacJson.databases),

--- a/src/stack/aliyunStack/deployer.ts
+++ b/src/stack/aliyunStack/deployer.ts
@@ -8,13 +8,12 @@ import {
 import {
   getContext,
   logger,
-  loadState,
-  saveState,
   getRoleArnFromState,
   setIac,
   getDependencyInfo,
   toDotFormat,
 } from '../../common';
+import { StateBackend } from '../../common/stateBackend';
 import { lang } from '../../lang';
 import { generateFunctionPlan } from './fc3Planner';
 import { executeFunctionPlan } from './fc3Executor';
@@ -27,8 +26,8 @@ import { executeTablePlan } from './tablestoreExecutor';
 import { generateApigwPlan } from './apigwPlanner';
 import { executeApigwPlan } from './apigwExecutor';
 
-const createSaveStateFn = (baseDir: string) => (state: StateFile) => {
-  saveState(state, baseDir);
+const createSaveStateFn = (backend: StateBackend) => (state: StateFile) => {
+  backend.saveState(state);
 };
 
 const handlePartialFailure = (failure: PartialFailureError): never => {
@@ -59,15 +58,17 @@ const logDependencyGraph = (orderedItems: Array<PlanItem>, dotGraph: string): vo
   logger.debug(`${lang.__('DOT_GRAPH_OUTPUT')}:\n${dotGraph}`);
 };
 
-export const deployAliyunStack = async (iac: ServerlessIac): Promise<void> => {
+export const deployAliyunStack = async (
+  iac: ServerlessIac,
+  backend: StateBackend,
+): Promise<void> => {
   const context = getContext();
-  const baseDir = process.cwd();
   // Cache IAC for access throughout the deployment
   setIac(iac);
   logger.info(lang.__('DEPLOYING_STACK_PUBLISHING_ASSETS'));
 
-  let state = loadState(iac.provider.name, baseDir);
-  const onStateChange = createSaveStateFn(baseDir);
+  let state = await backend.loadState(iac.provider.name);
+  const onStateChange = createSaveStateFn(backend);
 
   logger.info(lang.__('GENERATING_PLAN'));
   const functionPlan = await generateFunctionPlan(context, state, iac.functions);
@@ -191,7 +192,7 @@ export const deployAliyunStack = async (iac: ServerlessIac): Promise<void> => {
     });
   }
 
-  saveState(state, baseDir);
+  await backend.saveState(state);
 
   logger.info(lang.__('STACK_DEPLOYED'));
 };

--- a/src/stack/aliyunStack/destroyer.ts
+++ b/src/stack/aliyunStack/destroyer.ts
@@ -1,12 +1,5 @@
-import {
-  getContext,
-  logger,
-  loadState,
-  saveState,
-  ProviderEnum,
-  getRoleArnFromState,
-  setIac,
-} from '../../common';
+import { getContext, logger, ProviderEnum, getRoleArnFromState, setIac } from '../../common';
+import { StateBackend } from '../../common/stateBackend';
 import { lang } from '../../lang';
 import { generateFunctionPlan } from './fc3Planner';
 import { executeFunctionPlan } from './fc3Executor';
@@ -20,8 +13,8 @@ import { generateApigwPlan } from './apigwPlanner';
 import { executeApigwPlan } from './apigwExecutor';
 import { ExecutionResult, PartialFailureError, PlanItem, StateFile } from '../../types';
 
-const createSaveStateFn = (baseDir: string) => (state: StateFile) => {
-  saveState(state, baseDir);
+const createSaveStateFn = (backend: StateBackend) => (state: StateFile) => {
+  backend.saveState(state);
 };
 
 const handlePartialFailure = (failure: PartialFailureError): never => {
@@ -43,12 +36,11 @@ const handlePartialFailure = (failure: PartialFailureError): never => {
 const collectSuccessfulItems = (results: Array<ExecutionResult>): Array<PlanItem> =>
   results.flatMap((result) => result.partialFailure?.successfulItems ?? []);
 
-export const destroyAliyunStack = async (): Promise<void> => {
+export const destroyAliyunStack = async (backend: StateBackend): Promise<void> => {
   const context = getContext();
-  const baseDir = process.cwd();
   const providerName = ProviderEnum.ALIYUN;
-  let state = loadState(providerName, baseDir);
-  const onStateChange = createSaveStateFn(baseDir);
+  let state = await backend.loadState(providerName);
+  const onStateChange = createSaveStateFn(backend);
   // Set minimal IAC for destruction (function resolution not needed)
   setIac({ version: '1.0', service: '', provider: { name: providerName, region: context.region } });
 
@@ -156,5 +148,5 @@ export const destroyAliyunStack = async (): Promise<void> => {
     });
   }
 
-  saveState(state, baseDir);
+  await backend.saveState(state);
 };

--- a/src/stack/aliyunStack/planner.ts
+++ b/src/stack/aliyunStack/planner.ts
@@ -1,5 +1,6 @@
 import { ServerlessIac } from '../../types';
-import { getContext, loadState, getDependencyInfo, toDotFormat } from '../../common';
+import { getContext, getDependencyInfo, toDotFormat } from '../../common';
+import { StateBackend } from '../../common/stateBackend';
 import { lang } from '../../lang';
 import { generateFunctionPlan } from './fc3Planner';
 import { generateBucketPlan } from './ossPlanner';
@@ -7,9 +8,9 @@ import { generateDatabasePlan } from './databasePlanner';
 import { generateTablePlan } from './tablestorePlanner';
 import { generateApigwPlan } from './apigwPlanner';
 
-export const generateAliyunPlan = async (iac: ServerlessIac) => {
+export const generateAliyunPlan = async (iac: ServerlessIac, backend: StateBackend) => {
   const context = getContext();
-  const state = loadState(iac.provider.name, process.cwd());
+  const state = await backend.loadState(iac.provider.name);
 
   const functionPlan = await generateFunctionPlan(context, state, iac.functions);
   const bucketPlan = await generateBucketPlan(context, state, iac.buckets);

--- a/src/stack/deploy.ts
+++ b/src/stack/deploy.ts
@@ -1,5 +1,6 @@
 import { ServerlessIac } from '../types';
 import { logger, ProviderEnum } from '../common';
+import { StateBackend } from '../common/stateBackend';
 import { RfsStack } from './rfsStack';
 import { deployTencentStack } from './scfStack';
 import { deployAliyunStack } from './aliyunStack';
@@ -23,11 +24,11 @@ const deployHuawei = async (stackName: string, iac: ServerlessIac): Promise<void
   logger.info(lang.__('STACK_DEPLOYED'));
 };
 
-export const deployStack = async (stackName: string, iac: ServerlessIac) => {
+export const deployStack = async (stackName: string, iac: ServerlessIac, backend: StateBackend) => {
   if (iac.provider.name === ProviderEnum.TENCENT) {
-    await deployTencentStack(iac);
+    await deployTencentStack(iac, backend);
   } else if (iac.provider.name === ProviderEnum.ALIYUN) {
-    await deployAliyunStack(iac);
+    await deployAliyunStack(iac, backend);
   } else if (iac.provider.name === ProviderEnum.HUAWEI) {
     await deployHuawei(stackName, iac);
   }

--- a/src/stack/scfStack/deployer.ts
+++ b/src/stack/scfStack/deployer.ts
@@ -5,7 +5,8 @@ import {
   PlanItem,
   StateFile,
 } from '../../types';
-import { getContext, logger, loadState, saveState } from '../../common';
+import { getContext, logger } from '../../common';
+import { StateBackend } from '../../common/stateBackend';
 import { lang } from '../../lang';
 import { generateFunctionPlan } from './scfPlanner';
 import { executeFunctionPlan } from './scfExecutor';
@@ -16,8 +17,8 @@ import { executeDatabasePlan } from './tdsqlcExecutor';
 import { generateEsPlan } from './esServerlessPlanner';
 import { executeEsPlan } from './esServerlessExecutor';
 
-const createSaveStateFn = (baseDir: string) => (state: StateFile) => {
-  saveState(state, baseDir);
+const createSaveStateFn = (backend: StateBackend) => (state: StateFile) => {
+  backend.saveState(state);
 };
 
 const handlePartialFailure = (failure: PartialFailureError): never => {
@@ -39,13 +40,15 @@ const handlePartialFailure = (failure: PartialFailureError): never => {
 const collectSuccessfulItems = (results: Array<ExecutionResult>): Array<PlanItem> =>
   results.flatMap((result) => result.partialFailure?.successfulItems ?? []);
 
-export const deployTencentStack = async (iac: ServerlessIac): Promise<void> => {
+export const deployTencentStack = async (
+  iac: ServerlessIac,
+  backend: StateBackend,
+): Promise<void> => {
   const context = getContext();
-  const baseDir = process.cwd();
   logger.info(lang.__('DEPLOYING_STACK_PUBLISHING_ASSETS'));
 
-  let state = loadState(iac.provider.name, baseDir);
-  const onStateChange = createSaveStateFn(baseDir);
+  let state = await backend.loadState(iac.provider.name);
+  const onStateChange = createSaveStateFn(backend);
 
   logger.info(lang.__('GENERATING_PLAN'));
   const functionPlan = await generateFunctionPlan(context, state, iac.functions);
@@ -124,7 +127,7 @@ export const deployTencentStack = async (iac: ServerlessIac): Promise<void> => {
     });
   }
 
-  saveState(state, baseDir);
+  await backend.saveState(state);
 
   logger.info(lang.__('STACK_DEPLOYED'));
 };

--- a/src/stack/scfStack/destroyer.ts
+++ b/src/stack/scfStack/destroyer.ts
@@ -1,4 +1,5 @@
-import { getContext, logger, loadState, saveState, ProviderEnum } from '../../common';
+import { getContext, logger, ProviderEnum } from '../../common';
+import { StateBackend } from '../../common/stateBackend';
 import { lang } from '../../lang';
 import { generateFunctionPlan } from './scfPlanner';
 import { executeFunctionPlan } from './scfExecutor';
@@ -10,8 +11,8 @@ import { generateEsPlan } from './esServerlessPlanner';
 import { executeEsPlan } from './esServerlessExecutor';
 import { ExecutionResult, PartialFailureError, PlanItem, StateFile } from '../../types';
 
-const createSaveStateFn = (baseDir: string) => (state: StateFile) => {
-  saveState(state, baseDir);
+const createSaveStateFn = (backend: StateBackend) => (state: StateFile) => {
+  backend.saveState(state);
 };
 
 const handlePartialFailure = (failure: PartialFailureError): never => {
@@ -33,12 +34,11 @@ const handlePartialFailure = (failure: PartialFailureError): never => {
 const collectSuccessfulItems = (results: Array<ExecutionResult>): Array<PlanItem> =>
   results.flatMap((result) => result.partialFailure?.successfulItems ?? []);
 
-export const destroyTencentStack = async (): Promise<void> => {
+export const destroyTencentStack = async (backend: StateBackend): Promise<void> => {
   const context = getContext();
-  const baseDir = process.cwd();
   const providerName = ProviderEnum.TENCENT;
-  let state = loadState(providerName, baseDir);
-  const onStateChange = createSaveStateFn(baseDir);
+  let state = await backend.loadState(providerName);
+  const onStateChange = createSaveStateFn(backend);
 
   const functionPlan = await generateFunctionPlan(context, state, undefined);
   const bucketPlan = await generateBucketPlan(context, state, undefined);
@@ -114,5 +114,5 @@ export const destroyTencentStack = async (): Promise<void> => {
     });
   }
 
-  saveState(state, baseDir);
+  await backend.saveState(state);
 };

--- a/src/stack/scfStack/planner.ts
+++ b/src/stack/scfStack/planner.ts
@@ -1,14 +1,15 @@
 import { ServerlessIac } from '../../types';
-import { getContext, logger, loadState, getDependencyInfo, toDotFormat } from '../../common';
+import { getContext, logger, getDependencyInfo, toDotFormat } from '../../common';
+import { StateBackend } from '../../common/stateBackend';
 import { lang } from '../../lang';
 import { generateFunctionPlan } from './scfPlanner';
 import { generateBucketPlan } from './cosPlanner';
 import { generateDatabasePlan } from './tdsqlcPlanner';
 import { generateEsPlan } from './esServerlessPlanner';
 
-export const generateTencentPlan = async (iac: ServerlessIac) => {
+export const generateTencentPlan = async (iac: ServerlessIac, backend: StateBackend) => {
   const context = getContext();
-  const state = loadState(iac.provider.name, process.cwd());
+  const state = await backend.loadState(iac.provider.name);
 
   const functionPlan = await generateFunctionPlan(context, state, iac.functions);
   const bucketPlan = await generateBucketPlan(context, state, iac.buckets);

--- a/src/types/domains/backend.ts
+++ b/src/types/domains/backend.ts
@@ -1,0 +1,30 @@
+export enum StateBackendType {
+  LOCAL = 'LOCAL',
+  BUCKET_STORE = 'BUCKET_STORE',
+}
+
+export type LocalBackendConfig = {
+  type: StateBackendType.LOCAL;
+};
+
+export type BucketStoreBackendConfig = {
+  type: StateBackendType.BUCKET_STORE;
+  bucket: string;
+  key: string;
+  region?: string;
+  accessKeyId?: string;
+  accessKeySecret?: string;
+  securityToken?: string;
+};
+
+export type BackendConfig = LocalBackendConfig | BucketStoreBackendConfig;
+
+export type BackendConfigRaw = {
+  type: string;
+  bucket?: string;
+  key?: string;
+  region?: string;
+  accessKeyId?: string;
+  accessKeySecret?: string;
+  securityToken?: string;
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,6 +6,7 @@ import { FunctionDomain, FunctionRaw } from './domains/function';
 import { Provider } from './domains/provider';
 import { BucketDomain, BucketRaw } from './domains/bucket';
 import { TableDomain, TableRaw } from './domains/table';
+import { BackendConfig, BackendConfigRaw } from './domains/backend';
 
 export * from './domains/resolvable';
 export * from './domains/database';
@@ -18,6 +19,7 @@ export * from './domains/bucket';
 export * from './domains/table';
 export * from './domains/state';
 export * from './domains/lock';
+export * from './domains/backend';
 export * from './assets';
 
 export type ServerlessIacRaw = {
@@ -27,6 +29,7 @@ export type ServerlessIacRaw = {
   stages: Stages;
   service: string;
   tags: Tags;
+  backend?: BackendConfigRaw;
   functions: { [key: string]: FunctionRaw };
   events: { [key: string]: EventRaw };
   databases: { [key: string]: DatabaseRaw };
@@ -41,6 +44,7 @@ export type ServerlessIac = {
   vars?: Vars;
   stages?: Stages;
   tags?: Array<{ key: string; value: string }>;
+  backend?: BackendConfig;
   functions?: Array<FunctionDomain>;
   events?: Array<EventDomain>;
   databases?: Array<DatabaseDomain>;

--- a/tests/commands/deploy.test.ts
+++ b/tests/commands/deploy.test.ts
@@ -26,6 +26,10 @@ describe('unit test for deploy command', () => {
     });
 
     expect(mockedDeployStack).toHaveBeenCalledTimes(1);
-    expect(mockedDeployStack).toHaveBeenCalledWith(stackName, expect.any(Object));
+    expect(mockedDeployStack).toHaveBeenCalledWith(
+      stackName,
+      expect.any(Object),
+      expect.any(Object),
+    );
   });
 });

--- a/tests/stack/deploy.test.ts
+++ b/tests/stack/deploy.test.ts
@@ -2,6 +2,7 @@ import { deployStack } from '../../src/stack';
 import { minimumIac, oneFcIac } from '../fixtures/deploy-fixtures';
 import { Context } from '../../src/types';
 import { ProviderEnum } from '../../src/common';
+import { StateBackend } from '../../src/common/stateBackend/types';
 import fs from 'node:fs';
 
 const mockedGetContext = jest.fn();
@@ -42,6 +43,16 @@ const createMockContext = (
 describe('Unit tests for Aliyun stack deployment', () => {
   const testDir = '/tmp/test-deploy';
 
+  const mockBackend: StateBackend = {
+    loadState: jest.fn(),
+    saveState: jest.fn(),
+    acquireLock: jest.fn(),
+    releaseLock: jest.fn(),
+    forceUnlock: jest.fn(),
+    readLock: jest.fn(),
+    withLock: jest.fn(),
+  };
+
   beforeEach(() => {
     // Clean up
     if (fs.existsSync(testDir)) {
@@ -63,26 +74,26 @@ describe('Unit tests for Aliyun stack deployment', () => {
     const stackName = 'my-demo-minimum-stack';
     mockedGetContext.mockReturnValue(createMockContext(stackName));
 
-    await deployStack(stackName, minimumIac);
+    await deployStack(stackName, minimumIac, mockBackend);
 
-    expect(mockedDeployAliyunStack).toHaveBeenCalledWith(minimumIac);
+    expect(mockedDeployAliyunStack).toHaveBeenCalledWith(minimumIac, mockBackend);
   });
 
   it('should generate and execute function plan for FC functions', async () => {
     const stackName = 'my-demo-stack-fc-only';
     mockedGetContext.mockReturnValue(createMockContext(stackName));
 
-    await deployStack(stackName, oneFcIac);
+    await deployStack(stackName, oneFcIac, mockBackend);
 
-    expect(mockedDeployAliyunStack).toHaveBeenCalledWith(oneFcIac);
+    expect(mockedDeployAliyunStack).toHaveBeenCalledWith(oneFcIac, mockBackend);
   });
 
   it('should save state after execution', async () => {
     const stackName = 'my-demo-stack-save-state';
     mockedGetContext.mockReturnValue(createMockContext(stackName));
 
-    await deployStack(stackName, oneFcIac);
+    await deployStack(stackName, oneFcIac, mockBackend);
 
-    expect(mockedDeployAliyunStack).toHaveBeenCalledWith(oneFcIac);
+    expect(mockedDeployAliyunStack).toHaveBeenCalledWith(oneFcIac, mockBackend);
   });
 });


### PR DESCRIPTION
This pull request introduces a new abstraction for state backend management, allowing support for both local and remote (COS and OSS) state backends. It refactors the lock and state management logic in core commands (`deploy`, `destroy`, `plan`, and `force-unlock`) to use this backend abstraction, enabling seamless switching between different storage providers and improving extensibility.

Backend abstraction and implementation:

* Added a new `stateBackend` abstraction with implementations for local, COS (Tencent Cloud), and OSS (Aliyun) backends. This includes the creation of `createStateBackend`, `createLocalStateBackend`, `createCosStateBackend`, and `createOssStateBackend` functions, and a unified `StateBackend` interface. (`src/common/stateBackend/index.ts`, `src/common/stateBackend/localStateBackend.ts`, `src/common/stateBackend/cosStateBackend.ts`) [[1]](diffhunk://#diff-997615a2d80a76a96866c9cccef5ef2c51220431f1d46152829a5fbe291070b3R1-R55) [[2]](diffhunk://#diff-c5cd18e78c5bef2f67d453edcd098d50fcfcd85482328e1a421529f625b47712R1-R49) [[3]](diffhunk://#diff-b78b8a8a9ba735e2b371f998383e283de6a6075fd176bc8d4ed71a6abb8a0520R1-R237)

Command refactoring to use backend abstraction:

* Refactored `deploy`, `destroy`, and `plan` commands to use the new backend abstraction for state and lock management, replacing direct file operations and lock handling with backend methods. (`src/commands/deploy.ts`, `src/commands/destroy.ts`, `src/commands/plan.ts`) [[1]](diffhunk://#diff-38950282aef5cea0f96cba5414c96fc6597942377b028fddf996ad9b63649519L2-R3) [[2]](diffhunk://#diff-38950282aef5cea0f96cba5414c96fc6597942377b028fddf996ad9b63649519L45-R40) [[3]](diffhunk://#diff-93e37ab9850fe958e61a1f3929c056316515253ffcc9c3f259fa0991b8704716L1-R2) [[4]](diffhunk://#diff-93e37ab9850fe958e61a1f3929c056316515253ffcc9c3f259fa0991b8704716L48-R45) [[5]](diffhunk://#diff-641e792a726f881c8e7e163abde4cb2eb15dc0745bc957efa21d10fb2bfd38bfR2) [[6]](diffhunk://#diff-641e792a726f881c8e7e163abde4cb2eb15dc0745bc957efa21d10fb2bfd38bfR38-R44)

Force-unlock improvements and CLI enhancements:

* Updated the `force-unlock` command to support remote backends, including new CLI options for backend configuration (file, stage, region, provider, credentials). The command now uses the backend abstraction to read and release locks. (`src/commands/forceUnlock.ts`, `src/commands/index.ts`) [[1]](diffhunk://#diff-cc3160a591f876bb2755316472d6eed61ccf332c2be043ecbed89f382b7f947eL2-R6) [[2]](diffhunk://#diff-cc3160a591f876bb2755316472d6eed61ccf332c2be043ecbed89f382b7f947eL25-R48) [[3]](diffhunk://#diff-cc3160a591f876bb2755316472d6eed61ccf332c2be043ecbed89f382b7f947eL65-R84) [[4]](diffhunk://#diff-a6a1db61476382a80351bf0b40126b3cfca87878293a3fca70dfe04367f4a11fR231-R255)

Lock manager exports for backend usage:

* Exported `acquireLockInternal` and `releaseLockInternal` from `lockManager` to enable their use in backend implementations. (`src/common/lockManager.ts`) [[1]](diffhunk://#diff-f18b9c0c6fd151e4b24fd19cf04d1016a6cea5cb2b8d18f9ea192f5c855ff2c9L136-R136) [[2]](diffhunk://#diff-f18b9c0c6fd151e4b24fd19cf04d1016a6cea5cb2b8d18f9ea192f5c855ff2c9L201-R201)

These changes lay the foundation for supporting multiple state backends and improve the maintainability and extensibility of the codebase.

refer: https://github.com/geek-fun/serverlessinsight/issues/163