### PR TITLE
chore: standardize README badges to flat style

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,11 +219,17 @@ More in the [samples](./samples) directory.
 ## Community
 
 <p align="center">
-  <a href="https://github.com/geek-fun/serverlessinsight/discussions"><img src="https://img.shields.io/badge/GitHub_Discussions-Join-181717&logo=github&logoColor=white" alt="GitHub Discussions" /></a>
+  <img src="https://www.geekfun.club/wechat-group.jpg" width="140" alt="WeChat Group">
+</p>
+
+<p align="center">
+  <a href="https://discord.gg/5NSUyPK2E"><img src="https://img.shields.io/badge/Discord-Join-5865F2?logo=discord&logoColor=white" alt="Discord" /></a>
   &nbsp;&nbsp;&nbsp;
-  <a href="https://github.com/geek-fun/serverlessinsight/issues"><img src="https://img.shields.io/badge/GitHub_Issues-Report-181717&logo=github&logoColor=white" alt="GitHub Issues" /></a>
+  <a href="https://x.com/geekfun_club"><img src="https://img.shields.io/badge/X-Follow-000000?logo=x&logoColor=white" alt="X / Twitter" /></a>
   &nbsp;&nbsp;&nbsp;
-  <a href="https://github.com/geek-fun"><img src="https://img.shields.io/badge/GitHub-Follow-181717&logo=github&logoColor=white" alt="GitHub" /></a>
+  <a href="https://www.youtube.com/@geekfun-club"><img src="https://img.shields.io/badge/YouTube-Subscribe-FF0000?logo=youtube&logoColor=white" alt="YouTube" /></a>
+  &nbsp;&nbsp;&nbsp;
+  <a href="https://github.com/geek-fun"><img src="https://img.shields.io/badge/GitHub-Follow-181717?logo=github&logoColor=white" alt="GitHub" /></a>
 </p>
 
 ## Contributing
