### PR TITLE
fix:Align the OSS custom domain binding flow to match the API Gateway

### DIFF
--- a/src/common/aliyunClient/apigwOperations.ts
+++ b/src/common/aliyunClient/apigwOperations.ts
@@ -15,6 +15,7 @@ import {
   APIGW_DNS_PUBLIC_RESOLUTION_MAX_ATTEMPTS,
   APIGW_DNS_PUBLIC_RESOLUTION_DELAY_MS,
 } from '../constants';
+import { sleep } from '../retryUtils';
 
 type ApigwSdkClient = CloudApiClient;
 type DnsSdkClient = DnsClient;
@@ -145,8 +146,6 @@ export type ApigwCustomDomainConfig = {
 const removeUndefined = <T extends Record<string, unknown>>(obj: T): T => {
   return Object.fromEntries(Object.entries(obj).filter(([, value]) => value !== undefined)) as T;
 };
-
-const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
 
 export const isNetworkTimeoutError = (error: unknown): boolean => {
   if (!error || typeof error !== 'object') return false;

--- a/src/common/aliyunClient/ossOperations.ts
+++ b/src/common/aliyunClient/ossOperations.ts
@@ -14,6 +14,13 @@ import { DnsOperations } from './dnsOperations';
 import { logger } from '../logger';
 import { lang } from '../../lang';
 import { extractMainDomain, extractHostRecord } from '../domainUtils';
+import { sleep } from '../retryUtils';
+import {
+  DOMAIN_BIND_MAX_RETRIES,
+  DOMAIN_BIND_RETRY_DELAY_MS,
+  DNS_PROPAGATION_MAX_ATTEMPTS,
+  DNS_PROPAGATION_DELAY_MS,
+} from '../constants';
 
 export type OssBucketConfig = {
   bucketName: string;
@@ -33,7 +40,29 @@ export type OssCnameInfo = {
   domain: string;
   cname: string;
   dnsRecordId?: string;
+  txtRecordId?: string;
   bucketCnameBound?: boolean;
+};
+
+export type OssCnameTokenInfo = {
+  bucket: string;
+  cname: string;
+  token: string;
+  expireTime: string;
+};
+
+type PutCnameResult = {
+  success: boolean;
+  needVerification: boolean;
+};
+
+type VerificationResult = PutCnameResult & {
+  txtRecordId?: string;
+};
+
+type TxtRecordResult = {
+  success: boolean;
+  recordId?: string;
 };
 
 import { ResolvedCertificate } from '../certificateResolver';
@@ -47,6 +76,27 @@ type OssSdkClient = OSS;
 
 const escapeXmlText = (text: string): string =>
   text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+
+const toCamelCase = (str: string): string => str.charAt(0).toLowerCase() + str.slice(1);
+
+const parseXmlResponse = <T>(xml: string, tagName: string): T | null => {
+  try {
+    const containerRegex = new RegExp(`<${tagName}>([\\s\\S]*?)<\\/${tagName}>`);
+    const containerMatch = containerRegex.exec(xml);
+    if (!containerMatch) return null;
+
+    const innerXml = containerMatch[1];
+    const result: Record<string, string> = {};
+    const childRegex = /<(\w+)>([^<]*)<\/\1>/g;
+    let match: RegExpExecArray | null;
+    while ((match = childRegex.exec(innerXml)) !== null) {
+      result[toCamelCase(match[1])] = match[2].trim();
+    }
+    return Object.keys(result).length > 0 ? (result as T) : null;
+  } catch {
+    return null;
+  }
+};
 
 export const createOssOperations = (
   ossClient: OssSdkClient,
@@ -71,11 +121,50 @@ export const createOssOperations = (
     </CertificateConfiguration>`;
   };
 
+  const createCnameToken = async (
+    bucketName: string,
+    domain: string,
+  ): Promise<OssCnameTokenInfo> => {
+    useBucket(bucketName);
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<BucketCnameConfiguration>
+  <Cname>
+    <Domain>${escapeXmlText(domain)}</Domain>
+  </Cname>
+</BucketCnameConfiguration>`;
+
+    const params = {
+      method: 'POST',
+      bucket: bucketName,
+      subres: { cname: '', comp: 'token' },
+      headers: {
+        'Content-Type': 'application/xml',
+      },
+      content: xml,
+      successStatuses: [200],
+    };
+
+    const response = await ossRequest(ossClient, params);
+    const responseXml = (response as { data?: string }).data || '';
+    const parsed = parseXmlResponse<OssCnameTokenInfo>(responseXml, 'CnameToken');
+
+    if (!parsed || !parsed.token) {
+      throw new Error(lang.__('OSS_CNAME_TOKEN_CREATE_FAILED', { domain }));
+    }
+
+    return {
+      bucket: bucketName,
+      cname: domain,
+      token: parsed.token,
+      expireTime: parsed.expireTime || '',
+    };
+  };
+
   const putBucketCname = async (
     bucketName: string,
     domain: string,
     certificate?: OssCnameCertificateConfig,
-  ): Promise<boolean> => {
+  ): Promise<PutCnameResult> => {
     useBucket(bucketName);
     const certXml = buildCertificateXml(certificate);
     const xml = `<?xml version="1.0" encoding="UTF-8"?>
@@ -99,23 +188,23 @@ export const createOssOperations = (
       };
       await (ossClient as unknown as { request: (p: unknown) => Promise<unknown> }).request(params);
       logger.info(lang.__('OSS_BUCKET_CNAME_BOUND', { domain }));
-      return true;
+      return { success: true, needVerification: false };
     } catch (error) {
       const err = error as { code?: string; message?: string; status?: number };
       if (err.code === 'CnameAlreadyExists' || err.status === 409) {
         logger.info(lang.__('OSS_BUCKET_CNAME_EXISTS', { domain }));
-        return true;
+        return { success: true, needVerification: false };
       }
       if (err.code === 'NeedVerifyDomainOwnership') {
         logger.warn(lang.__('OSS_BUCKET_CNAME_NEED_VERIFY', { domain }));
-        return false;
+        return { success: false, needVerification: true };
       }
       if (certificate) {
         // eslint-disable-next-line preserve-caught-error
         throw new Error(lang.__('OSS_BUCKET_CNAME_BIND_FAILED', { error: String(error) }));
       }
       logger.warn(lang.__('OSS_BUCKET_CNAME_BIND_FAILED', { error: String(error) }));
-      return false;
+      return { success: false, needVerification: false };
     }
   };
 
@@ -235,7 +324,24 @@ export const createOssOperations = (
     const hostRecord = extractHostRecord(domain, mainDomain);
     const ossEndpoint = getOssEndpoint(bucketName);
 
-    const bucketCnameBound = await putBucketCname(bucketName, domain, certificate);
+    let cnameResult: PutCnameResult | VerificationResult = await putBucketCname(
+      bucketName,
+      domain,
+      certificate,
+    );
+    let txtRecordId: string | undefined;
+
+    if (cnameResult.needVerification) {
+      const verificationResult = await handleDomainOwnershipVerification(
+        bucketName,
+        domain,
+        certificate,
+      );
+      cnameResult = verificationResult;
+      txtRecordId = verificationResult.txtRecordId;
+    }
+
+    const bucketCnameBound = cnameResult.success;
     if (certificate && bucketCnameBound) {
       logger.info(lang.__('OSS_BUCKET_CERT_BOUND', { domain }));
     }
@@ -243,11 +349,244 @@ export const createOssOperations = (
 
     if (!dnsOps) {
       logger.warn(lang.__('OSS_DNS_MANUAL_CONFIG_REQUIRED', { domain, cname: ossEndpoint }));
-      return { domain, cname: ossEndpoint, bucketCnameBound };
+      return { domain, cname: ossEndpoint, bucketCnameBound, txtRecordId };
     }
 
+    const result = await createOrFindDnsCnameRecord(
+      domain,
+      mainDomain,
+      hostRecord,
+      ossEndpoint,
+      bucketCnameBound,
+    );
+    return { ...result, txtRecordId };
+  };
+
+  const logOssVerificationInstructions = (
+    domain: string,
+    fullTxtRecord: string,
+    token: string,
+  ): void => {
+    const mainDomain = extractMainDomain(domain);
+    const separator = '='.repeat(80);
+    logger.error(
+      `\n${separator}\n${lang.__('OSS_VERIFICATION_HEADER')}\n${separator}\n${lang.__('OSS_VERIFICATION_DOMAIN', { domain })}\n\n${lang.__('OSS_VERIFICATION_INSTRUCTIONS')}\n\n${lang.__('OSS_VERIFICATION_RECORD_NAME', { name: `${fullTxtRecord}.${mainDomain}` })}\n${lang.__('OSS_VERIFICATION_RECORD_TYPE')}\n${lang.__('OSS_VERIFICATION_RECORD_VALUE', { value: token })}`,
+    );
+    logger.error(
+      `\n${separator}\n${lang.__('OSS_VERIFICATION_NEXT_STEPS')}\n${lang.__('OSS_VERIFICATION_STEP1')}\n${lang.__('OSS_VERIFICATION_STEP2')}\n${separator}\n`,
+    );
+  };
+
+  const handleDomainOwnershipVerification = async (
+    bucketName: string,
+    domain: string,
+    certificate?: OssCnameCertificateConfig,
+  ): Promise<VerificationResult> => {
+    logger.info(lang.__('OSS_CNAME_CREATING_VERIFICATION_TOKEN', { domain }));
+
+    const tokenInfo = await createCnameToken(bucketName, domain);
+    const txtRecordName = '_dnsauth';
+    const hostRecord = extractHostRecord(domain, extractMainDomain(domain));
+    const fullTxtRecord = hostRecord ? `${txtRecordName}.${hostRecord}` : txtRecordName;
+
+    logger.info(
+      lang.__('OSS_CNAME_VERIFICATION_TOKEN_CREATED', {
+        domain,
+        txtRecord: fullTxtRecord,
+        token: tokenInfo.token,
+      }),
+    );
+
+    const txtResult = await addVerificationTxtRecord(
+      extractMainDomain(domain),
+      fullTxtRecord,
+      tokenInfo.token,
+    );
+
+    if (txtResult.success) {
+      await pollTxtDnsPropagation(extractMainDomain(domain), fullTxtRecord, tokenInfo.token);
+      const retryResult = await retryCnameBindingAfterVerification(bucketName, domain, certificate);
+      return { ...retryResult, txtRecordId: txtResult.recordId };
+    }
+
+    logOssVerificationInstructions(domain, fullTxtRecord, tokenInfo.token);
+    throw new Error(
+      lang.__('OSS_CNAME_MANUAL_VERIFICATION_REQUIRED', {
+        domain,
+        txtRecord: `${fullTxtRecord}.${extractMainDomain(domain)}`,
+        token: tokenInfo.token,
+      }),
+    );
+  };
+
+  const addVerificationTxtRecord = async (
+    mainDomain: string,
+    fullTxtRecord: string,
+    token: string,
+  ): Promise<TxtRecordResult> => {
+    if (!dnsOps) return { success: false };
+
     try {
-      const existingRecords = await dnsOps.describeDomainRecords(mainDomain, hostRecord);
+      const existingRecords = await dnsOps.describeDomainRecords(mainDomain, fullTxtRecord);
+      const existingRecord = existingRecords.find(
+        (record) => record.rr === fullTxtRecord && record.type === 'TXT' && record.value === token,
+      );
+
+      if (existingRecord) {
+        logger.info(
+          lang.__('OSS_CNAME_TXT_RECORD_ALREADY_EXISTS', {
+            txtRecord: `${fullTxtRecord}.${mainDomain}`,
+          }),
+        );
+        return { success: true, recordId: existingRecord.recordId };
+      }
+
+      const recordId = await dnsOps.addDomainRecord({
+        domainName: mainDomain,
+        rr: fullTxtRecord,
+        type: 'TXT',
+        value: token,
+        ttl: 600,
+      });
+      logger.info(
+        lang.__('OSS_CNAME_TXT_RECORD_CREATED', {
+          txtRecord: `${fullTxtRecord}.${mainDomain}`,
+        }),
+      );
+      return { success: true, recordId };
+    } catch (error) {
+      logger.warn(
+        lang.__('OSS_CNAME_TXT_RECORD_CREATE_FAILED', {
+          txtRecord: `${fullTxtRecord}.${mainDomain}`,
+          error: String(error),
+        }),
+      );
+      return { success: false };
+    }
+  };
+
+  const pollTxtDnsPropagation = async (
+    mainDomain: string,
+    fullTxtRecord: string,
+    token: string,
+  ): Promise<boolean> => {
+    if (!dnsOps) return false;
+
+    const checkPropagation = async (): Promise<boolean> => {
+      try {
+        const currentRecords = await dnsOps!.describeDomainRecords(mainDomain, fullTxtRecord);
+        return currentRecords.some(
+          (record) =>
+            record.rr === fullTxtRecord &&
+            record.type === 'TXT' &&
+            record.value === token &&
+            record.status === 'ENABLE',
+        );
+      } catch (checkError) {
+        logger.warn(lang.__('OSS_CNAME_DNS_CHECK_FAILED', { error: String(checkError) }));
+        return false;
+      }
+    };
+
+    logger.info(lang.__('OSS_CNAME_DNS_PROPAGATION_WAITING', { domain: mainDomain }));
+
+    for (let attempt = 1; attempt <= DNS_PROPAGATION_MAX_ATTEMPTS; attempt++) {
+      logger.info(
+        lang.__('OSS_CNAME_DNS_PROPAGATION_CHECK', {
+          attempt: String(attempt),
+          max: String(DNS_PROPAGATION_MAX_ATTEMPTS),
+        }),
+      );
+      await sleep(DNS_PROPAGATION_DELAY_MS);
+
+      const propagated = await checkPropagation();
+      if (propagated) {
+        logger.info(
+          lang.__('OSS_CNAME_DNS_PROPAGATION_VERIFIED', {
+            domain: mainDomain,
+            minutes: String(attempt),
+          }),
+        );
+        return true;
+      }
+    }
+
+    logger.warn(
+      lang.__('OSS_CNAME_DNS_PROPAGATION_TIMEOUT', {
+        max: String(DNS_PROPAGATION_MAX_ATTEMPTS),
+      }),
+    );
+    return false;
+  };
+
+  const retryCnameBindingAfterVerification = async (
+    bucketName: string,
+    domain: string,
+    certificate?: OssCnameCertificateConfig,
+  ): Promise<PutCnameResult> => {
+    logger.info(lang.__('OSS_CNAME_WAITING_FOR_VERIFICATION', { domain }));
+
+    for (let attempt = 1; attempt <= DOMAIN_BIND_MAX_RETRIES; attempt++) {
+      if (attempt > 1) {
+        logger.info(
+          lang.__('RETRY_ATTEMPT', {
+            operation: 'domain binding',
+            attempt: String(attempt),
+            max: String(DOMAIN_BIND_MAX_RETRIES),
+          }),
+        );
+      }
+
+      await sleep(DOMAIN_BIND_RETRY_DELAY_MS);
+
+      try {
+        const cnameResult = await putBucketCname(bucketName, domain, certificate);
+
+        if (cnameResult.success) {
+          return cnameResult;
+        }
+
+        if (!cnameResult.needVerification) {
+          return cnameResult;
+        }
+      } catch (error) {
+        if (attempt === DOMAIN_BIND_MAX_RETRIES) {
+          throw error;
+        }
+        logger.warn(
+          lang.__('RETRY_ATTEMPT_FAILED', {
+            operation: 'domain binding',
+            attempt: String(attempt),
+            max: String(DOMAIN_BIND_MAX_RETRIES),
+            error: String(error),
+          }),
+        );
+      }
+    }
+
+    const hostRecord = extractHostRecord(domain, extractMainDomain(domain));
+    const txtRecordName = '_dnsauth';
+    const fullTxtRecord = hostRecord ? `${txtRecordName}.${hostRecord}` : txtRecordName;
+
+    logger.warn(
+      lang.__('OSS_CNAME_VERIFICATION_RETRY_FAILED', {
+        domain,
+        txtRecord: `${fullTxtRecord}.${extractMainDomain(domain)}`,
+      }),
+    );
+
+    return { success: false, needVerification: true };
+  };
+
+  const createOrFindDnsCnameRecord = async (
+    domain: string,
+    mainDomain: string,
+    hostRecord: string,
+    ossEndpoint: string,
+    bucketCnameBound: boolean,
+  ): Promise<OssCnameInfo> => {
+    try {
+      const existingRecords = await dnsOps!.describeDomainRecords(mainDomain, hostRecord);
       const existingRecord = existingRecords.find(
         (record) =>
           record.rr === hostRecord && record.type === 'CNAME' && record.value === ossEndpoint,
@@ -263,7 +602,7 @@ export const createOssOperations = (
         };
       }
 
-      const recordId = await dnsOps.addDomainRecord({
+      const recordId = await dnsOps!.addDomainRecord({
         domainName: mainDomain,
         rr: hostRecord,
         type: 'CNAME',
@@ -317,19 +656,31 @@ export const createOssOperations = (
     bucketName: string,
     domain: string,
     dnsRecordId?: string,
+    txtRecordId?: string,
   ): Promise<void> => {
     await removeCorsRuleForDomain(bucketName, domain);
     await deleteBucketCname(bucketName, domain);
 
-    if (!dnsOps || !dnsRecordId || dnsRecordId === 'existing') {
-      return;
-    }
+    if (dnsOps) {
+      if (dnsRecordId && dnsRecordId !== 'existing') {
+        try {
+          await dnsOps.deleteDomainRecord(dnsRecordId);
+          logger.info(lang.__('OSS_DNS_CNAME_DELETED', { domain }));
+        } catch (error) {
+          logger.warn(lang.__('OSS_DNS_CNAME_DELETE_FAILED', { domain, error: String(error) }));
+        }
+      }
 
-    try {
-      await dnsOps.deleteDomainRecord(dnsRecordId);
-      logger.info(lang.__('OSS_DNS_CNAME_DELETED', { domain }));
-    } catch (error) {
-      logger.warn(lang.__('OSS_DNS_CNAME_DELETE_FAILED', { domain, error: String(error) }));
+      if (txtRecordId) {
+        try {
+          await dnsOps.deleteDomainRecord(txtRecordId);
+          logger.info(lang.__('OSS_DNS_TXT_RECORD_DELETED', { domain }));
+        } catch (error) {
+          logger.warn(
+            lang.__('OSS_DNS_TXT_RECORD_DELETE_FAILED', { domain, error: String(error) }),
+          );
+        }
+      }
     }
   };
 
@@ -596,5 +947,7 @@ export const createOssOperations = (
     unbindCustomDomain,
 
     getOssEndpoint,
+
+    createCnameToken,
   };
 };

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -17,9 +17,17 @@ export const DEFAULT_LOCK_TIMEOUT = 10 * 60 * 1000; // 10 minutes
 export const DEFAULT_LOCK_RETRY_DELAY = 2000; // 2 seconds
 export const STALE_LOCK_THRESHOLD = 60 * 60 * 1000; // 1 hour
 
-// API Gateway domain binding
-export const APIGW_DOMAIN_BIND_MAX_RETRIES = 5;
-export const APIGW_DOMAIN_BIND_RETRY_DELAY_MS = 30_000; // 30 seconds
+// Shared domain binding retry configuration (used by API Gateway, OSS, and future resources)
+export const DOMAIN_BIND_MAX_RETRIES = 5;
+export const DOMAIN_BIND_RETRY_DELAY_MS = 30_000; // 30 seconds
+
+// Shared DNS propagation polling configuration (used by API Gateway, OSS, and future resources)
+export const DNS_PROPAGATION_MAX_ATTEMPTS = 10;
+export const DNS_PROPAGATION_DELAY_MS = 60_000; // 1 minute
+
+// API Gateway domain binding (aliases for shared constants)
+export const APIGW_DOMAIN_BIND_MAX_RETRIES = DOMAIN_BIND_MAX_RETRIES;
+export const APIGW_DOMAIN_BIND_RETRY_DELAY_MS = DOMAIN_BIND_RETRY_DELAY_MS;
 export const APIGW_DNS_PUBLIC_RESOLUTION_MAX_ATTEMPTS = 10;
 export const APIGW_DNS_PUBLIC_RESOLUTION_DELAY_MS = 30_000; // 30 seconds
 

--- a/src/common/retryUtils.ts
+++ b/src/common/retryUtils.ts
@@ -1,0 +1,2 @@
+export const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -354,6 +354,43 @@ export const en = {
   OSS_BUCKET_CNAME_UNBIND_FAILED: 'Failed to unbind bucket CNAME: {{error}}',
   OSS_BUCKET_CNAME_NEED_VERIFY:
     'Domain ownership verification required. Please add TXT record in DNS console, then retry.',
+  OSS_CNAME_TOKEN_CREATE_FAILED:
+    'Failed to create CnameToken for domain ownership verification: {{domain}}',
+  OSS_CNAME_CREATING_VERIFICATION_TOKEN: 'Creating verification token for domain: {{domain}}',
+  OSS_CNAME_VERIFICATION_TOKEN_CREATED:
+    'Verification token created for domain {{domain}}. TXT record: {{txtRecord}}, Token: {{token}}',
+  OSS_CNAME_TXT_RECORD_CREATED:
+    'Created TXT record for domain ownership verification: {{txtRecord}}',
+  OSS_CNAME_TXT_RECORD_ALREADY_EXISTS: 'TXT verification record already exists: {{txtRecord}}',
+  OSS_CNAME_TXT_RECORD_CREATE_FAILED:
+    'Failed to create TXT record {{txtRecord}}: {{error}}. Please add manually.',
+  OSS_CNAME_WAITING_FOR_VERIFICATION:
+    'Waiting for domain ownership verification to propagate for: {{domain}}',
+  OSS_CNAME_DNS_PROPAGATION_WAITING:
+    'Waiting for TXT record DNS propagation for domain: {{domain}}',
+  OSS_CNAME_DNS_PROPAGATION_CHECK:
+    'Checking TXT record DNS propagation (attempt {{attempt}}/{{max}}, waiting 1 minute)...',
+  OSS_CNAME_DNS_PROPAGATION_VERIFIED:
+    'TXT record DNS propagation verified for domain: {{domain}} after {{minutes}} minute(s)',
+  OSS_CNAME_DNS_PROPAGATION_TIMEOUT:
+    'TXT record DNS propagation could not be verified after {{max}} attempts. Proceeding with binding retry anyway...',
+  OSS_CNAME_DNS_CHECK_FAILED: 'TXT record DNS propagation check failed: {{error}}',
+  OSS_CNAME_VERIFICATION_RETRY_FAILED:
+    'Domain ownership verification pending. Please add TXT record: {{txtRecord}} and retry deployment.',
+  OSS_CNAME_MANUAL_VERIFICATION_REQUIRED:
+    'Manual domain ownership verification required for {{domain}}. ' +
+    'Please add TXT record: {{txtRecord}} with value: {{token}}, then retry deployment.',
+  OSS_VERIFICATION_HEADER: 'OSS Domain Ownership Verification Required',
+  OSS_VERIFICATION_DOMAIN: 'Domain: {{domain}}',
+  OSS_VERIFICATION_INSTRUCTIONS: 'To verify domain ownership, add the following TXT DNS record:',
+  OSS_VERIFICATION_RECORD_NAME: '  Record Name: {{name}}',
+  OSS_VERIFICATION_RECORD_TYPE: '  Record Type: TXT',
+  OSS_VERIFICATION_RECORD_VALUE: '  Record Value: {{value}}',
+  OSS_VERIFICATION_NEXT_STEPS: 'After adding the TXT record:',
+  OSS_VERIFICATION_STEP1: '1. Wait 5-10 minutes for DNS propagation',
+  OSS_VERIFICATION_STEP2: '2. Run the deploy command again',
+  OSS_DNS_TXT_RECORD_DELETED: 'Deleted DNS TXT verification record for domain: {{domain}}',
+  OSS_DNS_TXT_RECORD_DELETE_FAILED: 'Failed to delete DNS TXT record for {{domain}}: {{error}}',
   OSS_BUCKET_CERT_BINDING:
     'Binding SSL certificate to custom domain {{domain}} on bucket {{bucketName}}',
   OSS_BUCKET_CERT_BOUND: 'SSL certificate bound to custom domain: {{domain}}',
@@ -592,4 +629,10 @@ export const en = {
   // Protocol messages
   PROTOCOL_INFERRED_REDIRECT:
     'Protocol "{{protocol}}" inferred HTTP-to-HTTPS redirect: {{redirect}}',
+
+  // Retry utility messages
+  RETRY_ATTEMPT: 'Retrying {{operation}} (attempt {{attempt}}/{{max}})...',
+  RETRY_ATTEMPT_FAILED: '{{operation}} attempt {{attempt}}/{{max}} failed: {{error}}. Retrying...',
+  RETRY_ALL_ATTEMPTS_FAILED: '{{operation}} failed after {{max}} attempts: {{error}}',
+  RETRY_UNEXPECTED_FAILURE: '{{operation}} failed unexpectedly',
 };

--- a/src/lang/zh-CN.ts
+++ b/src/lang/zh-CN.ts
@@ -315,6 +315,37 @@ export const zhCN = {
   OSS_BUCKET_CNAME_BIND_FAILED: '绑定存储桶 CNAME 失败: {{error}}',
   OSS_BUCKET_CNAME_UNBIND_FAILED: '解绑存储桶 CNAME 失败: {{error}}',
   OSS_BUCKET_CNAME_NEED_VERIFY: '需要验证域名所有权。请在 DNS 控制台添加 TXT 记录后重试。',
+  OSS_CNAME_TOKEN_CREATE_FAILED: '创建域名所有权验证 CnameToken 失败: {{domain}}',
+  OSS_CNAME_CREATING_VERIFICATION_TOKEN: '正在为域名创建验证令牌: {{domain}}',
+  OSS_CNAME_VERIFICATION_TOKEN_CREATED:
+    '已为域名 {{domain}} 创建验证令牌。TXT 记录: {{txtRecord}}, 令牌: {{token}}',
+  OSS_CNAME_TXT_RECORD_CREATED: '已创建域名所有权验证 TXT 记录: {{txtRecord}}',
+  OSS_CNAME_TXT_RECORD_ALREADY_EXISTS: 'TXT 验证记录已存在: {{txtRecord}}',
+  OSS_CNAME_TXT_RECORD_CREATE_FAILED: '创建 TXT 记录 {{txtRecord}} 失败: {{error}}。请手动添加。',
+  OSS_CNAME_WAITING_FOR_VERIFICATION: '等待域名所有权验证生效: {{domain}}',
+  OSS_CNAME_DNS_PROPAGATION_WAITING: '等待域名 TXT 记录 DNS 生效: {{domain}}',
+  OSS_CNAME_DNS_PROPAGATION_CHECK:
+    '正在检查 TXT 记录 DNS 生效状态（第 {{attempt}}/{{max}} 次，等待 1 分钟）...',
+  OSS_CNAME_DNS_PROPAGATION_VERIFIED: '域名 TXT 记录 DNS 已生效: {{domain}}，耗时 {{minutes}} 分钟',
+  OSS_CNAME_DNS_PROPAGATION_TIMEOUT:
+    'TXT 记录 DNS 在 {{max}} 次尝试后仍未验证生效。继续尝试绑定...',
+  OSS_CNAME_DNS_CHECK_FAILED: 'TXT 记录 DNS 生效检查失败: {{error}}',
+  OSS_CNAME_VERIFICATION_RETRY_FAILED:
+    '域名所有权验证中。请添加 TXT 记录: {{txtRecord}} 后重新部署。',
+  OSS_CNAME_MANUAL_VERIFICATION_REQUIRED:
+    '域名 {{domain}} 需要手动验证所有权。' +
+    '请添加 TXT 记录: {{txtRecord}}，值为: {{token}}，然后重新部署。',
+  OSS_VERIFICATION_HEADER: 'OSS 域名所有权验证',
+  OSS_VERIFICATION_DOMAIN: '域名: {{domain}}',
+  OSS_VERIFICATION_INSTRUCTIONS: '请添加以下 TXT DNS 记录以验证域名所有权:',
+  OSS_VERIFICATION_RECORD_NAME: '  记录名称: {{name}}',
+  OSS_VERIFICATION_RECORD_TYPE: '  记录类型: TXT',
+  OSS_VERIFICATION_RECORD_VALUE: '  记录值: {{value}}',
+  OSS_VERIFICATION_NEXT_STEPS: '添加 TXT 记录后:',
+  OSS_VERIFICATION_STEP1: '1. 等待 5-10 分钟 DNS 生效',
+  OSS_VERIFICATION_STEP2: '2. 重新运行部署命令',
+  OSS_DNS_TXT_RECORD_DELETED: '已删除域名所有权验证 TXT 记录: {{domain}}',
+  OSS_DNS_TXT_RECORD_DELETE_FAILED: '删除域名 TXT 记录失败: {{domain}}: {{error}}',
   OSS_BUCKET_CERT_BINDING: '正在为存储桶 {{bucketName}} 的自定义域名 {{domain}} 绑定 SSL 证书',
   OSS_BUCKET_CERT_BOUND: '已为自定义域名绑定 SSL 证书: {{domain}}',
   OSS_CORS_RULE_ADDED: '已为自定义域名添加 CORS 规则: {{domain}}',
@@ -538,4 +569,10 @@ export const zhCN = {
 
   // 协议消息
   PROTOCOL_INFERRED_REDIRECT: '协议 "{{protocol}}" 推断 HTTP 到 HTTPS 重定向：{{redirect}}',
+
+  // 重试工具消息
+  RETRY_ATTEMPT: '正在重试 {{operation}}（第 {{attempt}}/{{max}} 次）...',
+  RETRY_ATTEMPT_FAILED: '{{operation}} 第 {{attempt}}/{{max}} 次尝试失败：{{error}}。正在重试...',
+  RETRY_ALL_ATTEMPTS_FAILED: '{{operation}} 在 {{max}} 次尝试后失败：{{error}}',
+  RETRY_UNEXPECTED_FAILURE: '{{operation}} 意外失败',
 };

--- a/src/stack/aliyunStack/ossResource.ts
+++ b/src/stack/aliyunStack/ossResource.ts
@@ -31,6 +31,7 @@ type OssDnsInstance = ResourceInstance & {
   domain: string;
   cname: string;
   dnsRecordId?: string;
+  txtRecordId?: string;
 };
 
 const buildOssInstanceFromProvider = (info: OssBucketInfo, sid: string): CommonBucketInstance => {
@@ -216,6 +217,7 @@ export const createBucketResource = async (
         domain: bucket.website.domain,
         cname: cnameInfo.cname,
         ...(cnameInfo.dnsRecordId ? { dnsRecordId: cnameInfo.dnsRecordId } : {}),
+        ...(cnameInfo.txtRecordId ? { txtRecordId: cnameInfo.txtRecordId } : {}),
       };
       instances.push(dnsInstance);
 
@@ -307,6 +309,7 @@ export const updateBucketResource = async (
         config.bucketName,
         existingDnsInstance.domain,
         existingDnsInstance.dnsRecordId,
+        existingDnsInstance.txtRecordId,
       );
     }
 
@@ -344,6 +347,7 @@ export const updateBucketResource = async (
         domain: bucket.website.domain,
         cname: cnameInfo.cname,
         ...(cnameInfo.dnsRecordId ? { dnsRecordId: cnameInfo.dnsRecordId } : {}),
+        ...(cnameInfo.txtRecordId ? { txtRecordId: cnameInfo.txtRecordId } : {}),
       };
       instances.push(dnsInstance);
 
@@ -358,6 +362,7 @@ export const updateBucketResource = async (
       config.bucketName,
       existingDnsInstance.domain,
       existingDnsInstance.dnsRecordId,
+      existingDnsInstance.txtRecordId,
     );
   }
 
@@ -386,7 +391,12 @@ export const deleteBucketResource = async (
   ) as OssDnsInstance | undefined;
 
   if (dnsInstance) {
-    await client.oss.unbindCustomDomain(bucketName, dnsInstance.domain, dnsInstance.dnsRecordId);
+    await client.oss.unbindCustomDomain(
+      bucketName,
+      dnsInstance.domain,
+      dnsInstance.dnsRecordId,
+      dnsInstance.txtRecordId,
+    );
   }
 
   try {

--- a/tests/common/aliyunClient/ossOperations.test.ts
+++ b/tests/common/aliyunClient/ossOperations.test.ts
@@ -305,7 +305,7 @@ describe('ossOperations putBucketCname', () => {
       expect(result.domain).toBe('cdn.example.com');
     });
 
-    it('should tolerate NeedVerifyDomainOwnership when certificate is present', async () => {
+    it('should throw when NeedVerifyDomainOwnership and no DNS operations available', async () => {
       const verifyError = Object.assign(new Error('NeedVerifyDomainOwnership'), {
         code: 'NeedVerifyDomainOwnership',
       });
@@ -318,10 +318,9 @@ describe('ossOperations putBucketCname', () => {
           '-----BEGIN RSA PRIVATE KEY-----\nKEY\n-----END RSA PRIVATE KEY-----',
       };
 
-      const result = await operations.bindCustomDomain('test-bucket', 'cdn.example.com', cert);
-
-      expect(result).toBeDefined();
-      expect(result.bucketCnameBound).toBe(false);
+      await expect(
+        operations.bindCustomDomain('test-bucket', 'cdn.example.com', cert),
+      ).rejects.toThrow();
     });
   });
 });

--- a/tests/stack/aliyunStack/ossResource.test.ts
+++ b/tests/stack/aliyunStack/ossResource.test.ts
@@ -206,6 +206,7 @@ describe('OssResource', () => {
         bucketName,
         'example.com',
         'dns-record-123',
+        undefined,
       );
       expect(mockOssOperations.deleteBucket).toHaveBeenCalledWith(bucketName);
       expect(mockedStateManager.removeResource).toHaveBeenCalledWith(stateWithDns, logicalId);
@@ -250,6 +251,7 @@ describe('OssResource', () => {
       expect(mockOssOperations.unbindCustomDomain).toHaveBeenCalledWith(
         bucketName,
         'example.com',
+        undefined,
         undefined,
       );
       expect(mockOssOperations.deleteBucket).toHaveBeenCalledWith(bucketName);


### PR DESCRIPTION
This pull request introduces robust support for automatic domain ownership verification when binding custom domains to OSS buckets. It adds logic to handle TXT DNS record creation, polling for DNS propagation, and retrying domain binding after verification, enabling smoother and more reliable deployments. The changes also unify domain binding and DNS propagation retry configurations, improve error handling and user guidance, and refactor utility code for maintainability.

**OSS domain ownership verification enhancements:**

* Added support for domain ownership verification by creating and polling TXT DNS records during OSS custom domain binding. This includes new logic to create verification tokens, add TXT records, poll for DNS propagation, and retry domain binding, with clear user instructions and error handling throughout (`src/common/aliyunClient/ossOperations.ts`, `src/lang/en.ts`). [[1]](diffhunk://#diff-1d984aaa7a86b1a52ab15cfa1bc893253029360dc8ef59dea448978fbbb155e5R43-R67) [[2]](diffhunk://#diff-1d984aaa7a86b1a52ab15cfa1bc893253029360dc8ef59dea448978fbbb155e5L238-R589) [[3]](diffhunk://#diff-1d984aaa7a86b1a52ab15cfa1bc893253029360dc8ef59dea448978fbbb155e5R80-R100) [[4]](diffhunk://#diff-1d984aaa7a86b1a52ab15cfa1bc893253029360dc8ef59dea448978fbbb155e5R124-R167) [[5]](diffhunk://#diff-1d984aaa7a86b1a52ab15cfa1bc893253029360dc8ef59dea448978fbbb155e5L102-R207) [[6]](diffhunk://#diff-1d984aaa7a86b1a52ab15cfa1bc893253029360dc8ef59dea448978fbbb155e5R659-R684) [[7]](diffhunk://#diff-1d984aaa7a86b1a52ab15cfa1bc893253029360dc8ef59dea448978fbbb155e5R950-R951) [[8]](diffhunk://#diff-6f5b32186d541b1092dda3dee5faf12a24bb0c4cfc7a344ffb48bde7e2d7d065R357-R393)
* Extended the domain unbinding logic to remove associated TXT verification records, ensuring proper cleanup of DNS entries (`src/common/aliyunClient/ossOperations.ts`).

**Retry and DNS propagation configuration unification:**

* Unified retry and DNS propagation configurations for domain binding across OSS and API Gateway, using shared constants for maximum retries and delay intervals (`src/common/constants.ts`).
* Added new retry-related messages for user-facing logs and errors (`src/lang/en.ts`).

**Utility and code structure improvements:**

* Refactored the `sleep` utility into a shared module (`src/common/retryUtils.ts`) and updated imports in relevant files (`src/common/aliyunClient/apigwOperations.ts`, `src/common/aliyunClient/ossOperations.ts`). [[1]](diffhunk://#diff-b8119e42dd6161a902e413f1424bc87ce27cf5f05ea13fe3345cd5bde190af43R1-R2) [[2]](diffhunk://#diff-60b3d56e7778727b6fa6aa71286ff7d24c45d7d84eeab555b8d9b8ed5e8537c8R18) [[3]](diffhunk://#diff-1d984aaa7a86b1a52ab15cfa1bc893253029360dc8ef59dea448978fbbb155e5R17-R23)
* Improved XML parsing and response handling for OSS operations, aiding maintainability and extensibility (`src/common/aliyunClient/ossOperations.ts`).

**Type and interface updates:**

* Expanded types and interfaces to support TXT record tracking and verification token information in OSS domain binding flows (`src/common/aliyunClient/ossOperations.ts`).

These enhancements collectively make OSS domain binding more reliable, automate verification steps, and provide clearer guidance and error messages to users.