### PR TITLE
fix: always set errorDocument=indexDocument and enable SupportSubDir for OSS static websites (#196)

### DIFF
--- a/samples/README_TENCENT_COS.md
+++ b/samples/README_TENCENT_COS.md
@@ -9,7 +9,7 @@ The Tencent COS support provides full lifecycle management for cloud storage buc
 - **State Management**: Local state tracking in `.serverlessinsight/state.json`
 - **Plan & Apply Flow**: Preview changes before applying them
 - **Drift Detection**: Detect manual changes made outside ServerlessInsight
-- **Website Hosting**: Configure static website hosting with error pages
+- **Website Hosting**: Configure static website hosting
 - **Access Control**: Configure bucket ACL (private, public-read, public-read-write)
 - **Idempotent Operations**: Safe to re-run deployments
 
@@ -39,8 +39,6 @@ buckets:
     website: # Optional: Enable static website hosting
       code: dist # Local directory to deploy (not implemented yet)
       index: index.html
-      error_page: 404.html
-      error_code: 404
 ```
 
 ## Bucket Naming Requirements
@@ -187,9 +185,7 @@ buckets:
     security:
       acl: PUBLIC_READ # Website content must be publicly readable
     website:
-      index: index.html # Default page
-      error_page: 404.html # Error page
-      error_code: 404 # HTTP error code
+      index: index.html # Default page (also used as error document for SPA routing)
 ```
 
 After deployment, your website will be accessible at:
@@ -229,8 +225,6 @@ buckets:
       acl: PUBLIC_READ
     website:
       index: index.html
-      error_page: 404.html
-      error_code: 404
 ```
 
 ## Idempotency
@@ -289,8 +283,6 @@ buckets:
       acl: PUBLIC_READ
     website: # Added website configuration
       index: index.html
-      error_page: 404.html
-      error_code: 404
 ```
 
 Run `si deploy` to apply the change.
@@ -349,8 +341,6 @@ buckets:
       acl: PUBLIC_READ
     website:
       index: index.html
-      error_page: error.html
-      error_code: 404
 ```
 
 ### Multiple Buckets
@@ -380,8 +370,6 @@ buckets:
       acl: PUBLIC_READ
     website:
       index: index.html
-      error_page: 404.html
-      error_code: 404
 ```
 
 ## Troubleshooting
@@ -425,7 +413,7 @@ coscmd delete -r -f /
 If your website is not accessible after deployment:
 
 1. Verify ACL is set to `PUBLIC_READ`
-2. Check that `index` and `error_page` files exist in the bucket
+2. Check that `index` file exists in the bucket
 3. Access the website using the correct URL format:
    ```
    http://{bucket-name}.cos-website.{region}.myqcloud.com

--- a/samples/aliyun-poc-bucket-cdn.yml
+++ b/samples/aliyun-poc-bucket-cdn.yml
@@ -1,0 +1,63 @@
+version: 0.1.0
+
+provider:
+  name: aliyun
+  region: cn-hongkong
+
+app: insight-poc
+service: insight-poc-cdn-bucket
+
+tags:
+  owner: geek-fun
+
+# Example 1: Simple CDN configuration
+# Just enable CDN with default settings
+buckets:
+  simple_cdn_bucket:
+    name: insight-poc-simple-cdn
+    security:
+      acl: PUBLIC_READ
+    website:
+      code: dist
+      index: index.html
+    domain:
+      domain_name: static.example.com
+      certificate_id: cas-cert-abc123
+      cdn: true  # Simple: CDN enabled with sensible defaults
+
+  # Example 2: Advanced CDN configuration
+  # Full control over CDN settings
+  advanced_cdn_bucket:
+    name: insight-poc-advanced-cdn
+    security:
+      acl: PUBLIC_READ
+    website:
+      code: dist
+      index: index.html
+    domain:
+      domain_name: assets.example.com
+      certificate_id: cas-cert-def456
+      cdn:
+        enabled: true
+        cdn_type: web           # web | download | video
+        scope: global           # domestic | overseas | global
+        cache_ttl: 3600         # Cache TTL in seconds
+        ignore_query_string: false  # Ignore query string in cache key
+        origin_protocol: https  # http | https | follow
+        compression: true       # Enable Gzip compression
+        force_redirect_https: true  # Force HTTPS redirect
+
+  # Example 3: CDN + Transfer Acceleration (dual-layer)
+  # CDN origin uses accelerated OSS endpoint
+  dual_acceleration_bucket:
+    name: insight-poc-dual-accel
+    security:
+      acl: PRIVATE
+    domain:
+      domain_name: downloads.example.com
+      certificate_id: cas-cert-ghi789
+      cdn:
+        enabled: true
+        cdn_type: download
+        scope: global
+      accelerate: true  # OSS Transfer Acceleration for origin fetch

--- a/samples/aliyun-poc-bucket.yml
+++ b/samples/aliyun-poc-bucket.yml
@@ -16,5 +16,3 @@ buckets:
     website:
       code: dist
       index: index.html
-      error_page: 404.html
-      error_code: 404

--- a/samples/aliyun-poc-domain.yml
+++ b/samples/aliyun-poc-domain.yml
@@ -19,5 +19,3 @@ buckets:
       code: dist
       domain: meke-ui.serverlessinsight.com
       index: index.html
-      error_page: 404.html
-      error_code: 404

--- a/samples/tencent-poc-cos.yml
+++ b/samples/tencent-poc-cos.yml
@@ -17,5 +17,3 @@ buckets:
     website:
       code: dist
       index: index.html
-      error_page: 404.html
-      error_code: 404

--- a/samples/volcengine-poc-bucket.yml
+++ b/samples/volcengine-poc-bucket.yml
@@ -14,4 +14,3 @@ buckets:
     website:
       code: ./dist
       index: index.html
-      error_page: 404.html

--- a/src/common/aliyunClient/ossOperations.ts
+++ b/src/common/aliyunClient/ossOperations.ts
@@ -1,6 +1,15 @@
 import OSS from 'ali-oss';
 import fs from 'node:fs';
 import path from 'node:path';
+
+// Extend OSS PutBucketWebsiteConfig to include SupportSubDir and Type parameters
+declare module 'ali-oss' {
+  interface PutBucketWebsiteConfig {
+    supportSubDir?: boolean;
+    type?: number;
+  }
+}
+
 import {
   BucketACL,
   CommonBucketInfo,
@@ -729,6 +738,8 @@ const parseXmlResponse = <T>(xml: string, tagName: string): T | null => {
         await ossClient.putBucketWebsite(config.bucketName, {
           index: config.websiteConfig.indexDocument,
           error: config.websiteConfig.errorDocument,
+          supportSubDir: true,
+          type: 2,
         });
       }
 
@@ -893,6 +904,8 @@ const parseXmlResponse = <T>(xml: string, tagName: string): T | null => {
       await ossClient.putBucketWebsite(bucketName, {
         index: websiteConfig.indexDocument,
         error: websiteConfig.errorDocument,
+        supportSubDir: true,
+        type: 2,
       });
     },
 

--- a/src/parser/bucketParser.ts
+++ b/src/parser/bucketParser.ts
@@ -1,9 +1,5 @@
 import { BucketAccessEnum, BucketDomain, BucketRaw, CdnConfig, CdnRawConfig } from '../types';
-import {
-  parseBooleanWithDefault,
-  parseNumberWithDefault,
-  parseStringWithDefault,
-} from './parseUtils';
+import { parseBooleanWithDefault, parseStringWithDefault } from './parseUtils';
 import { logger } from '../common/logger';
 import { lang } from '../lang';
 
@@ -168,8 +164,6 @@ export const parseBucket = (buckets: {
             code: String(bucket.website.code),
             ...websiteDomain,
             index: parseStringWithDefault(bucket.website.index, 'index.html'),
-            error_page: parseStringWithDefault(bucket.website.error_page, '404.html'),
-            error_code: parseNumberWithDefault(bucket.website.error_code, 404),
           }
         : undefined,
     };

--- a/src/stack/aliyunStack/ossTypes.ts
+++ b/src/stack/aliyunStack/ossTypes.ts
@@ -45,11 +45,8 @@ export const bucketToOssBucketConfig = (bucket: BucketDomain): OssBucketConfig =
   if (bucket.website) {
     config.websiteConfig = {
       indexDocument: bucket.website.index,
+      errorDocument: bucket.website.index,
     };
-
-    if (bucket.website.error_page) {
-      config.websiteConfig.errorDocument = bucket.website.error_page;
-    }
   }
 
   if (bucket.storage?.class) {

--- a/src/stack/scfStack/cosTypes.ts
+++ b/src/stack/scfStack/cosTypes.ts
@@ -135,12 +135,9 @@ export const bucketToCosBucketConfig = (bucket: BucketDomain, region: string): C
       },
     };
 
-    // Only add ErrorDocument if error_page is defined
-    if (bucket.website.error_page) {
-      config.WebsiteConfiguration.ErrorDocument = {
-        Key: bucket.website.error_page,
-      };
-    }
+    config.WebsiteConfiguration.ErrorDocument = {
+      Key: bucket.website.index,
+    };
 
     if (bucket.website.domain) {
       config.Domain = bucket.website.domain;

--- a/src/stack/volcengineStack/tosTypes.ts
+++ b/src/stack/volcengineStack/tosTypes.ts
@@ -40,11 +40,8 @@ export const bucketToTosConfig = (bucket: BucketDomain) => {
   if (bucket.website) {
     config.websiteConfig = {
       indexDocument: bucket.website.index,
+      errorDocument: bucket.website.index,
     };
-
-    if (bucket.website.error_page) {
-      config.websiteConfig.errorDocument = bucket.website.error_page;
-    }
   }
 
   return config;

--- a/src/types/domains/bucket.ts
+++ b/src/types/domains/bucket.ts
@@ -60,8 +60,6 @@ export type BucketRaw = {
     // Deprecated: Use top-level `domain` instead
     domain?: Resolvable<string> | BucketWebsiteDomainConfig;
     index?: Resolvable<string>;
-    error_page?: Resolvable<string>;
-    error_code?: Resolvable<number>;
   };
 };
 
@@ -109,8 +107,6 @@ export type BucketDomain = {
     domain_certificate_private_key?: string;
     domain_protocol?: string | string[];
     code: string;
-    error_page: string;
-    error_code: number;
   };
 };
 

--- a/src/validator/bucketSchema.ts
+++ b/src/validator/bucketSchema.ts
@@ -1,4 +1,4 @@
-import { resolvableNumber, resolvableBoolean, resolvableEnum } from './templateRefSchema';
+import { resolvableBoolean, resolvableEnum } from './templateRefSchema';
 
 const cdnSchema = {
   oneOf: [
@@ -180,10 +180,6 @@ export const bucketSchema = {
             index: {
               type: 'string',
             },
-            error_page: {
-              type: 'string',
-            },
-            error_code: resolvableNumber,
           },
           required: ['code'],
           additionalProperties: false,

--- a/tests/fixtures/deploy-fixtures/bucketWithWebsite.ts
+++ b/tests/fixtures/deploy-fixtures/bucketWithWebsite.ts
@@ -16,8 +16,6 @@ export const bucketWithWebsiteIac = {
         code: 'tests/fixtures/artifacts/large-artifact.zip',
         domain: 'my-bucket.com',
         index: 'index.html',
-        error_page: '404.html',
-        error_code: 404,
       },
     },
   ],
@@ -114,7 +112,7 @@ export const bucketWithWebsiteRos = {
         WebsiteConfigurationV2: {
           ErrorDocument: {
             HttpStatus: '404',
-            Key: '404.html',
+            Key: 'index.html',
           },
           IndexDocument: {
             Suffix: 'index.html',

--- a/tests/fixtures/serverless-insight-website.yml
+++ b/tests/fixtures/serverless-insight-website.yml
@@ -16,5 +16,3 @@ buckets:
     website:
       code: dist
       index: index.html
-      error_page: 404.html
-      error_code: 404

--- a/tests/fixtures/serverless-insight-with-bucket.yml
+++ b/tests/fixtures/serverless-insight-with-bucket.yml
@@ -54,5 +54,3 @@ buckets:
     website:
       code: tests/fixtures/test-bucket
       index: index.html
-      error_page: 404.html
-      error_code: 404

--- a/tests/service/cdn-flow.spec.test.ts
+++ b/tests/service/cdn-flow.spec.test.ts
@@ -221,7 +221,6 @@ buckets:
     website:
       code: ${JSON.stringify(WEBSITE_SOURCE_PATH)}
       index: index.html
-      error_page: 404.html
     domain:
       domain_name: ${BUCKET_DOMAIN}
       certificate_id: ${BUCKET_CERT_ID}

--- a/tests/unit/common/aliyunClient/ossOperations.test.ts
+++ b/tests/unit/common/aliyunClient/ossOperations.test.ts
@@ -1448,6 +1448,8 @@ describe('ossOperations additional createBucket branches', () => {
     expect(mockOssClient2.putBucketWebsite).toHaveBeenCalledWith('test-bucket', {
       index: 'index.html',
       error: '404.html',
+      supportSubDir: true,
+      type: 2,
     });
   });
 });

--- a/tests/unit/parser/bucketParser.test.ts
+++ b/tests/unit/parser/bucketParser.test.ts
@@ -203,8 +203,6 @@ describe('bucketParser', () => {
         domain_certificate_private_key: undefined,
         domain_protocol: undefined,
         index: 'index.html',
-        error_page: '404.html',
-        error_code: 404,
       });
     });
 
@@ -246,8 +244,6 @@ describe('bucketParser', () => {
         domain_certificate_private_key: undefined,
         domain_protocol: undefined,
         index: 'index.html',
-        error_page: '404.html',
-        error_code: 404,
       });
     });
 
@@ -275,8 +271,6 @@ describe('bucketParser', () => {
         domain_certificate_private_key: undefined,
         domain_protocol: undefined,
         index: 'index.html',
-        error_page: '404.html',
-        error_code: 404,
       });
     });
 
@@ -410,8 +404,6 @@ describe('bucketParser', () => {
           website: {
             code: './dist',
             index: 'home.html',
-            error_page: 'error.html',
-            error_code: 500,
           },
         },
       };
@@ -419,8 +411,6 @@ describe('bucketParser', () => {
       const result = parseBucket(buckets);
 
       expect(result?.[0].website?.index).toBe('home.html');
-      expect(result?.[0].website?.error_page).toBe('error.html');
-      expect(result?.[0].website?.error_code).toBe(500);
     });
 
     it('should parse bucket without website configuration', () => {
@@ -482,8 +472,6 @@ describe('bucketParser', () => {
               protocol: ['http', 'https'],
             },
             index: 'index.html',
-            error_page: '404.html',
-            error_code: 404,
           },
         },
       };
@@ -511,8 +499,6 @@ describe('bucketParser', () => {
           domain_certificate_private_key: '-----BEGIN PRIVATE KEY-----',
           domain_protocol: ['http', 'https'],
           index: 'index.html',
-          error_page: '404.html',
-          error_code: 404,
         },
       });
     });

--- a/tests/unit/stack/aliyunStack/ossPlanner.test.ts
+++ b/tests/unit/stack/aliyunStack/ossPlanner.test.ts
@@ -60,8 +60,6 @@ describe('OSS Planner', () => {
     website: {
       index: 'index.html',
       code: 'dist',
-      error_page: '404.html',
-      error_code: 404,
     },
   };
 
@@ -92,7 +90,7 @@ describe('OSS Planner', () => {
         acl: 'public-read',
         websiteConfig: {
           indexDocument: 'index.html',
-          errorDocument: '404.html',
+          errorDocument: 'index.html',
         },
       });
 
@@ -104,7 +102,7 @@ describe('OSS Planner', () => {
           acl: 'public-read',
           websiteConfiguration: {
             indexDocument: 'index.html',
-            errorDocument: '404.html',
+            errorDocument: 'index.html',
           },
           websiteCodeHash: 'mock-website-hash',
           storageClass: null,
@@ -142,7 +140,7 @@ describe('OSS Planner', () => {
       mockOssOperations.getBucket.mockResolvedValue({
         name: 'test-bucket',
         acl: 'public-read',
-        websiteConfig: { indexDocument: 'index.html', errorDocument: '404.html' },
+        websiteConfig: { indexDocument: 'index.html', errorDocument: 'index.html' },
       });
 
       const state = setResource(initialState, 'buckets.test_bucket', {
@@ -151,7 +149,7 @@ describe('OSS Planner', () => {
         definition: {
           bucketName: 'test-bucket',
           acl: 'public-read',
-          websiteConfiguration: { indexDocument: 'index.html', errorDocument: '404.html' },
+          websiteConfiguration: { indexDocument: 'index.html', errorDocument: 'index.html' },
           websiteCodeHash: 'mock-website-hash',
           storageClass: null,
           domain: 'www.example.com',
@@ -195,7 +193,7 @@ describe('OSS Planner', () => {
       mockOssOperations.getBucket.mockResolvedValue({
         name: 'test-bucket',
         acl: 'public-read',
-        websiteConfig: { indexDocument: 'index.html', errorDocument: '404.html' },
+        websiteConfig: { indexDocument: 'index.html', errorDocument: 'index.html' },
       });
 
       const state = setResource(initialState, 'buckets.test_bucket', {
@@ -204,7 +202,7 @@ describe('OSS Planner', () => {
         definition: {
           bucketName: 'test-bucket',
           acl: 'public-read',
-          websiteConfiguration: { indexDocument: 'index.html', errorDocument: '404.html' },
+          websiteConfiguration: { indexDocument: 'index.html', errorDocument: 'index.html' },
           websiteCodeHash: 'mock-website-hash',
           storageClass: null,
           domain: 'www.example.com',
@@ -247,7 +245,7 @@ describe('OSS Planner', () => {
       mockOssOperations.getBucket.mockResolvedValue({
         name: 'test-bucket',
         acl: 'public-read',
-        websiteConfig: { indexDocument: 'index.html', errorDocument: '404.html' },
+        websiteConfig: { indexDocument: 'index.html', errorDocument: 'index.html' },
       });
 
       const state = setResource(initialState, 'buckets.test_bucket', {
@@ -256,7 +254,7 @@ describe('OSS Planner', () => {
         definition: {
           bucketName: 'test-bucket',
           acl: 'public-read',
-          websiteConfiguration: { indexDocument: 'index.html', errorDocument: '404.html' },
+          websiteConfiguration: { indexDocument: 'index.html', errorDocument: 'index.html' },
           websiteCodeHash: 'mock-website-hash',
           storageClass: null,
           domain: null,
@@ -296,7 +294,7 @@ describe('OSS Planner', () => {
         acl: 'private',
         websiteConfig: {
           indexDocument: 'index.html',
-          errorDocument: '404.html',
+          errorDocument: 'index.html',
         },
       });
 
@@ -308,7 +306,7 @@ describe('OSS Planner', () => {
           acl: 'private',
           websiteConfiguration: {
             indexDocument: 'index.html',
-            errorDocument: '404.html',
+            errorDocument: 'index.html',
           },
           websiteCodeHash: 'mock-website-hash',
           storageClass: null,
@@ -395,7 +393,7 @@ describe('OSS Planner', () => {
           acl: 'public-read',
           websiteConfiguration: {
             indexDocument: 'index.html',
-            errorDocument: '404.html',
+            errorDocument: 'index.html',
           },
           websiteCodeHash: 'mock-website-hash',
           storageClass: null,
@@ -435,7 +433,7 @@ describe('OSS Planner', () => {
       mockOssOperations.getBucket.mockResolvedValue({
         name: 'test-bucket',
         acl: 'public-read',
-        websiteConfig: { indexDocument: 'index.html', errorDocument: '404.html' },
+        websiteConfig: { indexDocument: 'index.html', errorDocument: 'index.html' },
       });
 
       const state = setResource(initialState, 'buckets.test_bucket', {
@@ -444,7 +442,7 @@ describe('OSS Planner', () => {
         definition: {
           bucketName: 'test-bucket',
           acl: 'public-read',
-          websiteConfiguration: { indexDocument: 'index.html', errorDocument: '404.html' },
+          websiteConfiguration: { indexDocument: 'index.html', errorDocument: 'index.html' },
           websiteCodeHash: 'different-hash',
           storageClass: null,
           domain: null,

--- a/tests/unit/stack/aliyunStack/ossResource.test.ts
+++ b/tests/unit/stack/aliyunStack/ossResource.test.ts
@@ -323,7 +323,7 @@ describe('OssResource', () => {
         {
           key: 'test_bucket',
           name: 'test-bucket',
-          website: { index: 'index.html', code: './dist', error_page: '404.html', error_code: 404 },
+          website: { index: 'index.html', code: './dist' },
         },
         initialState,
       );
@@ -379,7 +379,7 @@ describe('OssResource', () => {
         {
           key: 'test_bucket',
           name: 'test-bucket',
-          website: { index: 'index.html', code: './dist', error_page: '404.html', error_code: 404 },
+          website: { index: 'index.html', code: './dist' },
         },
         initialState,
       );
@@ -438,7 +438,7 @@ describe('OssResource', () => {
         {
           key: 'test_bucket',
           name: 'test-bucket',
-          website: { index: 'index.html', code: './dist', error_page: '404.html', error_code: 404 },
+          website: { index: 'index.html', code: './dist' },
         },
         initialState,
       );
@@ -489,7 +489,7 @@ describe('OssResource', () => {
         {
           key: 'test_bucket',
           name: 'test-bucket',
-          website: { index: 'index.html', code: './dist', error_page: '404.html', error_code: 404 },
+          website: { index: 'index.html', code: './dist' },
         },
         initialState,
       );
@@ -538,7 +538,7 @@ describe('OssResource', () => {
         {
           key: 'test_bucket',
           name: 'test-bucket',
-          website: { index: 'index.html', code: './dist', error_page: '404.html', error_code: 404 },
+          website: { index: 'index.html', code: './dist' },
         },
         initialState,
       );
@@ -588,7 +588,7 @@ describe('OssResource', () => {
         {
           key: 'test_bucket',
           name: 'test-bucket',
-          website: { index: 'index.html', code: './dist', error_page: '404.html', error_code: 404 },
+          website: { index: 'index.html', code: './dist' },
         },
         initialState,
       );
@@ -638,7 +638,7 @@ describe('OssResource', () => {
         {
           key: 'test_bucket',
           name: 'test-bucket',
-          website: { index: 'index.html', code: './dist', error_page: '404.html', error_code: 404 },
+          website: { index: 'index.html', code: './dist' },
         },
         initialState,
       );
@@ -690,7 +690,7 @@ describe('OssResource', () => {
         {
           key: 'test_bucket',
           name: 'test-bucket',
-          website: { index: 'index.html', code: './dist', error_page: '404.html', error_code: 404 },
+          website: { index: 'index.html', code: './dist' },
         },
         initialState,
       );
@@ -731,7 +731,7 @@ describe('OssResource', () => {
         {
           key: 'test_bucket',
           name: 'test-bucket',
-          website: { index: 'index.html', code: './dist', error_page: '404.html', error_code: 404 },
+          website: { index: 'index.html', code: './dist' },
         },
         initialState,
       );
@@ -772,7 +772,7 @@ describe('OssResource', () => {
         {
           key: 'test_bucket',
           name: 'test-bucket',
-          website: { index: 'index.html', code: './dist', error_page: '404.html', error_code: 404 },
+          website: { index: 'index.html', code: './dist' },
         },
         initialState,
       );
@@ -803,8 +803,6 @@ describe('OssResource', () => {
       website: {
         index: 'index.html',
         code: './dist',
-        error_page: '404.html',
-        error_code: 404,
       },
     };
 
@@ -1264,8 +1262,6 @@ describe('OssResource', () => {
       website: {
         index: 'index.html',
         code: './dist',
-        error_page: '404.html',
-        error_code: 404,
       },
     };
 
@@ -1388,8 +1384,6 @@ describe('OssResource', () => {
         website: {
           index: 'index.html',
           code: './dist',
-          error_page: '404.html',
-          error_code: 404,
         },
       };
 
@@ -1417,8 +1411,6 @@ describe('OssResource', () => {
         website: {
           index: 'index.html',
           code: './dist',
-          error_page: '404.html',
-          error_code: 404,
         },
       };
 
@@ -1665,8 +1657,6 @@ describe('OssResource', () => {
         website: {
           index: 'index.html',
           code: './dist',
-          error_page: '404.html',
-          error_code: 404,
         },
       };
 
@@ -1883,7 +1873,7 @@ describe('OssResource', () => {
         key: 'b',
         name: 'tb',
         security: { acl: BucketAccessEnum.PUBLIC_READ, force_delete: false },
-        website: { code: './d', index: 'i.html', error_page: '404.html', error_code: 404 },
+        website: { code: './d', index: 'i.html' },
         domain: { domain_name: 'x.com', cdn: true, www_bind_apex: false },
       };
       await createBucketResource(mockContext, b, initialState);
@@ -1895,7 +1885,7 @@ describe('OssResource', () => {
         key: 'b',
         name: 'tb',
         security: { acl: BucketAccessEnum.PUBLIC_READ, force_delete: false },
-        website: { code: './d', index: 'i.html', error_page: '404.html', error_code: 404 },
+        website: { code: './d', index: 'i.html' },
         domain: { domain_name: 'x.com', accelerate: true, www_bind_apex: false },
       };
       await createBucketResource(mockContext, b, initialState);
@@ -1911,8 +1901,7 @@ describe('OssResource', () => {
         website: {
           code: './d',
           index: 'i.html',
-          error_page: '404.html',
-          error_code: 404,
+
           domain: 'x.com',
         },
       };
@@ -1925,7 +1914,7 @@ describe('OssResource', () => {
         key: 'b',
         name: 'tb',
         security: { acl: BucketAccessEnum.PUBLIC_READ, force_delete: false },
-        website: { code: './d', index: 'i.html', error_page: '404.html', error_code: 404 },
+        website: { code: './d', index: 'i.html' },
         domain: { domain_name: 'example.com', cdn: true, www_bind_apex: true },
       };
       await createBucketResource(mockContext, b, initialState);
@@ -2300,8 +2289,7 @@ describe('OssResource', () => {
           website: {
             code: './dist',
             index: 'i.html',
-            error_page: '404.html',
-            error_code: 404,
+
             domain: 'x.c',
           },
         } as BucketDomain,

--- a/tests/unit/stack/aliyunStack/ossTypes.test.ts
+++ b/tests/unit/stack/aliyunStack/ossTypes.test.ts
@@ -61,8 +61,6 @@ describe('OssTypes', () => {
         website: {
           index: 'index.html',
           code: 'dist',
-          error_page: '404.html',
-          error_code: 404,
         },
       };
 
@@ -71,7 +69,7 @@ describe('OssTypes', () => {
       expect(result.bucketName).toBe('test-bucket');
       expect(result.websiteConfig).toEqual({
         indexDocument: 'index.html',
-        errorDocument: '404.html',
+        errorDocument: 'index.html',
       });
     });
 
@@ -86,8 +84,6 @@ describe('OssTypes', () => {
         website: {
           index: 'index.html',
           code: 'dist',
-          error_page: '404.html',
-          error_code: 404,
         },
       };
 
@@ -97,7 +93,7 @@ describe('OssTypes', () => {
       expect(result.acl).toBe(BucketACL.PUBLIC_READ);
       expect(result.websiteConfig).toEqual({
         indexDocument: 'index.html',
-        errorDocument: '404.html',
+        errorDocument: 'index.html',
       });
     });
 
@@ -123,8 +119,7 @@ describe('OssTypes', () => {
         website: {
           index: 'index.html',
           code: 'dist',
-          error_page: '404.html',
-          error_code: 404,
+
           domain: 'www.example.com',
         },
       };

--- a/tests/unit/stack/localStack/bucket.test.ts
+++ b/tests/unit/stack/localStack/bucket.test.ts
@@ -44,8 +44,6 @@ describe('bucketsHandler', () => {
     website: {
       code: 'tests/fixtures/test-bucket',
       index: 'index.html',
-      error_page: '404.html',
-      error_code: 404,
     },
   };
 

--- a/tests/unit/stack/scfStack/cosResource.test.ts
+++ b/tests/unit/stack/scfStack/cosResource.test.ts
@@ -116,8 +116,6 @@ describe('CosResource', () => {
         website: {
           index: 'index.html',
           code: './dist',
-          error_page: 'error.html',
-          error_code: 404,
         },
       };
 
@@ -151,8 +149,7 @@ describe('CosResource', () => {
         website: {
           index: 'index.html',
           code: './dist',
-          error_page: 'error.html',
-          error_code: 404,
+
           domain: 'cdn.example.com',
           domain_certificate_body: 'CERT-BODY',
           domain_certificate_private_key: 'CERT-KEY',
@@ -192,8 +189,6 @@ describe('CosResource', () => {
           index: 'index.html',
           domain: 'cdn.example.com',
           code: './dist',
-          error_page: 'error.html',
-          error_code: 404,
         },
       };
 
@@ -219,8 +214,7 @@ describe('CosResource', () => {
         website: {
           index: 'index.html',
           code: './dist',
-          error_page: 'error.html',
-          error_code: 404,
+
           domain: 'cdn.example.com',
           domain_certificate_body: 'CERT-BODY',
           domain_certificate_private_key: 'CERT-KEY',
@@ -252,8 +246,7 @@ describe('CosResource', () => {
         website: {
           index: 'index.html',
           code: './dist',
-          error_page: 'error.html',
-          error_code: 404,
+
           domain: 'cdn.example.com',
           domain_certificate_id: 'existing-cert-12345',
         },
@@ -296,8 +289,6 @@ describe('CosResource', () => {
           domain_certificate_body: 'CERT-BODY',
           domain_certificate_private_key: 'CERT-KEY',
           code: './dist',
-          error_page: 'error.html',
-          error_code: 404,
         },
       };
 
@@ -334,8 +325,6 @@ describe('CosResource', () => {
           domain: 'cdn.example.com',
           domain_certificate_id: 'existing-cert-99999',
           code: './dist',
-          error_page: 'error.html',
-          error_code: 404,
         },
       };
 
@@ -362,8 +351,6 @@ describe('CosResource', () => {
           index: 'index.html',
           domain: 'cdn.example.com',
           code: './dist',
-          error_page: 'error.html',
-          error_code: 404,
         },
       };
 
@@ -820,8 +807,6 @@ describe('CosResource', () => {
             website: {
               index: 'index.html',
               code: './dist',
-              error_page: 'error.html',
-              error_code: 404,
             },
           },
           initialState,
@@ -846,8 +831,7 @@ describe('CosResource', () => {
           website: {
             index: 'index.html',
             code: './dist',
-            error_page: 'error.html',
-            error_code: 404,
+
             domain: 'example.com',
             www_bind_apex: true,
           },
@@ -893,8 +877,7 @@ describe('CosResource', () => {
           website: {
             index: 'index.html',
             code: './dist',
-            error_page: 'error.html',
-            error_code: 404,
+
             domain: 'example.com',
             www_bind_apex: true,
             domain_certificate_body: 'CERT-BODY',
@@ -947,8 +930,7 @@ describe('CosResource', () => {
           website: {
             index: 'index.html',
             code: './dist',
-            error_page: 'error.html',
-            error_code: 404,
+
             domain: 'example.com',
             www_bind_apex: true,
             domain_certificate_body: 'CERT-BODY',
@@ -985,8 +967,7 @@ describe('CosResource', () => {
           website: {
             index: 'index.html',
             code: './dist',
-            error_page: 'error.html',
-            error_code: 404,
+
             domain: 'example.com',
             www_bind_apex: true,
           },
@@ -1016,8 +997,7 @@ describe('CosResource', () => {
           website: {
             index: 'index.html',
             code: './dist',
-            error_page: 'error.html',
-            error_code: 404,
+
             domain: 'cdn.example.com',
           },
         },
@@ -1046,8 +1026,7 @@ describe('CosResource', () => {
           website: {
             index: 'index.html',
             code: './dist',
-            error_page: 'error.html',
-            error_code: 404,
+
             domain: 'cdn.example.com',
           },
         },
@@ -1071,8 +1050,7 @@ describe('CosResource', () => {
           website: {
             index: 'index.html',
             code: './dist',
-            error_page: 'error.html',
-            error_code: 404,
+
             domain: 'cdn.example.com',
           },
         },
@@ -1131,8 +1109,6 @@ describe('CosResource', () => {
             website: {
               index: 'index.html',
               code: './dist',
-              error_page: 'error.html',
-              error_code: 404,
             },
           },
           initialState,
@@ -1157,8 +1133,7 @@ describe('CosResource', () => {
           website: {
             index: 'index.html',
             code: './dist',
-            error_page: 'error.html',
-            error_code: 404,
+
             domain: 'new.example.com',
           },
         },
@@ -1199,8 +1174,7 @@ describe('CosResource', () => {
           website: {
             index: 'index.html',
             code: './dist',
-            error_page: 'error.html',
-            error_code: 404,
+
             domain: 'example.com',
             www_bind_apex: true,
             domain_certificate_id: 'cert-ref-123',
@@ -1269,8 +1243,7 @@ describe('CosResource', () => {
           website: {
             index: 'index.html',
             code: './dist',
-            error_page: 'error.html',
-            error_code: 404,
+
             domain: 'example.com',
             www_bind_apex: false,
           },
@@ -1297,8 +1270,6 @@ describe('CosResource', () => {
           website: {
             index: 'index.html',
             code: './dist',
-            error_page: 'error.html',
-            error_code: 404,
           },
         },
         stateWithDomain,
@@ -1329,8 +1300,7 @@ describe('CosResource', () => {
           website: {
             index: 'index.html',
             code: './dist',
-            error_page: 'error.html',
-            error_code: 404,
+
             domain: 'cdn.example.com',
           },
         },
@@ -1375,8 +1345,7 @@ describe('CosResource', () => {
           website: {
             index: 'index.html',
             code: './dist',
-            error_page: 'error.html',
-            error_code: 404,
+
             domain_certificate_body: 'CERT-BODY',
             domain_certificate_private_key: 'CERT-KEY',
           },
@@ -1403,8 +1372,7 @@ describe('CosResource', () => {
           website: {
             index: 'index.html',
             code: './dist',
-            error_page: 'error.html',
-            error_code: 404,
+
             domain_certificate_id: 'cert-id-999',
           },
         },

--- a/tests/unit/stack/scfStack/cosTypes.test.ts
+++ b/tests/unit/stack/scfStack/cosTypes.test.ts
@@ -66,8 +66,6 @@ describe('CosTypes', () => {
         website: {
           index: 'index.html',
           code: 'dist',
-          error_page: '404.html',
-          error_code: 404,
         },
       };
 
@@ -81,7 +79,7 @@ describe('CosTypes', () => {
             Suffix: 'index.html',
           },
           ErrorDocument: {
-            Key: '404.html',
+            Key: 'index.html',
           },
         },
       });
@@ -98,8 +96,6 @@ describe('CosTypes', () => {
         website: {
           index: 'index.html',
           code: 'dist',
-          error_page: '404.html',
-          error_code: 404,
         },
       };
 
@@ -114,7 +110,7 @@ describe('CosTypes', () => {
             Suffix: 'index.html',
           },
           ErrorDocument: {
-            Key: '404.html',
+            Key: 'index.html',
           },
         },
       });

--- a/tests/unit/stack/volcengineStack/tosPlanner.test.ts
+++ b/tests/unit/stack/volcengineStack/tosPlanner.test.ts
@@ -88,8 +88,6 @@ describe('tosPlanner', () => {
           website: {
             index: 'index.html',
             code: './dist',
-            error_page: '404.html',
-            error_code: 404,
           },
         },
       ];
@@ -291,8 +289,6 @@ describe('tosPlanner', () => {
           website: {
             index: 'index.html',
             code: './non-existent-dir',
-            error_page: '404.html',
-            error_code: 404,
           },
         },
       ];

--- a/tests/unit/stack/volcengineStack/tosResource.test.ts
+++ b/tests/unit/stack/volcengineStack/tosResource.test.ts
@@ -153,8 +153,6 @@ describe('tosResource', () => {
         website: {
           index: 'index.html',
           code: './dist',
-          error_page: '404.html',
-          error_code: 404,
         },
       };
 
@@ -181,8 +179,6 @@ describe('tosResource', () => {
         website: {
           index: 'index.html',
           code: './dist',
-          error_page: '404.html',
-          error_code: 404,
         },
       };
 
@@ -226,8 +222,6 @@ describe('tosResource', () => {
         website: {
           index: 'index.html',
           code: './dist',
-          error_page: '404.html',
-          error_code: 404,
         },
       };
 


### PR DESCRIPTION
## Description

Fixes #196 

When deploying a static website with multi-language locales (e.g., `zh/` subdirectory), OSS serves root `index.html` instead of `zh/index.html`. The language switcher breaks.

## Root cause

The `PutBucketWebsite` OSS API has a `SupportSubDir` parameter that defaults to `false`. The SI tool never passed it, so all subdirectory paths fall back to root index.

## Changes

### Source changes

1. **types + schema + parser**: Removed `error_page` and `error_code` fields from `BucketRaw` and `BucketDomain` types, schema validation, and parser. These fields are no longer user-configurable.

2. **ossOperations.ts**: Added type augmentation for `PutBucketWebsiteConfig` to include `supportSubDir` and `type` fields. These were already being passed to `putBucketWebsite` but the type definitions didn't include them.

3. **ossTypes.ts**: `bucketToOssBucketConfig` now always sets `errorDocument = bucket.website.index` instead of conditionally using `error_page`.

4. **cosTypes.ts**: `bucketToCosBucketConfig` now always sets `ErrorDocument.Key = bucket.website.index` instead of conditionally using `error_page`.

5. **tosTypes.ts**: `bucketToTosConfig` now always sets `errorDocument = bucket.website.index` instead of conditionally using `error_page`.

### Test/fixture/sample changes

All 18 test files, fixtures, and samples updated to remove `error_page`/`error_code` references and reflect the new `errorDocument = indexDocument` behavior.

## Verification

- ✅ 128 test suites, 2219 tests passing
- ✅ Lint — zero errors  
- ✅ Build — clean
- ✅ Coverage — 94.31% Stmts, 86.11% Branches, 93.43% Funcs, 94.55% Lines