### PR TITLE
fix: PASSTHROUGH mode support for non-JSON responses in local stack

### DIFF
--- a/src/stack/localStack/aliyunFc.ts
+++ b/src/stack/localStack/aliyunFc.ts
@@ -158,11 +158,27 @@ export const transformFCResponse = (
       body = Buffer.from(body, 'base64').toString('utf-8');
     }
 
+    // Only JSON-parse if the response Content-Type indicates JSON — otherwise pass through as-is.
+    // Aliyun API Gateway PASSTHROUGH mode sends raw body; si-local mirrors this behavior.
     if (typeof body === 'string') {
-      try {
-        body = JSON.parse(body);
-      } catch {
-        // If parsing fails, keep as string
+      const contentType =
+        typeof headers === 'object' && headers
+          ? (Object.values(headers).find(
+              (v) => typeof v === 'string' && v.toLowerCase().includes('application/json'),
+            ) ??
+            Object.keys(headers).find(
+              (k) =>
+                k.toLowerCase() === 'content-type' &&
+                typeof headers[k] === 'string' &&
+                headers[k].toLowerCase().includes('application/json'),
+            ))
+          : undefined;
+      if (contentType || /^\s*[{[]/.test(body)) {
+        try {
+          body = JSON.parse(body);
+        } catch {
+          // keep as string
+        }
       }
     }
 

--- a/src/stack/localStack/localServer.ts
+++ b/src/stack/localStack/localServer.ts
@@ -87,15 +87,10 @@ export const servLocal = async (
         return;
       }
 
-      // Raw responses (e.g., from bucket handler) include both Content-Type and Content-Length headers
-      // and the body is already formatted as a string (not a JSON object)
-      const isRawResponse =
-        typeof outcome.body === 'string' &&
-        outcome.headers?.['Content-Type'] &&
-        outcome.headers?.['Content-Length'];
-
-      if (isRawResponse) {
-        respondRaw(res, outcome.statusCode, outcome.body as string, outcome.headers);
+      // Cloud API Gateway in PASSTHROUGH mode passes through all responses as-is.
+      // Si-local mirrors this by always using respondRaw for function responses.
+      if (typeof outcome.body === 'string' || Buffer.isBuffer(outcome.body)) {
+        respondRaw(res, outcome.statusCode, outcome.body, outcome.headers);
       } else {
         respondJson(res, outcome.statusCode, outcome.body ?? {}, outcome.headers);
       }

--- a/tests/fixtures/aliyun-fc-handler-html/index.js
+++ b/tests/fixtures/aliyun-fc-handler-html/index.js
@@ -1,0 +1,39 @@
+// Aliyun FC handler that returns HTML (simulating static content serving)
+module.exports.handler = function (event, context, callback) {
+  var eventData = JSON.parse(event.toString());
+  context.logger.info('Serving HTML for ' + eventData.path);
+
+  var html =
+    '<!DOCTYPE html>\n' +
+    '<html lang="en">\n' +
+    '<head><meta charset="utf-8"><title>Test Page</title></head>\n' +
+    '<body><h1>Hello from HTML handler</h1></body>\n' +
+    '</html>';
+
+  var response = {
+    isBase64Encoded: false,
+    statusCode: 200,
+    headers: {
+      'Content-Type': 'text/html; charset=utf-8',
+    },
+    body: html,
+  };
+
+  callback(null, response);
+};
+
+// Handler that returns CSS for verifying non-JSON static content
+module.exports.css = function (event, context, callback) {
+  var css = 'body { margin: 0; padding: 0; color: #333; }';
+
+  var response = {
+    isBase64Encoded: false,
+    statusCode: 200,
+    headers: {
+      'Content-Type': 'text/css',
+    },
+    body: css,
+  };
+
+  callback(null, response);
+};

--- a/tests/unit/stack/localStack/aliyunFc.test.ts
+++ b/tests/unit/stack/localStack/aliyunFc.test.ts
@@ -118,3 +118,115 @@ describe('Aliyun FC LocalStack', () => {
     expect(body.queryParameters).toEqual({ param: 'value' });
   });
 });
+
+describe('Aliyun FC LocalStack - HTML serving', () => {
+  const iac: ServerlessIac = {
+    app: 'html-serving-app',
+    version: '0.0.1',
+    service: 'html-serving-test',
+    provider: {
+      name: ProviderEnum.ALIYUN,
+      region: 'cn-hangzhou',
+    },
+    functions: [
+      {
+        key: 'html_fn',
+        name: 'html-serving-function',
+        code: {
+          runtime: 'nodejs18',
+          handler: 'index.handler',
+          path: 'tests/fixtures/aliyun-fc-handler-html',
+        },
+        memory: 512,
+        timeout: 10,
+        environment: {},
+        storage: {},
+      },
+      {
+        key: 'css_fn',
+        name: 'css-serving-function',
+        code: {
+          runtime: 'nodejs18',
+          handler: 'index.css',
+          path: 'tests/fixtures/aliyun-fc-handler-html',
+        },
+        memory: 512,
+        timeout: 10,
+        environment: {},
+        storage: {},
+      },
+    ],
+    events: [
+      {
+        key: 'static_gateway',
+        name: 'static-api-gateway',
+        type: EventTypes.API_GATEWAY,
+        triggers: [
+          {
+            method: 'GET',
+            path: '/map/map.html',
+            backend: 'html_fn',
+          },
+          {
+            method: 'GET',
+            path: '/static/style.css',
+            backend: 'css_fn',
+          },
+        ],
+      },
+    ],
+  };
+
+  beforeAll(async () => {
+    // Stop previous LocalStack if running
+    await stopLocal().catch(() => {});
+    await startLocalStack(iac);
+    await new Promise((resolve) => setTimeout(resolve, 1500));
+  });
+
+  afterAll(async () => {
+    await stopLocal();
+  });
+
+  it('should serve HTML response with correct Content-Type', async () => {
+    const res = await makeRequest(
+      `http://localhost:${SI_LOCALSTACK_SERVER_PORT}/si_events/static_gateway/map/map.html`,
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['content-type']).toBe('text/html; charset=utf-8');
+    expect(res.data.startsWith('<!DOCTYPE html>')).toBe(true);
+    expect(res.data).toContain('<h1>Hello from HTML handler</h1>');
+  });
+
+  it('should NOT wrap HTML body in JSON', async () => {
+    const res = await makeRequest(
+      `http://localhost:${SI_LOCALSTACK_SERVER_PORT}/si_events/static_gateway/map/map.html`,
+    );
+
+    expect(res.data.charAt(0)).toBe('<');
+    expect(res.data.charAt(0)).not.toBe('"');
+    expect(res.data.charAt(0)).not.toBe('{');
+  });
+
+  it('should serve CSS response with correct Content-Type', async () => {
+    const res = await makeRequest(
+      `http://localhost:${SI_LOCALSTACK_SERVER_PORT}/si_events/static_gateway/static/style.css`,
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['content-type']).toBe('text/css');
+    expect(res.data).toContain('body { margin: 0');
+    expect(res.data).not.toContain('"body');
+  });
+
+  it('should serve HTML via direct function invocation', async () => {
+    const res = await makeRequest(
+      `http://localhost:${SI_LOCALSTACK_SERVER_PORT}/si_functions/html_fn/any-path`,
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['content-type']).toBe('text/html; charset=utf-8');
+    expect(res.data).toContain('<!DOCTYPE html>');
+  });
+});

--- a/tests/unit/stack/localStack/aliyunFc.unit.test.ts
+++ b/tests/unit/stack/localStack/aliyunFc.unit.test.ts
@@ -370,6 +370,128 @@ describe('Aliyun FC Utilities', () => {
 
       expect(result.statusCode).toBe(200);
     });
+
+    it('should pass through HTML body unchanged when Content-Type is text/html', () => {
+      const fcResponse = {
+        statusCode: 200,
+        body: '<!DOCTYPE html><html><body>Hello</body></html>',
+        headers: { 'Content-Type': 'text/html; charset=utf-8' },
+      };
+
+      const result = transformFCResponse(fcResponse);
+
+      expect(result.body).toBe('<!DOCTYPE html><html><body>Hello</body></html>');
+      expect(typeof result.body).toBe('string');
+      expect(result.statusCode).toBe(200);
+      expect(result.headers['Content-Type']).toBe('text/html; charset=utf-8');
+    });
+
+    it('should pass through HTML body when Content-Type is text/html (lowercase)', () => {
+      const fcResponse = {
+        statusCode: 200,
+        body: '<html></html>',
+        headers: { 'content-type': 'text/html' },
+      };
+
+      const result = transformFCResponse(fcResponse);
+
+      expect(result.body).toBe('<html></html>');
+      expect(typeof result.body).toBe('string');
+    });
+
+    it('should pass through plain text body when Content-Type is text/plain', () => {
+      const fcResponse = {
+        statusCode: 200,
+        body: 'Hello, this is plain text',
+        headers: { 'Content-Type': 'text/plain' },
+      };
+
+      const result = transformFCResponse(fcResponse);
+
+      expect(result.body).toBe('Hello, this is plain text');
+      expect(typeof result.body).toBe('string');
+    });
+
+    it('should pass through CSS body unchanged', () => {
+      const fcResponse = {
+        statusCode: 200,
+        body: 'body { color: red; }',
+        headers: { 'Content-Type': 'text/css' },
+      };
+
+      const result = transformFCResponse(fcResponse);
+
+      expect(result.body).toBe('body { color: red; }');
+      expect(typeof result.body).toBe('string');
+    });
+
+    it('should pass through PNG binary (base64 decoded) body unchanged', () => {
+      const pngData = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+      const base64Png = pngData.toString('base64');
+
+      const fcResponse = {
+        statusCode: 200,
+        body: base64Png,
+        headers: { 'Content-Type': 'image/png' },
+        isBase64Encoded: true,
+      };
+
+      const result = transformFCResponse(fcResponse);
+
+      expect(result.body).not.toBe(base64Png);
+      expect(Buffer.isBuffer(result.body)).toBe(false);
+      expect(result.headers['Content-Type']).toBe('image/png');
+    });
+
+    it('should still JSON-parse body when Content-Type is application/json', () => {
+      const fcResponse = {
+        statusCode: 200,
+        body: '{"key":"value"}',
+        headers: { 'Content-Type': 'application/json' },
+      };
+
+      const result = transformFCResponse(fcResponse);
+
+      expect(result.body).toEqual({ key: 'value' });
+    });
+
+    it('should JSON-parse body that looks like JSON (starts with {) even without Content-Type header', () => {
+      const fcResponse = {
+        statusCode: 200,
+        body: '{"data": "test"}',
+        headers: {},
+      };
+
+      const result = transformFCResponse(fcResponse);
+
+      expect(result.body).toEqual({ data: 'test' });
+    });
+
+    it('should pass through body that is not JSON-like and has no Content-Type', () => {
+      const fcResponse = {
+        statusCode: 200,
+        body: 'just some string data',
+        headers: {},
+      };
+
+      const result = transformFCResponse(fcResponse);
+
+      expect(result.body).toBe('just some string data');
+      expect(typeof result.body).toBe('string');
+    });
+
+    it('should pass through JavaScript body unchanged', () => {
+      const fcResponse = {
+        statusCode: 200,
+        body: "console.log('hello');",
+        headers: { 'Content-Type': 'application/javascript' },
+      };
+
+      const result = transformFCResponse(fcResponse);
+
+      expect(result.body).toBe("console.log('hello');");
+      expect(typeof result.body).toBe('string');
+    });
   });
 
   describe('logApiGatewayRequest', () => {

--- a/tests/unit/stack/localStack/index.test.ts
+++ b/tests/unit/stack/localStack/index.test.ts
@@ -44,7 +44,7 @@ describe('localStack Server', () => {
     }
 
     expect(response!.statusCode).toBe(200);
-    expect(response!.data).toBe('"ServerlessInsight Hello World"');
+    expect(response!.data).toBe('ServerlessInsight Hello World');
   });
 
   it('should return 404 for non-matching path', async () => {

--- a/tests/unit/stack/localStack/localServer.test.ts
+++ b/tests/unit/stack/localStack/localServer.test.ts
@@ -4,16 +4,25 @@ import { RouteHandler, RouteKind } from '../../../../src/types/localStack';
 import { ServerlessIac } from '../../../../src/types';
 import { makeRequest } from '../../../autils';
 
+const htmlRoute: RouteKind = 'SI_BUCKETS' as RouteKind;
+
 describe('localServer routing', () => {
+  const jsonHandler: RouteHandler = async () => ({
+    statusCode: 200,
+    body: { ok: true },
+  });
+
+  const htmlHandler: RouteHandler = async () => ({
+    statusCode: 200,
+    headers: { 'Content-Type': 'text/html; charset=utf-8' },
+    body: '<!DOCTYPE html><html><body><h1>Hello</h1></body></html>',
+  });
+
   const handlers: Array<{ kind: RouteKind; handler: RouteHandler }> = [
-    {
-      kind: RouteKind.SI_FUNCTIONS,
-      handler: async () => ({
-        statusCode: 200,
-        body: { ok: true },
-      }),
-    },
+    { kind: RouteKind.SI_FUNCTIONS, handler: jsonHandler },
+    { kind: htmlRoute, handler: htmlHandler },
   ];
+
   const iac = {
     service: 'test',
     version: '0.0.1',
@@ -28,18 +37,45 @@ describe('localServer routing', () => {
     await stopLocal();
   });
 
-  it('returns 200 when handler registered', async () => {
-    const res = await makeRequest(`http://localhost:${SI_LOCALSTACK_SERVER_PORT}/si_functions/`);
+  describe('JSON responses', () => {
+    it('returns 200 when handler registered', async () => {
+      const res = await makeRequest(`http://localhost:${SI_LOCALSTACK_SERVER_PORT}/si_functions/`);
 
-    expect(res.statusCode).toBe(200);
-    expect(res.data).toContain('ok');
+      expect(res.statusCode).toBe(200);
+      expect(res.data).toContain('ok');
+    });
+
+    it('returns 404 for unknown route', async () => {
+      const res = await makeRequest(
+        `http://localhost:${SI_LOCALSTACK_SERVER_PORT}/unknown_route/path`,
+      );
+
+      expect(res.statusCode).toBe(404);
+    });
   });
 
-  it('returns 404 for unknown route', async () => {
-    const res = await makeRequest(
-      `http://localhost:${SI_LOCALSTACK_SERVER_PORT}/unknown_route/path`,
-    );
+  describe('Raw HTML responses', () => {
+    it('should pass through raw HTML without JSON wrapping', async () => {
+      const res = await makeRequest(`http://localhost:${SI_LOCALSTACK_SERVER_PORT}/si_buckets/`);
 
-    expect(res.statusCode).toBe(404);
+      expect(res.statusCode).toBe(200);
+      expect(res.headers['content-type']).toBe('text/html; charset=utf-8');
+      expect(res.data).toBe('<!DOCTYPE html><html><body><h1>Hello</h1></body></html>');
+    });
+
+    it('should send HTML as text/html, not application/json', async () => {
+      const res = await makeRequest(`http://localhost:${SI_LOCALSTACK_SERVER_PORT}/si_buckets/`);
+
+      expect(res.headers['content-type']).toBe('text/html; charset=utf-8');
+      expect(res.data.startsWith('<!DOCTYPE html>')).toBe(true);
+    });
+
+    it('should not wrap HTML body in JSON string quotes', async () => {
+      const res = await makeRequest(`http://localhost:${SI_LOCALSTACK_SERVER_PORT}/si_buckets/`);
+
+      expect(res.data.charAt(0)).toBe('<');
+      expect(res.data.charAt(0)).not.toBe('"');
+      expect(res.data.charAt(0)).not.toBe('{');
+    });
   });
 });


### PR DESCRIPTION
## Summary

Fixes the local development server to properly handle non-JSON responses (HTML, CSS, JavaScript, etc.) by mirroring Aliyun API Gateway PASSTHROUGH mode behavior. Previously, all function responses were JSON-wrapped regardless of Content-Type, breaking static content serving during local development.

## Changes

### fix(transformFCResponse): skip JSON parse for non-JSON Content-Type responses
`src/stack/localStack/aliyunFc.ts`, `tests/unit/stack/localStack/aliyunFc.unit.test.ts`

- Checks response Content-Type header before attempting JSON parse
- Passes through HTML/CSS/JS/plaintext bodies as strings
- Falls back to heuristic (body starts with `{` or `[`) when no Content-Type
- Adds 8 new unit tests for various Content-Type scenarios

### fix(localServer): always use respondRaw for string/buffer responses
`src/stack/localStack/localServer.ts`, `tests/unit/stack/localStack/localServer.test.ts`, `tests/unit/stack/localStack/index.test.ts`

- Routes all string/buffer responses through `respondRaw` instead of checking for Content-Type + Content-Length headers only
- Adds server-level tests verifying HTML passthrough without JSON wrapping

### test: add integration tests for HTML passthrough in local stack
`tests/unit/stack/localStack/aliyunFc.test.ts`, `tests/fixtures/aliyun-fc-handler-html/`

- Full end-to-end tests: HTML page serving, CSS serving, direct function invocation
- Fixture handlers returning `text/html` and `text/css` Content-Type responses

## Testing

- ✅ Unit tests for `transformFCResponse` with various Content-Types
- ✅ Server routing tests for raw vs JSON response paths
- ✅ Integration tests through the full local stack server
- ✅ All existing tests pass