### PR TITLE
fix(apigw): use domain-specific DNS state keys to prevent www domain collision

### DIFF
--- a/src/common/aliyunClient/apigwOperations.ts
+++ b/src/common/aliyunClient/apigwOperations.ts
@@ -294,7 +294,9 @@ export const createApigwOperations = (
     // For CNAME verification: point the domain directly to the group subdomain
     const verificationHost = domainName;
     const verificationValue = groupSubdomain;
-    const dnsResourceId = `${eventLogicalId}.dns_verification`;
+    // Use domain-specific key so primary and www don't collide
+    const domainKey = domainName.replace(/[^a-zA-Z0-9]/g, '_');
+    const dnsResourceId = `${eventLogicalId}.dns_verification.${domainKey}`;
 
     try {
       // Check if DNS record is tracked in state
@@ -435,7 +437,8 @@ export const createApigwOperations = (
   ): Promise<StateFile> => {
     const mainDomain = extractMainDomain(domainName);
     const txtRecord = buildTxtVerificationRecord(groupId, domainName, groupSubdomain, mainDomain);
-    const txtResourceId = `${eventLogicalId}.dns_txt_verification`;
+    const txtDomainKey = domainName.replace(/[^a-zA-Z0-9]/g, '_');
+    const txtResourceId = `${eventLogicalId}.dns_txt_verification.${txtDomainKey}`;
 
     logger.info(lang.__('APIGW_TXT_ADDING_RECORD', { rr: txtRecord.rr, value: txtRecord.value }));
 

--- a/src/stack/aliyunStack/apigwResource.ts
+++ b/src/stack/aliyunStack/apigwResource.ts
@@ -878,9 +878,17 @@ export const updateApigwResource = async (
     // the domain was previously successfully bound (DNS records exist in state).
     // This avoids unnecessary DNS verification (minutes-long) on every deploy.
     // We check DNS sub-resources to avoid skipping after a previously failed binding.
+    // Check for ANY DNS sub-resource — covers both primary and www domains.
+    // If any domain was previously bound, its DNS record exists in state.
     const hasBoundDomains =
       getResource(state, `${logicalId}.dns_verification`) !== undefined ||
-      getResource(state, `${logicalId}.dns_txt_verification`) !== undefined;
+      getResource(state, `${logicalId}.dns_txt_verification`) !== undefined ||
+      Object.keys(state.resources ?? {}).some(
+        (k) =>
+          k.startsWith(`${logicalId}.dns_`) &&
+          k !== `${logicalId}.dns_verification` &&
+          k !== `${logicalId}.dns_txt_verification`,
+      );
     if (
       previousDomainDef &&
       desiredDomainDef &&
@@ -1169,10 +1177,18 @@ const cleanupDnsRecords = async (
   state: StateFile,
 ): Promise<StateFile> => {
   const client = createAliyunClient(context);
-  const dnsResourceIds = [
+  // Backward-compatible: always check old-style fixed keys, then scan for
+  // domain-specific keys (primary + www + any) created by the new code.
+  const dnsResourceIds: string[] = [
     `${eventLogicalId}.dns_verification`,
     `${eventLogicalId}.dns_txt_verification`,
   ];
+  const dnsPrefix = `${eventLogicalId}.dns_`;
+  for (const key of Object.keys(state.resources ?? {})) {
+    if (key.startsWith(dnsPrefix) && !dnsResourceIds.includes(key)) {
+      dnsResourceIds.push(key);
+    }
+  }
 
   for (const dnsResourceId of dnsResourceIds) {
     const dnsState = getResource(state, dnsResourceId);


### PR DESCRIPTION
## Problem

When `www_bind_apex: true` is set, the www domain binding reuses the same `eventLogicalId` for DNS verification state keys. Both primary and www domains end up using `{eventLogicalId}.dns_verification`.

This causes the www domain's CNAME record to **never be created**: the code finds the primary domain's DNS state, assumes the CNAME already exists, skips creation, and tries to verify propagation for a non-existent record → fails after 10-minute timeout.

## Root Cause

`addDomainVerificationRecord` and `addTxtVerificationRecord` in `apigwOperations.ts` use:
```typescript
const dnsResourceId = `${eventLogicalId}.dns_verification`;
```

Both primary and www domains call `bindCustomDomain(wwwConfig, state, logicalId)` → `addDomainVerificationRecord(wwwDomain, ..., eventLogicalId)` with the **same** `eventLogicalId`.

## Fix

1. **Append a domain-derived suffix** to DNS state keys:
   - Before: `events.api_gateway.dns_verification`
   - After: `events.api_gateway.dns_verification.mycotrail-api_wentsen_com`
   - After: `events.api_gateway.dns_verification.www_mycotrail-api_wentsen_com`

2. **`cleanupDnsRecords`** scans for ANY `dns_*` keys under the event prefix (backward-compatible with old-format keys too)

3. **Domain skip check** (from PR #207) checks all DNS sub-resources, not just legacy keys

## Effect

| Scenario | Before | After |
|----------|--------|-------|
| www domain CNAME creation | ❌ Skipped (state collision) | ✅ Created independently |
| www domain binding | ❌ Always fails | ✅ Succeeds |
| DNS record cleanup | ✅ Both domains cleaned | ✅ Both domains cleaned |
| Backward compat (existing state) | — | ✅ Old-format keys still cleaned