@@ -233,7 +239,7 @@ Contributions welcome! Open an issue or pull request. See the [AGENTS.md](AGENTS
 ## Sponsor
 
 <p align="center">
-  <a href="https://github.com/sponsors/geek-fun"><img src="https://img.shields.io/badge/GitHub_Sponsors-%E2%9D%A4_Support-EA4AAA&logo=githubsponsors&logoColor=white" alt="GitHub Sponsors" /></a>
+  <a href="https://github.com/sponsors/geek-fun"><img src="https://img.shields.io/badge/GitHub_Sponsors-%E2%9D%A4_Support-EA4AAA?logo=githubsponsors&logoColor=white" alt="GitHub Sponsors" /></a>
 </p>
 
 ## Star History

--- a/README.md
+++ b/README.md
@@ -6,19 +6,19 @@
 
 **Open source. Multi-cloud. Infrastructure as Code.**
 
-[![Release](https://img.shields.io/github/v/release/geek-fun/serverlessinsight?color=orange&label=release&style=for-the-badge&logo=github)](https://github.com/geek-fun/serverlessinsight/releases)
-[![npm version](https://img.shields.io/npm/v/@geek-fun/serverlessinsight?color=orange&style=for-the-badge&logo=npm)](https://www.npmjs.com/package/@geek-fun/serverlessinsight)
-[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg?style=for-the-badge&logo=apache)](LICENSE)
-[![Stars](https://img.shields.io/github/stars/geek-fun/serverlessinsight?style=for-the-badge&logo=github)](https://github.com/geek-fun/serverlessinsight/stargazers)
-[![CI](https://github.com/geek-fun/serverlessinsight/actions/workflows/node.yml/badge.svg?style=for-the-badge)](https://github.com/geek-fun/serverlessinsight/actions/workflows/node.yml)
+[![Release](https://img.shields.io/github/v/release/geek-fun/serverlessinsight?color=orange&label=release&logo=github)](https://github.com/geek-fun/serverlessinsight/releases)
+[![npm version](https://img.shields.io/npm/v/@geek-fun/serverlessinsight?color=orange&logo=npm)](https://www.npmjs.com/package/@geek-fun/serverlessinsight)
+[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg&logo=apache)](LICENSE)
+[![Stars](https://img.shields.io/github/stars/geek-fun/serverlessinsight&logo=github)](https://github.com/geek-fun/serverlessinsight/stargazers)
+[![CI](https://github.com/geek-fun/serverlessinsight/actions/workflows/node.yml/badge.svg)](https://github.com/geek-fun/serverlessinsight/actions/workflows/node.yml)
 
 <p>
-  <img src="https://img.shields.io/badge/Node.js-339933?style=for-the-badge&logo=nodedotjs&logoColor=white"/>
-  <img src="https://img.shields.io/badge/TypeScript-3178C6?style=for-the-badge&logo=typescript&logoColor=white"/>
-  <img src="https://img.shields.io/badge/Alibaba%20Cloud-FF6A00?style=for-the-badge&logo=alibabacloud&logoColor=white"/>
-  <img src="https://img.shields.io/badge/Tencent%20Cloud-0A9AED?style=for-the-badge&logo=tencentqq&logoColor=white"/>
-  <img src="https://img.shields.io/badge/Huawei%20Cloud-FF0000?style=for-the-badge&logo=hauwei&logoColor=white"/>
-  <img src="https://img.shields.io/badge/AWS-232F3E?style=for-the-badge&logo=amazonwebservices&logoColor=white"/>
+  <img src="https://img.shields.io/badge/Node.js-339933&logo=nodedotjs&logoColor=white"/>
+  <img src="https://img.shields.io/badge/TypeScript-3178C6&logo=typescript&logoColor=white"/>
+  <img src="https://img.shields.io/badge/Alibaba%20Cloud-FF6A00&logo=alibabacloud&logoColor=white"/>
+  <img src="https://img.shields.io/badge/Tencent%20Cloud-0A9AED&logo=tencentqq&logoColor=white"/>
+  <img src="https://img.shields.io/badge/Huawei%20Cloud-FF0000&logo=hauwei&logoColor=white"/>
+  <img src="https://img.shields.io/badge/AWS-232F3E&logo=amazonwebservices&logoColor=white"/>
 </p>
 
 [npm i -g @geek-fun/serverlessinsight](https://www.npmjs.com/package/@geek-fun/serverlessinsight) · [Docs](https://serverlessinsight.geekfun.club) · [Website](https://serverlessinsight.geekfun.club) · [GitHub](https://github.com/geek-fun/serverlessinsight)
@@ -44,15 +44,15 @@ ServerlessInsight is a **cross-provider serverless framework** — it replaces c
 ## Installation
 
 <a href="https://www.npmjs.com/package/@geek-fun/serverlessinsight">
-  <img src="https://img.shields.io/badge/npm_install-g_--g_@geek--fun/serverlessinsight-CB3837?style=for-the-badge&logo=npm&logoColor=white" alt="npm install">
+  <img src="https://img.shields.io/badge/npm_install-g_--g_@geek--fun/serverlessinsight-CB3837&logo=npm&logoColor=white" alt="npm install">
 </a>
 &nbsp;
 <a href="https://github.com/geek-fun/serverlessinsight/releases">
-  <img src="https://img.shields.io/badge/Releases-GitHub-lightgrey?style=for-the-badge&logo=github" alt="Releases">
+  <img src="https://img.shields.io/badge/Releases-GitHub-lightgrey&logo=github" alt="Releases">
 </a>
 &nbsp;
 <a href="https://serverlessinsight.geekfun.club">
-  <img src="https://img.shields.io/badge/Docs-serverlessinsight.geekfun.club-blue?style=for-the-badge&logo=gitbook&logoColor=white" alt="Docs">
+  <img src="https://img.shields.io/badge/Docs-serverlessinsight.geekfun.club-blue&logo=gitbook&logoColor=white" alt="Docs">
 </a>
 
 ```bash
@@ -219,11 +219,11 @@ More in the [samples](./samples) directory.
 ## Community
 
 <p align="center">
-  <a href="https://github.com/geek-fun/serverlessinsight/discussions"><img src="https://img.shields.io/badge/GitHub_Discussions-Join-181717?style=for-the-badge&logo=github&logoColor=white" alt="GitHub Discussions" /></a>
+  <a href="https://github.com/geek-fun/serverlessinsight/discussions"><img src="https://img.shields.io/badge/GitHub_Discussions-Join-181717&logo=github&logoColor=white" alt="GitHub Discussions" /></a>
   &nbsp;&nbsp;&nbsp;
-  <a href="https://github.com/geek-fun/serverlessinsight/issues"><img src="https://img.shields.io/badge/GitHub_Issues-Report-181717?style=for-the-badge&logo=github&logoColor=white" alt="GitHub Issues" /></a>
+  <a href="https://github.com/geek-fun/serverlessinsight/issues"><img src="https://img.shields.io/badge/GitHub_Issues-Report-181717&logo=github&logoColor=white" alt="GitHub Issues" /></a>
   &nbsp;&nbsp;&nbsp;
-  <a href="https://github.com/geek-fun"><img src="https://img.shields.io/badge/GitHub-Follow-181717?style=for-the-badge&logo=github&logoColor=white" alt="GitHub" /></a>
+  <a href="https://github.com/geek-fun"><img src="https://img.shields.io/badge/GitHub-Follow-181717&logo=github&logoColor=white" alt="GitHub" /></a>
 </p>
 
 ## Contributing
@@ -233,7 +233,7 @@ Contributions welcome! Open an issue or pull request. See the [AGENTS.md](AGENTS
 ## Sponsor
 
 <p align="center">
-  <a href="https://github.com/sponsors/geek-fun"><img src="https://img.shields.io/badge/GitHub_Sponsors-%E2%9D%A4_Support-EA4AAA?style=for-the-badge&logo=githubsponsors&logoColor=white" alt="GitHub Sponsors" /></a>
+  <a href="https://github.com/sponsors/geek-fun"><img src="https://img.shields.io/badge/GitHub_Sponsors-%E2%9D%A4_Support-EA4AAA&logo=githubsponsors&logoColor=white" alt="GitHub Sponsors" /></a>
 </p>
 
 ## Star History

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -341,12 +341,25 @@ ServerlessInsight 使用基于状态的部署模型，在本地状态文件 (`.s
 
 ## 👥 社区
 
-加入我们的社区以获取帮助、分享想法和贡献：
+<p align="center">
+  <img src="https://www.geekfun.club/wechat-group.jpg" width="140" alt="微信群">
+</p>
 
-- **GitHub Issues** - [报告错误或请求功能](https://github.com/geek-fun/serverlessinsight/issues)
-- **官方网站** - [serverlessinsight.geekfun.club](https://serverlessinsight.geekfun.club)
+<p align="center">
+  <a href="https://discord.gg/5NSUyPK2E"><img src="https://img.shields.io/badge/Discord-加入-5865F2?logo=discord&logoColor=white" alt="Discord" /></a>
+  &nbsp;&nbsp;&nbsp;
+  <a href="https://x.com/geekfun_club"><img src="https://img.shields.io/badge/X-关注-000000?logo=x&logoColor=white" alt="X / Twitter" /></a>
+  &nbsp;&nbsp;&nbsp;
+  <a href="https://www.youtube.com/@geekfun-club"><img src="https://img.shields.io/badge/YouTube-订阅-FF0000?logo=youtube&logoColor=white" alt="YouTube" /></a>
+  &nbsp;&nbsp;&nbsp;
+  <a href="https://github.com/geek-fun"><img src="https://img.shields.io/badge/GitHub-关注-181717?logo=github&logoColor=white" alt="GitHub" /></a>
+</p>
 
----
+## Sponsor
+
+<p align="center">
+  <a href="https://github.com/sponsors/geek-fun"><img src="https://img.shields.io/badge/GitHub_Sponsors-%E2%9D%A4_支持-EA4AAA?logo=githubsponsors&logoColor=white" alt="GitHub Sponsors" /></a>
+</p>
 
 ## 📄 许可证
 


### PR DESCRIPTION
Remove `style=for-the-badge` from all shields.io badges to match the simpler flat style, consistent with the Node.js CI badge.