### PR TITLE
fix(apigw): skip domain binding when config unchanged to avoid DNS delay

### DIFF
--- a/src/stack/aliyunStack/apigwResource.ts
+++ b/src/stack/aliyunStack/apigwResource.ts
@@ -24,6 +24,7 @@ import { readPemContent, warnInlinePem } from '../../common/certUtils';
 import { logger } from '../../common/logger';
 import { lang } from '../../lang';
 import { deriveWwwDomain, extractHostRecord, extractMainDomain } from '../../common/domainUtils';
+import { attributesEqual } from '../../common/hashUtils';
 
 type ApigwCdnInstance = ResourceInstance & {
   type: 'ALIYUN_CDN_DISTRIBUTION';
@@ -869,15 +870,49 @@ export const updateApigwResource = async (
   }
 
   if (event.domain) {
+    const desiredDomainDef = extractEventDomainDefinition(event.domain);
+    const previousDomainDef = existingState?.definition?.domain as
+      Record<string, unknown> | null | undefined;
+
+    // Skip domain binding when the domain configuration hasn't changed AND
+    // the domain was previously successfully bound (DNS records exist in state).
+    // This avoids unnecessary DNS verification (minutes-long) on every deploy.
+    // We check DNS sub-resources to avoid skipping after a previously failed binding.
+    const hasBoundDomains =
+      getResource(state, `${logicalId}.dns_verification`) !== undefined ||
+      getResource(state, `${logicalId}.dns_txt_verification`) !== undefined;
+    if (
+      previousDomainDef &&
+      desiredDomainDef &&
+      hasBoundDomains &&
+      attributesEqual(previousDomainDef, desiredDomainDef as Record<string, unknown>)
+    ) {
+      logger.info('Domain configuration unchanged and previously bound, skipping DNS verification');
+      // Still include existing domain instances for state consistency
+      const existingDomainInstances =
+        existingState?.instances?.filter(
+          (i) =>
+            i.type === 'ALIYUN_APIGW_GROUP' ||
+            i.type === 'ALIYUN_APIGW_API' ||
+            i.type === 'ALIYUN_APIGW_DEPLOYMENT',
+        ) ?? [];
+      instances.push(...existingDomainInstances);
+      return setResource(state, logicalId, {
+        mode: 'managed',
+        region: context.region,
+        definition: { ...(existingState?.definition ?? {}), domain: desiredDomainDef },
+        instances: [...instances, ...existingDomainInstances],
+        lastUpdated: new Date().toISOString(),
+      });
+    }
+
     const primaryDomain = event.domain.domain_name as string;
     const wwwBindApex = event.domain.www_bind_apex === true;
     const wwwDomain = wwwBindApex ? deriveWwwDomain(primaryDomain) : null;
     const isCdnEnabled = getIsCdnEnabled(event);
-    const existingDomain = existingState?.definition?.domain as
-      Record<string, unknown> | null | undefined;
-    const previousWwwBindApex = existingDomain?.wwwBindApex === true;
-    const previousDomainName = existingDomain?.domainName as string | null | undefined;
-    const previousCdnEnabled = existingDomain?.cdnEnabled === true;
+    const previousWwwBindApex = previousDomainDef?.wwwBindApex === true;
+    const previousDomainName = previousDomainDef?.domainName as string | null | undefined;
+    const previousCdnEnabled = previousDomainDef?.cdnEnabled === true;
     const previousTrackedDomains = getApigwTrackedDomains(previousDomainName, previousWwwBindApex);
     const originDomain = groupInfo.subDomain;
 


### PR DESCRIPTION
## Problem

`updateApigwResource` always runs the full domain binding flow during every update, including DNS verification (10+ attempts × 1 min each). This adds 10-15 minutes to every deployment even when the domain configuration hasn't changed.

## Solution

Compare the desired domain definition with the previous state's domain definition using `attributesEqual`. If identical, skip the entire domain binding block.

```typescript
const desiredDomainDef = extractEventDomainDefinition(event.domain);
const previousDomainDef = existingState?.definition?.domain;
if (previousDomainDef && desiredDomainDef && attributesEqual(...)) {
  // skip binding
}
```

## Effect

| Scenario | Before | After |
|----------|--------|-------|
| First deploy (no state) | ~15 min (DNS verify) | ~15 min (same) |
| Subsequent deploy (domain unchanged) | ~15 min (DNS verify) | ~1 sec (skip) |
| Domain config changed | ~15 min (DNS verify) | ~15 min (same) |

## Related

Ref: #206 (unified planner-driven diff tracking)