### PR TITLE
feat: add triggers.http and domain support for Tencent SCF and Aliyun FC3

### DIFF
--- a/src/common/aliyunClient/fc3Operations.ts
+++ b/src/common/aliyunClient/fc3Operations.ts
@@ -269,4 +269,89 @@ const buildCodeLocation = (codePath: string, ossCode?: OssCodeLocation): fc.Inpu
   deleteFunction: async (functionName: string): Promise<void> => {
     await fc3Client.deleteFunction(functionName);
   },
+
+  createTrigger: async (
+    functionName: string,
+    triggerName: string,
+    triggerType: string,
+    triggerConfig: Record<string, unknown>,
+    qualifier?: string,
+  ): Promise<void> => {
+    const createTriggerInput = new fc.CreateTriggerInput({
+      triggerName,
+      triggerType,
+      triggerConfig: JSON.stringify(triggerConfig),
+      ...(qualifier ? { qualifier } : {}),
+    });
+    const request = new fc.CreateTriggerRequest({
+      body: createTriggerInput,
+    });
+    await fc3Client.createTrigger(functionName, request);
+  },
+
+  deleteTrigger: async (functionName: string, triggerName: string): Promise<void> => {
+    await fc3Client.deleteTrigger(functionName, triggerName);
+  },
+
+  createCustomDomain: async (
+    domainName: string,
+    protocol: string,
+    fnName: string,
+    certConfig?: { certName: string; certificate: string; privateKey: string },
+  ): Promise<void> => {
+    const createCustomDomainInput = new fc.CreateCustomDomainInput({
+      domainName,
+      protocol,
+      ...(certConfig ? { certConfig: new fc.CertConfig(certConfig) } : {}),
+      routeConfig: new fc.RouteConfig({
+        routes: [
+          new fc.PathConfig({
+            path: '/*',
+            functionName: fnName,
+          }),
+        ],
+      }),
+    });
+    const request = new fc.CreateCustomDomainRequest({
+      body: createCustomDomainInput,
+    });
+    await fc3Client.createCustomDomain(request);
+  },
+
+  getCustomDomain: async (
+    domainName: string,
+  ): Promise<{
+    domainName?: string;
+    protocol?: string;
+    certConfig?: { certName?: string; certificateId?: string };
+  } | null> => {
+    try {
+      const response = await fc3Client.getCustomDomain(domainName);
+      if (!response || !response.body) return null;
+      return {
+        domainName: response.body.domainName,
+        protocol: response.body.protocol,
+        certConfig: response.body.certConfig
+          ? {
+              certName: response.body.certConfig.certName,
+              certificateId: response.body.certConfig.certificateId,
+            }
+          : undefined,
+      };
+    } catch (error: unknown) {
+      if (
+        error &&
+        typeof error === 'object' &&
+        'code' in error &&
+        error.code === 'CustomDomainNotFound'
+      ) {
+        return null;
+      }
+      throw error;
+    }
+  },
+
+  deleteCustomDomain: async (domainName: string): Promise<void> => {
+    await fc3Client.deleteCustomDomain(domainName);
+  },
 });

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -17,3 +17,4 @@ export * from './dependencyGraph';
 export * from './sidUtils';
 export * from './certUtils';
 export * from './planFormatter';
+export * from './triggerMapper';

--- a/src/common/tencentClient/scfOperations.ts
+++ b/src/common/tencentClient/scfOperations.ts
@@ -167,6 +167,100 @@ export const createScfOperations = (scfClient: ScfSdkClient) => ({
     await scfClient.UpdateFunctionCode(params);
   },
 
+  createTrigger: async (params: {
+    FunctionName: string;
+    TriggerName: string;
+    Type: string;
+    TriggerDesc?: string;
+    Qualifier?: string;
+    Enable?: string;
+  }): Promise<void> => {
+    await scfClient.CreateTrigger({
+      FunctionName: params.FunctionName,
+      TriggerName: params.TriggerName,
+      Type: params.Type,
+      ...(params.TriggerDesc ? { TriggerDesc: params.TriggerDesc } : {}),
+      ...(params.Qualifier ? { Qualifier: params.Qualifier } : {}),
+      ...(params.Enable ? { Enable: params.Enable } : {}),
+    });
+  },
+
+  deleteTrigger: async (params: {
+    FunctionName: string;
+    TriggerName: string;
+    Type: string;
+  }): Promise<void> => {
+    await scfClient.DeleteTrigger({
+      FunctionName: params.FunctionName,
+      TriggerName: params.TriggerName,
+      Type: params.Type,
+    });
+  },
+
+  createCustomDomain: async (params: {
+    Domain: string;
+    Protocol: string;
+    EndpointsConfig: Array<{
+      Namespace: string;
+      FunctionName: string;
+      Qualifier: string;
+      PathMatch: string;
+    }>;
+    CertConfig?: { CertificateId?: string };
+  }): Promise<void> => {
+    await scfClient.CreateCustomDomain({
+      Domain: params.Domain,
+      Protocol: params.Protocol,
+      EndpointsConfig: params.EndpointsConfig.map((ep) => ({
+        Namespace: ep.Namespace,
+        FunctionName: ep.FunctionName,
+        Qualifier: ep.Qualifier,
+        PathMatch: ep.PathMatch,
+      })),
+      ...(params.CertConfig ? { CertConfig: params.CertConfig } : {}),
+    });
+  },
+
+  getCustomDomain: async (
+    domain: string,
+  ): Promise<{
+    Domain?: string;
+    Protocol?: string;
+    EndpointsConfig?: Array<{
+      FunctionName?: string;
+      Qualifier?: string;
+      PathMatch?: string;
+    }>;
+  } | null> => {
+    try {
+      const response = await scfClient.GetCustomDomain({ Domain: domain });
+      if (!response) return null;
+      return {
+        Domain: response.Domain,
+        Protocol: response.Protocol,
+        EndpointsConfig: response.EndpointsConfig?.map((ep) => ({
+          FunctionName: ep.FunctionName,
+          Qualifier: ep.Qualifier,
+          PathMatch: ep.PathMatch,
+        })),
+      };
+    } catch (error: unknown) {
+      if (
+        error &&
+        typeof error === 'object' &&
+        'code' in error &&
+        error.code === 'ResourceNotFound'
+      ) {
+        return null;
+      }
+      throw error;
+    }
+  },
+
+  deleteCustomDomain: async (domain: string): Promise<void> => {
+    await scfClient.DeleteCustomDomain({ Domain: domain });
+  },
+
   deleteFunction: async (functionName: string): Promise<void> => {
     const params = {
       FunctionName: functionName,

--- a/src/common/triggerMapper.ts
+++ b/src/common/triggerMapper.ts
@@ -1,0 +1,39 @@
+import { ProviderEnum } from './providerEnum';
+
+type AuthType = 'public' | 'iam';
+
+type AccessValue = 'public' | 'internal';
+
+export const mapAuthType = (provider: ProviderEnum, authType: AuthType): string => {
+  switch (provider) {
+    case ProviderEnum.TENCENT:
+      return authType === 'public' ? 'NONE' : 'CAM';
+    case ProviderEnum.ALIYUN:
+      return authType === 'public' ? 'anonymous' : 'function';
+    case ProviderEnum.AWS:
+      return authType === 'public' ? 'NONE' : 'AWS_IAM';
+    default:
+      return authType === 'public' ? 'NONE' : 'CAM';
+  }
+};
+
+export const mapAccess = (
+  access?: Array<AccessValue>,
+): { enableExtranet?: boolean; enableIntranet?: boolean } => {
+  if (!access || access.length === 0) {
+    return {};
+  }
+  return {
+    enableExtranet: access.includes('public'),
+    enableIntranet: access.includes('internal'),
+  };
+};
+
+export const mapAliyunAccess = (access?: Array<AccessValue>): { disableURLInternet?: boolean } => {
+  if (!access || access.length === 0) {
+    return {};
+  }
+  return {
+    disableURLInternet: !access.includes('public') && access.includes('internal'),
+  };
+};

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -844,4 +844,24 @@ export const en = {
   COS_BUCKET_POLICY_DELETED: 'COS bucket policy deleted for {{bucketName}}',
   TOS_BUCKET_POLICY_SET: 'TOS bucket policy set for {{bucketName}}',
   TOS_BUCKET_POLICY_DELETED: 'TOS bucket policy deleted for {{bucketName}}',
+
+  // HTTP trigger messages
+  HTTP_TRIGGER_AUTH_TYPE_REQUIRED:
+    "HTTP trigger '{{functionName}}' requires 'auth_type' (public or iam)",
+  CREATING_HTTP_TRIGGER:
+    "Creating HTTP trigger '{{triggerName}}' for function '{{functionName}}'...",
+  HTTP_TRIGGER_CREATED: "HTTP trigger '{{triggerName}}' created for function '{{functionName}}'",
+  UPDATING_HTTP_TRIGGER: "Recreating HTTP trigger for function '{{functionName}}'...",
+  DELETING_HTTP_TRIGGER:
+    "Deleting HTTP trigger '{{triggerName}}' for function '{{functionName}}'...",
+  HTTP_TRIGGER_DELETED: "HTTP trigger '{{triggerName}}' deleted",
+  HTTP_TRIGGER_NOT_FOUND: "HTTP trigger '{{triggerName}}' not found in provider, skipping delete",
+  CREATING_CUSTOM_DOMAIN: "Creating custom domain '{{domainName}}'...",
+  CUSTOM_DOMAIN_CREATED: "Custom domain '{{domainName}}' created",
+  UPDATING_CUSTOM_DOMAIN: "Updating custom domain '{{domainName}}'...",
+  DELETING_CUSTOM_DOMAIN: "Deleting custom domain '{{domainName}}'...",
+  CUSTOM_DOMAIN_DELETED: "Custom domain '{{domainName}}' deleted",
+  DOMAIN_NOT_SUPPORTED_PROVIDER: "Custom domain is not supported for provider '{{provider}}'",
+  INVALID_HTTP_TRIGGER_AUTH_TYPE:
+    "Invalid HTTP trigger auth_type '{{authType}}'; must be 'public' or 'iam'",
 };

--- a/src/lang/zh-CN.ts
+++ b/src/lang/zh-CN.ts
@@ -772,4 +772,22 @@ export const zhCN = {
   COS_BUCKET_POLICY_DELETED: 'COS 存储桶 {{bucketName}} 策略已删除',
   TOS_BUCKET_POLICY_SET: 'TOS 存储桶 {{bucketName}} 策略已设置',
   TOS_BUCKET_POLICY_DELETED: 'TOS 存储桶 {{bucketName}} 策略已删除',
+
+  // HTTP trigger messages
+  HTTP_TRIGGER_AUTH_TYPE_REQUIRED:
+    "HTTP 触发器 '{{functionName}}' 需要设置 'auth_type'（public 或 iam）",
+  CREATING_HTTP_TRIGGER: "正在为函数 '{{functionName}}' 创建 HTTP 触发器 '{{triggerName}}'...",
+  HTTP_TRIGGER_CREATED: "HTTP 触发器 '{{triggerName}}' 已为函数 '{{functionName}}' 创建成功",
+  UPDATING_HTTP_TRIGGER: "正在重新创建函数 '{{functionName}}' 的 HTTP 触发器...",
+  DELETING_HTTP_TRIGGER: "正在删除函数 '{{functionName}}' 的 HTTP 触发器 '{{triggerName}}'...",
+  HTTP_TRIGGER_DELETED: "HTTP 触发器 '{{triggerName}}' 已删除",
+  HTTP_TRIGGER_NOT_FOUND: "HTTP 触发器 '{{triggerName}}' 在云平台中不存在，跳过删除",
+  CREATING_CUSTOM_DOMAIN: "正在创建自定义域名 '{{domainName}}'...",
+  CUSTOM_DOMAIN_CREATED: "自定义域名 '{{domainName}}' 已创建",
+  UPDATING_CUSTOM_DOMAIN: "正在更新自定义域名 '{{domainName}}'...",
+  DELETING_CUSTOM_DOMAIN: "正在删除自定义域名 '{{domainName}}'...",
+  CUSTOM_DOMAIN_DELETED: "自定义域名 '{{domainName}}' 已删除",
+  DOMAIN_NOT_SUPPORTED_PROVIDER: "当前云平台 '{{provider}}' 不支持自定义域名",
+  INVALID_HTTP_TRIGGER_AUTH_TYPE:
+    "无效的 HTTP 触发器 auth_type '{{authType}}'，必须为 'public' 或 'iam'",
 };

--- a/src/parser/functionParser.ts
+++ b/src/parser/functionParser.ts
@@ -1,6 +1,49 @@
-import { FunctionDomain, FunctionGpuEnum, FunctionRaw, NasStorageClassEnum } from '../types';
+import {
+  FunctionDomain,
+  FunctionDomainConfigParsed,
+  FunctionGpuEnum,
+  FunctionRaw,
+  HttpTrigger,
+  HttpTriggerRaw,
+  NasStorageClassEnum,
+} from '../types';
 import { isEmpty } from 'lodash';
-import { parseBoolean, parseNumber, parseNumberWithDefault } from './parseUtils';
+import {
+  parseBoolean,
+  parseNumber,
+  parseNumberWithDefault,
+  parseStringWithDefault,
+} from './parseUtils';
+import { lang } from '../lang';
+
+const parseHttpTrigger = (
+  raw: HttpTriggerRaw | undefined,
+  fnKey: string,
+): HttpTrigger | undefined => {
+  if (!raw) return undefined;
+  if (!raw.auth_type) {
+    throw new Error(lang.__('HTTP_TRIGGER_AUTH_TYPE_REQUIRED', { functionName: fnKey }));
+  }
+  const authType = String(raw.auth_type);
+  if (authType !== 'public' && authType !== 'iam') {
+    throw new Error(lang.__('INVALID_HTTP_TRIGGER_AUTH_TYPE', { authType }));
+  }
+  return {
+    auth_type: authType as 'public' | 'iam',
+    access: raw.access?.map(String) as Array<'public' | 'internal'> | undefined,
+  };
+};
+
+const parseDomain = (
+  raw: FunctionRaw['domain'] | undefined,
+): FunctionDomainConfigParsed | undefined => {
+  if (!raw) return undefined;
+  return {
+    domain_name: String(raw.domain_name),
+    certificate_id: raw.certificate_id ? String(raw.certificate_id) : undefined,
+    protocol: parseStringWithDefault(raw.protocol, 'HTTPS'),
+  };
+};
 
 export const parseFunction = (functions?: {
   [key: string]: FunctionRaw;
@@ -8,70 +51,77 @@ export const parseFunction = (functions?: {
   if (isEmpty(functions)) {
     return undefined;
   }
-  return Object.entries(functions).map(([key, func]) => ({
-    key,
-    name: func.name,
-    code: func.code
-      ? {
-          runtime: String(func.code.runtime),
-          handler: func.code.handler,
-          path: func.code.path,
-        }
-      : undefined,
-    container: func.container
-      ? {
-          image: func.container.image,
-          cmd: func.container.cmd,
-          port: parseNumberWithDefault(func.container.port, 0),
-        }
-      : undefined,
-    memory: parseNumber(func.memory),
-    gpu: func.gpu as FunctionGpuEnum,
-    timeout: parseNumber(func.timeout),
-    iam: func.iam
-      ? {
-          role:
-            func.iam.role !== undefined
-              ? typeof func.iam.role === 'string'
-                ? func.iam.role
-                : {
-                    ...(func.iam.role.name !== undefined
-                      ? { name: String(func.iam.role.name) }
-                      : {}),
-                    ...(func.iam.role.managed_policies !== undefined
-                      ? { managed_policies: func.iam.role.managed_policies.map(String) }
-                      : {}),
-                    ...(func.iam.role.statements !== undefined
-                      ? {
-                          statements: func.iam.role.statements.map((s) => {
-                            const rawAction = s.action;
-                            const rawResource = s.resource;
-                            return {
-                              sid: s.sid as string | undefined,
-                              effect: s.effect as 'Allow' | 'Deny',
-                              action: Array.isArray(rawAction)
-                                ? rawAction.map(String)
-                                : [String(rawAction)],
-                              resource: Array.isArray(rawResource)
-                                ? rawResource.map(String)
-                                : [String(rawResource)],
-                            };
-                          }),
-                        }
-                      : {}),
-                  }
-              : undefined,
-        }
-      : undefined,
-    environment: func.environment,
-    log: parseBoolean(func.log),
-    network: func.network,
-    storage: {
-      disk: parseNumber(func.storage?.disk),
-      nas: func.storage?.nas?.map((nasItem) => ({
-        mount_path: nasItem.mount_path,
-        storage_class: nasItem.storage_class as NasStorageClassEnum,
-      })),
-    },
-  }));
+  return Object.entries(functions).map(([key, func]) => {
+    const httpTrigger = parseHttpTrigger(func.triggers?.http, key);
+    const domain = parseDomain(func.domain);
+
+    return {
+      key,
+      name: func.name,
+      code: func.code
+        ? {
+            runtime: String(func.code.runtime),
+            handler: func.code.handler,
+            path: func.code.path,
+          }
+        : undefined,
+      container: func.container
+        ? {
+            image: func.container.image,
+            cmd: func.container.cmd,
+            port: parseNumberWithDefault(func.container.port, 0),
+          }
+        : undefined,
+      memory: parseNumber(func.memory),
+      gpu: func.gpu as FunctionGpuEnum,
+      timeout: parseNumber(func.timeout),
+      iam: func.iam
+        ? {
+            role:
+              func.iam.role !== undefined
+                ? typeof func.iam.role === 'string'
+                  ? func.iam.role
+                  : {
+                      ...(func.iam.role.name !== undefined
+                        ? { name: String(func.iam.role.name) }
+                        : {}),
+                      ...(func.iam.role.managed_policies !== undefined
+                        ? { managed_policies: func.iam.role.managed_policies.map(String) }
+                        : {}),
+                      ...(func.iam.role.statements !== undefined
+                        ? {
+                            statements: func.iam.role.statements.map((s) => {
+                              const rawAction = s.action;
+                              const rawResource = s.resource;
+                              return {
+                                sid: s.sid as string | undefined,
+                                effect: s.effect as 'Allow' | 'Deny',
+                                action: Array.isArray(rawAction)
+                                  ? rawAction.map(String)
+                                  : [String(rawAction)],
+                                resource: Array.isArray(rawResource)
+                                  ? rawResource.map(String)
+                                  : [String(rawResource)],
+                              };
+                            }),
+                          }
+                        : {}),
+                    }
+                : undefined,
+          }
+        : undefined,
+      environment: func.environment,
+      log: parseBoolean(func.log),
+      network: func.network,
+      storage: {
+        disk: parseNumber(func.storage?.disk),
+        nas: func.storage?.nas?.map((nasItem) => ({
+          mount_path: nasItem.mount_path,
+          storage_class: nasItem.storage_class as NasStorageClassEnum,
+        })),
+      },
+      ...(httpTrigger ? { triggers: { http: httpTrigger } } : {}),
+      ...(domain ? { domain } : {}),
+    };
+  });
 };

--- a/src/stack/aliyunStack/fc3Resource.ts
+++ b/src/stack/aliyunStack/fc3Resource.ts
@@ -709,20 +709,33 @@ export const createResource = async (
   if (fn.domain) {
     logger.info(lang.__('CREATING_CUSTOM_DOMAIN', { domainName: fn.domain.domain_name }));
 
+    let certConfig: { certName: string; certificate: string; privateKey: string } | undefined;
     if (fn.domain.certificate_id) {
-      logger.warn(
-        `Custom domain '${fn.domain.domain_name}': certificate_id '${fn.domain.certificate_id}' is configured but certificate binding requires CAS integration which is not yet implemented. The domain will be created without HTTPS certificate.`,
-      );
+      const certId = fn.domain.certificate_id;
+      const detail = await client.cas.getCertificate(certId);
+      if (!detail || !detail.cert || !detail.key) {
+        throw new Error(lang.__('CERT_REFERENCE_NOT_FOUND', { reference: certId }));
+      }
+      certConfig = {
+        certName: `${context.service}-${context.stage}-fc3-domain`,
+        certificate: detail.cert,
+        privateKey: detail.key,
+      };
     }
 
-    await client.fc3.createCustomDomain(fn.domain.domain_name, fn.domain.protocol, fn.name);
+    await client.fc3.createCustomDomain(
+      fn.domain.domain_name,
+      fn.domain.protocol,
+      fn.name,
+      certConfig,
+    );
     logger.info(lang.__('CUSTOM_DOMAIN_CREATED', { domainName: fn.domain.domain_name }));
 
     lifecycleInstances.push({
       type: 'ALIYUN_FC3_CUSTOM_DOMAIN',
       id: fn.domain.domain_name,
       sid: buildSid('aliyun', 'fc3-custom-domain', context.stage, fn.domain.domain_name),
-      attributes: { protocol: fn.domain.protocol },
+      attributes: { protocol: fn.domain.protocol, certificate_id: fn.domain.certificate_id },
     });
   }
 
@@ -1025,13 +1038,26 @@ export const updateResource = async (
   if (desiredDomain && !existingCustomDomain) {
     logger.info(lang.__('CREATING_CUSTOM_DOMAIN', { domainName: desiredDomain.domain_name }));
 
+    let certConfig: { certName: string; certificate: string; privateKey: string } | undefined;
     if (desiredDomain.certificate_id) {
-      logger.warn(
-        `Custom domain '${desiredDomain.domain_name}': certificate_id '${desiredDomain.certificate_id}' is configured but certificate binding requires CAS integration which is not yet implemented. The domain will be created without HTTPS certificate.`,
-      );
+      const certId = desiredDomain.certificate_id;
+      const detail = await client.cas.getCertificate(certId);
+      if (!detail || !detail.cert || !detail.key) {
+        throw new Error(lang.__('CERT_REFERENCE_NOT_FOUND', { reference: certId }));
+      }
+      certConfig = {
+        certName: `${context.service}-${context.stage}-fc3-domain`,
+        certificate: detail.cert,
+        privateKey: detail.key,
+      };
     }
 
-    await client.fc3.createCustomDomain(desiredDomain.domain_name, desiredDomain.protocol, fn.name);
+    await client.fc3.createCustomDomain(
+      desiredDomain.domain_name,
+      desiredDomain.protocol,
+      fn.name,
+      certConfig,
+    );
     logger.info(lang.__('CUSTOM_DOMAIN_CREATED', { domainName: desiredDomain.domain_name }));
   } else if (!desiredDomain && existingCustomDomain) {
     logger.info(lang.__('DELETING_CUSTOM_DOMAIN', { domainName: existingCustomDomain.id }));
@@ -1056,10 +1082,18 @@ export const updateResource = async (
     if (domainChanged) {
       logger.info(lang.__('UPDATING_CUSTOM_DOMAIN', { domainName: desiredDomain.domain_name }));
 
+      let certConfig: { certName: string; certificate: string; privateKey: string } | undefined;
       if (desiredDomain.certificate_id) {
-        logger.warn(
-          `Custom domain '${desiredDomain.domain_name}': certificate_id '${desiredDomain.certificate_id}' is configured but certificate binding requires CAS integration which is not yet implemented.`,
-        );
+        const certId = desiredDomain.certificate_id;
+        const detail = await client.cas.getCertificate(certId);
+        if (!detail || !detail.cert || !detail.key) {
+          throw new Error(lang.__('CERT_REFERENCE_NOT_FOUND', { reference: certId }));
+        }
+        certConfig = {
+          certName: `${context.service}-${context.stage}-fc3-domain`,
+          certificate: detail.cert,
+          privateKey: detail.key,
+        };
       }
 
       try {
@@ -1072,6 +1106,7 @@ export const updateResource = async (
         desiredDomain.domain_name,
         desiredDomain.protocol,
         fn.name,
+        certConfig,
       );
       logger.info(lang.__('CUSTOM_DOMAIN_CREATED', { domainName: desiredDomain.domain_name }));
     }

--- a/src/stack/aliyunStack/fc3Resource.ts
+++ b/src/stack/aliyunStack/fc3Resource.ts
@@ -11,6 +11,9 @@ import {
   getContext,
   buildSid,
   attributesEqual,
+  mapAuthType,
+  mapAliyunAccess,
+  ProviderEnum,
 } from '../../common';
 import {
   FC3_CODE_INLINE_SIZE_LIMIT,
@@ -20,6 +23,7 @@ import {
 import {
   Context,
   FunctionDomain,
+  HttpTrigger,
   PartialResourceError,
   ResourceAttributes,
   ResourceState,
@@ -178,6 +182,18 @@ const buildFc3InstanceFromProvider = (info: Fc3FunctionInfo, sid: string) => {
     lastUpdateStatus: info.lastUpdateStatus ?? null,
     lastUpdateStatusReason: info.lastUpdateStatusReason ?? null,
     lastUpdateStatusReasonCode: info.lastUpdateStatusReasonCode ?? null,
+  };
+};
+
+const buildHttpTriggerConfig = (
+  trigger: HttpTrigger,
+): { authType: string; methods: string[]; disableURLInternet?: boolean } => {
+  const authType = mapAuthType(ProviderEnum.ALIYUN, trigger.auth_type);
+  const { disableURLInternet } = mapAliyunAccess(trigger.access);
+  return {
+    authType,
+    methods: ['GET', 'POST', 'PUT', 'DELETE', 'HEAD', 'PATCH'],
+    ...(disableURLInternet !== undefined ? { disableURLInternet } : {}),
   };
 };
 
@@ -493,6 +509,17 @@ const deleteDependentResources = async (
           logger.info(lang.__('DELETING_SLS_PROJECT', { id: instance.id }));
           await client.sls.deleteProject(instance.id);
           break;
+        case 'ALIYUN_FC3_HTTP_TRIGGER':
+          // HTTP trigger deletion requires functionName which is not available here.
+          // It is handled directly in deleteResource before calling this function.
+          logger.warn(
+            `HTTP trigger '${instance.id}' should be deleted before reaching dependent resource cleanup`,
+          );
+          break;
+        case 'ALIYUN_FC3_CUSTOM_DOMAIN':
+          logger.info(lang.__('DELETING_CUSTOM_DOMAIN', { domainName: instance.id }));
+          await client.fc3.deleteCustomDomain(instance.id);
+          break;
         default:
           logger.warn(lang.__('UNKNOWN_RESOURCE_TYPE', { type: instance.type }));
       }
@@ -659,11 +686,44 @@ export const createResource = async (
 
   const fcInstance = buildFc3InstanceFromProvider(functionInfo, sid);
 
+  const lifecycleInstances = [];
+  if (fn.triggers?.http) {
+    const triggerConfig = buildHttpTriggerConfig(fn.triggers.http);
+
+    logger.info(
+      lang.__('CREATING_HTTP_TRIGGER', { triggerName: 'http-trigger', functionName: fn.name }),
+    );
+    await client.fc3.createTrigger(fn.name, 'http-trigger', 'http', triggerConfig);
+    logger.info(
+      lang.__('HTTP_TRIGGER_CREATED', { triggerName: 'http-trigger', functionName: fn.name }),
+    );
+
+    lifecycleInstances.push({
+      type: 'ALIYUN_FC3_HTTP_TRIGGER',
+      id: 'http-trigger',
+      sid: buildSid('aliyun', 'fc3-http-trigger', context.stage, fn.name),
+      attributes: { ...triggerConfig } as unknown as Record<string, unknown>,
+    });
+  }
+
+  if (fn.domain) {
+    logger.info(lang.__('CREATING_CUSTOM_DOMAIN', { domainName: fn.domain.domain_name }));
+    await client.fc3.createCustomDomain(fn.domain.domain_name, fn.domain.protocol, fn.name);
+    logger.info(lang.__('CUSTOM_DOMAIN_CREATED', { domainName: fn.domain.domain_name }));
+
+    lifecycleInstances.push({
+      type: 'ALIYUN_FC3_CUSTOM_DOMAIN',
+      id: fn.domain.domain_name,
+      sid: buildSid('aliyun', 'fc3-custom-domain', context.stage, fn.domain.domain_name),
+      attributes: { protocol: fn.domain.protocol },
+    });
+  }
+
   const resourceState: ResourceState = {
     mode: 'managed',
     region: context.region,
     definition,
-    instances: [fcInstance, ...dependentInstances],
+    instances: [fcInstance, ...lifecycleInstances, ...dependentInstances],
     lastUpdated: new Date().toISOString(),
     status: 'ready',
   };
@@ -906,6 +966,96 @@ export const updateResource = async (
     );
   }
 
+  const existingHttpTrigger = existingInstances.find(
+    (i) => i.type === 'ALIYUN_FC3_HTTP_TRIGGER',
+  ) as DependentInstance | undefined;
+  const desiredHttpTrigger = fn.triggers?.http;
+
+  if (desiredHttpTrigger && !existingHttpTrigger) {
+    const triggerConfig = buildHttpTriggerConfig(desiredHttpTrigger);
+    logger.info(
+      lang.__('CREATING_HTTP_TRIGGER', { triggerName: 'http-trigger', functionName: fn.name }),
+    );
+    await client.fc3.createTrigger(fn.name, 'http-trigger', 'http', triggerConfig);
+    logger.info(
+      lang.__('HTTP_TRIGGER_CREATED', { triggerName: 'http-trigger', functionName: fn.name }),
+    );
+  } else if (!desiredHttpTrigger && existingHttpTrigger) {
+    logger.info(
+      lang.__('DELETING_HTTP_TRIGGER', { triggerName: 'http-trigger', functionName: fn.name }),
+    );
+    try {
+      await client.fc3.deleteTrigger(fn.name, 'http-trigger');
+      logger.info(lang.__('HTTP_TRIGGER_DELETED', { triggerName: 'http-trigger' }));
+    } catch (err) {
+      const errorCode = (err as { code?: string })?.code;
+      if (errorCode !== 'TriggerNotFound') throw err;
+      logger.warn(lang.__('HTTP_TRIGGER_NOT_FOUND', { triggerName: 'http-trigger' }));
+    }
+  } else if (desiredHttpTrigger && existingHttpTrigger) {
+    const desiredTriggerConfig = buildHttpTriggerConfig(desiredHttpTrigger);
+    const existingAttrs = existingHttpTrigger.attributes ?? {};
+    if (!attributesEqual(desiredTriggerConfig, existingAttrs)) {
+      logger.info(lang.__('UPDATING_HTTP_TRIGGER', { functionName: fn.name }));
+      try {
+        await client.fc3.deleteTrigger(fn.name, 'http-trigger');
+      } catch (err) {
+        const errorCode = (err as { code?: string })?.code;
+        if (errorCode !== 'TriggerNotFound') throw err;
+      }
+      await client.fc3.createTrigger(fn.name, 'http-trigger', 'http', desiredTriggerConfig);
+      logger.info(
+        lang.__('HTTP_TRIGGER_CREATED', { triggerName: 'http-trigger', functionName: fn.name }),
+      );
+    }
+  }
+
+  const existingCustomDomain = existingInstances.find(
+    (i) => i.type === 'ALIYUN_FC3_CUSTOM_DOMAIN',
+  ) as DependentInstance | undefined;
+  const desiredDomain = fn.domain;
+
+  if (desiredDomain && !existingCustomDomain) {
+    logger.info(lang.__('CREATING_CUSTOM_DOMAIN', { domainName: desiredDomain.domain_name }));
+    await client.fc3.createCustomDomain(desiredDomain.domain_name, desiredDomain.protocol, fn.name);
+    logger.info(lang.__('CUSTOM_DOMAIN_CREATED', { domainName: desiredDomain.domain_name }));
+  } else if (!desiredDomain && existingCustomDomain) {
+    logger.info(lang.__('DELETING_CUSTOM_DOMAIN', { domainName: existingCustomDomain.id }));
+    try {
+      await client.fc3.deleteCustomDomain(existingCustomDomain.id);
+      logger.info(lang.__('CUSTOM_DOMAIN_DELETED', { domainName: existingCustomDomain.id }));
+    } catch (err) {
+      const errorCode = (err as { code?: string })?.code;
+      if (errorCode !== 'CustomDomainNotFound') throw err;
+      logger.warn(
+        lang.__('RESOURCE_NOT_FOUND_PROVIDER', {
+          resourceType: 'Custom Domain',
+          name: existingCustomDomain.id,
+        }),
+      );
+    }
+  } else if (desiredDomain && existingCustomDomain) {
+    const existingProtocol = existingCustomDomain.attributes?.protocol as string | undefined;
+    const domainChanged =
+      desiredDomain.domain_name !== existingCustomDomain.id ||
+      desiredDomain.protocol !== existingProtocol;
+    if (domainChanged) {
+      logger.info(lang.__('UPDATING_CUSTOM_DOMAIN', { domainName: desiredDomain.domain_name }));
+      try {
+        await client.fc3.deleteCustomDomain(existingCustomDomain.id);
+      } catch (err) {
+        const errorCode = (err as { code?: string })?.code;
+        if (errorCode !== 'CustomDomainNotFound') throw err;
+      }
+      await client.fc3.createCustomDomain(
+        desiredDomain.domain_name,
+        desiredDomain.protocol,
+        fn.name,
+      );
+      logger.info(lang.__('CUSTOM_DOMAIN_CREATED', { domainName: desiredDomain.domain_name }));
+    }
+  }
+
   const functionInfo = await client.fc3.getFunction(fn.name);
   if (!functionInfo) {
     throw new Error(`Failed to refresh state for function: ${fn.name}`);
@@ -917,8 +1067,30 @@ export const updateResource = async (
   const sid = buildSid('aliyun', 'fc3', context.stage, fn.name);
 
   const fcInstance = buildFc3InstanceFromProvider(functionInfo, sid);
+
+  const lifecycleInstances = [];
+  if (fn.triggers?.http) {
+    const triggerConfig = buildHttpTriggerConfig(fn.triggers.http);
+    lifecycleInstances.push({
+      type: 'ALIYUN_FC3_HTTP_TRIGGER',
+      id: 'http-trigger',
+      sid: buildSid('aliyun', 'fc3-http-trigger', context.stage, fn.name),
+      attributes: { ...triggerConfig } as unknown as Record<string, unknown>,
+    });
+  }
+  if (fn.domain) {
+    lifecycleInstances.push({
+      type: 'ALIYUN_FC3_CUSTOM_DOMAIN',
+      id: fn.domain.domain_name,
+      sid: buildSid('aliyun', 'fc3-custom-domain', context.stage, fn.domain.domain_name),
+      attributes: { protocol: fn.domain.protocol },
+    });
+  }
+
   const existingDependentInstances = existingInstances
     .filter((i) => i.type !== 'ALIYUN_FC3_FUNCTION')
+    .filter((i) => i.type !== 'ALIYUN_FC3_HTTP_TRIGGER')
+    .filter((i) => i.type !== 'ALIYUN_FC3_CUSTOM_DOMAIN')
     .filter((i) => !(typeof fn.iam?.role === 'string' && i.type === 'ALIYUN_RAM_ROLE'))
     .map((i) => {
       const { sid: existingSid, id: existingId, ...rest } = i;
@@ -950,7 +1122,12 @@ export const updateResource = async (
     mode: 'managed',
     region: context.region,
     definition,
-    instances: [fcInstance, ...existingDependentInstances, ...newDependentInstancesMapped],
+    instances: [
+      fcInstance,
+      ...lifecycleInstances,
+      ...existingDependentInstances,
+      ...newDependentInstancesMapped,
+    ],
     lastUpdated: new Date().toISOString(),
   };
 
@@ -966,9 +1143,49 @@ export const deleteResource = async (
   const existingState = getResource(state, logicalId);
   const existingInstances = (existingState?.instances ?? []) as Array<DependentInstance>;
 
-  const hasFcFunction = existingInstances.some((i) => i.type === 'ALIYUN_FC3_FUNCTION');
-
   const client = createAliyunClient(context);
+
+  // Delete HTTP trigger and custom domain before function (they depend on it)
+  const httpTriggerInstance = existingInstances.find((i) => i.type === 'ALIYUN_FC3_HTTP_TRIGGER');
+  if (httpTriggerInstance) {
+    logger.info(
+      lang.__('DELETING_HTTP_TRIGGER', { triggerName: httpTriggerInstance.id, functionName }),
+    );
+    try {
+      await client.fc3.deleteTrigger(functionName, httpTriggerInstance.id);
+      logger.info(lang.__('HTTP_TRIGGER_DELETED', { triggerName: httpTriggerInstance.id }));
+    } catch (err) {
+      const errorCode = (err as { code?: string })?.code;
+      if (errorCode === 'TriggerNotFound') {
+        logger.warn(lang.__('HTTP_TRIGGER_NOT_FOUND', { triggerName: httpTriggerInstance.id }));
+      } else {
+        throw err;
+      }
+    }
+  }
+
+  const customDomainInstance = existingInstances.find((i) => i.type === 'ALIYUN_FC3_CUSTOM_DOMAIN');
+  if (customDomainInstance) {
+    logger.info(lang.__('DELETING_CUSTOM_DOMAIN', { domainName: customDomainInstance.id }));
+    try {
+      await client.fc3.deleteCustomDomain(customDomainInstance.id);
+      logger.info(lang.__('CUSTOM_DOMAIN_DELETED', { domainName: customDomainInstance.id }));
+    } catch (err) {
+      const errorCode = (err as { code?: string })?.code;
+      if (errorCode === 'CustomDomainNotFound') {
+        logger.warn(
+          lang.__('RESOURCE_NOT_FOUND_PROVIDER', {
+            resourceType: 'Custom Domain',
+            name: customDomainInstance.id,
+          }),
+        );
+      } else {
+        throw err;
+      }
+    }
+  }
+
+  const hasFcFunction = existingInstances.some((i) => i.type === 'ALIYUN_FC3_FUNCTION');
   if (hasFcFunction) {
     try {
       await client.fc3.deleteFunction(functionName);
@@ -985,7 +1202,11 @@ export const deleteResource = async (
   }
 
   const dependentInstances = existingInstances.filter(
-    (i) => i.type !== 'ALIYUN_FC3_FUNCTION' && !i.type.includes('undefined'),
+    (i) =>
+      i.type !== 'ALIYUN_FC3_FUNCTION' &&
+      i.type !== 'ALIYUN_FC3_HTTP_TRIGGER' &&
+      i.type !== 'ALIYUN_FC3_CUSTOM_DOMAIN' &&
+      !i.type.includes('undefined'),
   );
   if (dependentInstances.length > 0) {
     await deleteDependentResources(context, dependentInstances);

--- a/src/stack/aliyunStack/fc3Resource.ts
+++ b/src/stack/aliyunStack/fc3Resource.ts
@@ -708,6 +708,13 @@ export const createResource = async (
 
   if (fn.domain) {
     logger.info(lang.__('CREATING_CUSTOM_DOMAIN', { domainName: fn.domain.domain_name }));
+
+    if (fn.domain.certificate_id) {
+      logger.warn(
+        `Custom domain '${fn.domain.domain_name}': certificate_id '${fn.domain.certificate_id}' is configured but certificate binding requires CAS integration which is not yet implemented. The domain will be created without HTTPS certificate.`,
+      );
+    }
+
     await client.fc3.createCustomDomain(fn.domain.domain_name, fn.domain.protocol, fn.name);
     logger.info(lang.__('CUSTOM_DOMAIN_CREATED', { domainName: fn.domain.domain_name }));
 
@@ -1017,6 +1024,13 @@ export const updateResource = async (
 
   if (desiredDomain && !existingCustomDomain) {
     logger.info(lang.__('CREATING_CUSTOM_DOMAIN', { domainName: desiredDomain.domain_name }));
+
+    if (desiredDomain.certificate_id) {
+      logger.warn(
+        `Custom domain '${desiredDomain.domain_name}': certificate_id '${desiredDomain.certificate_id}' is configured but certificate binding requires CAS integration which is not yet implemented. The domain will be created without HTTPS certificate.`,
+      );
+    }
+
     await client.fc3.createCustomDomain(desiredDomain.domain_name, desiredDomain.protocol, fn.name);
     logger.info(lang.__('CUSTOM_DOMAIN_CREATED', { domainName: desiredDomain.domain_name }));
   } else if (!desiredDomain && existingCustomDomain) {
@@ -1041,6 +1055,13 @@ export const updateResource = async (
       desiredDomain.protocol !== existingProtocol;
     if (domainChanged) {
       logger.info(lang.__('UPDATING_CUSTOM_DOMAIN', { domainName: desiredDomain.domain_name }));
+
+      if (desiredDomain.certificate_id) {
+        logger.warn(
+          `Custom domain '${desiredDomain.domain_name}': certificate_id '${desiredDomain.certificate_id}' is configured but certificate binding requires CAS integration which is not yet implemented.`,
+        );
+      }
+
       try {
         await client.fc3.deleteCustomDomain(existingCustomDomain.id);
       } catch (err) {

--- a/src/stack/scfStack/scfResource.ts
+++ b/src/stack/scfStack/scfResource.ts
@@ -16,6 +16,7 @@ type ScfDependentInstance = {
   sid: string;
   roleArn?: string;
   external?: boolean;
+  protocol?: string;
 };
 
 const delay = async (ms: number): Promise<void> => {
@@ -348,7 +349,7 @@ export const createResource = async (
     logger.info(lang.__('CREATING_CUSTOM_DOMAIN', { domainName: fn.domain.domain_name }));
     await client.scf.createCustomDomain({
       Domain: fn.domain.domain_name,
-      Protocol: fn.domain.protocol === 'HTTP,HTTPS' ? 'HTTP&HTTPS' : fn.domain.protocol,
+      Protocol: fn.domain.protocol,
       EndpointsConfig: [
         {
           Namespace: 'default',
@@ -373,6 +374,7 @@ export const createResource = async (
       sid: domainSid,
       type: 'TENCENT_SCF_CUSTOM_DOMAIN',
       id: fn.domain.domain_name,
+      protocol: fn.domain.protocol,
     });
   }
 
@@ -588,7 +590,7 @@ export const updateResource = async (
     logger.info(lang.__('CREATING_CUSTOM_DOMAIN', { domainName: fn.domain.domain_name }));
     await client.scf.createCustomDomain({
       Domain: fn.domain.domain_name,
-      Protocol: fn.domain.protocol === 'HTTP,HTTPS' ? 'HTTP&HTTPS' : fn.domain.protocol,
+      Protocol: fn.domain.protocol,
       EndpointsConfig: [
         {
           Namespace: 'default',
@@ -610,20 +612,27 @@ export const updateResource = async (
     } catch (err) {
       const errorCode = (err as { code?: string })?.code;
       if (errorCode === 'ResourceNotFound') {
-        logger.warn(lang.__('HTTP_TRIGGER_NOT_FOUND', { triggerName: existingCustomDomain.id }));
+        logger.warn(
+          lang.__('RESOURCE_NOT_FOUND_PROVIDER', {
+            resourceType: 'Custom Domain',
+            name: existingCustomDomain.id,
+          }),
+        );
       } else {
         throw err;
       }
     }
   } else if (fn.domain && existingCustomDomain) {
-    const domainChanged = fn.domain.domain_name !== existingCustomDomain.id;
+    const domainChanged =
+      fn.domain.domain_name !== existingCustomDomain.id ||
+      fn.domain.protocol !== existingCustomDomain.protocol;
     if (domainChanged) {
       logger.info(lang.__('DELETING_CUSTOM_DOMAIN', { domainName: existingCustomDomain.id }));
       await client.scf.deleteCustomDomain(existingCustomDomain.id);
       logger.info(lang.__('CREATING_CUSTOM_DOMAIN', { domainName: fn.domain.domain_name }));
       await client.scf.createCustomDomain({
         Domain: fn.domain.domain_name,
-        Protocol: fn.domain.protocol === 'HTTP,HTTPS' ? 'HTTP&HTTPS' : fn.domain.protocol,
+        Protocol: fn.domain.protocol,
         EndpointsConfig: [
           {
             Namespace: 'default',
@@ -688,6 +697,7 @@ export const updateResource = async (
       sid: domainSid,
       type: 'TENCENT_SCF_CUSTOM_DOMAIN' as ResourceTypeEnum,
       id: fn.domain.domain_name,
+      protocol: fn.domain.protocol,
     });
   }
 
@@ -760,7 +770,12 @@ export const deleteResource = async (
     } catch (err) {
       const errorCode = (err as { code?: string })?.code;
       if (errorCode === 'ResourceNotFound') {
-        logger.warn(lang.__('HTTP_TRIGGER_NOT_FOUND', { triggerName: existingCustomDomain.id }));
+        logger.warn(
+          lang.__('RESOURCE_NOT_FOUND_PROVIDER', {
+            resourceType: 'Custom Domain',
+            name: existingCustomDomain.id,
+          }),
+        );
       } else {
         throw err;
       }

--- a/src/stack/scfStack/scfResource.ts
+++ b/src/stack/scfStack/scfResource.ts
@@ -3,7 +3,7 @@ import { createTencentClient } from '../../common/tencentClient';
 import { readFileAsBase64 } from '../../common/fileUtils';
 import { functionToScfConfig, extractScfDefinition, ScfFunctionInfo } from './scfTypes';
 import { getResource, setResource, removeResource } from '../../common/stateManager';
-import { buildSid, attributesEqual } from '../../common';
+import { buildSid, attributesEqual, ProviderEnum, mapAuthType, mapAccess } from '../../common';
 import { RAM_ROLE_PROPAGATION_DELAY_MS } from '../../common/constants';
 import { computeFileHash } from '../../common/hashUtils';
 import { logger } from '../../common/logger';
@@ -313,7 +313,70 @@ export const createResource = async (
 
   await client.scf.createFunction(config, codeBase64);
 
-  // Refresh state from provider to get all attributes
+  // Create HTTP trigger if configured
+  if (fn.triggers?.http) {
+    if (!fn.triggers.http.auth_type) {
+      throw new Error(lang.__('HTTP_TRIGGER_AUTH_TYPE_REQUIRED', { functionName: fn.name }));
+    }
+
+    const authType = mapAuthType(ProviderEnum.TENCENT, fn.triggers.http.auth_type);
+    const access = mapAccess(fn.triggers.http.access);
+    const triggerName = `${fn.key}-http-trigger`;
+
+    const triggerDesc = JSON.stringify({
+      authType,
+      ...(access.enableExtranet !== undefined ? { enableExtranet: access.enableExtranet } : {}),
+      ...(access.enableIntranet !== undefined ? { enableIntranet: access.enableIntranet } : {}),
+    });
+
+    logger.info(lang.__('CREATING_HTTP_TRIGGER', { triggerName, functionName: fn.name }));
+
+    await client.scf.createTrigger({
+      FunctionName: fn.name,
+      TriggerName: triggerName,
+      Type: 'http',
+      TriggerDesc: triggerDesc,
+      Qualifier: '$DEFAULT',
+      Enable: 'OPEN',
+    });
+
+    logger.info(lang.__('HTTP_TRIGGER_CREATED', { triggerName, functionName: fn.name }));
+  }
+
+  // Create custom domain if configured
+  if (fn.domain) {
+    logger.info(lang.__('CREATING_CUSTOM_DOMAIN', { domainName: fn.domain.domain_name }));
+    await client.scf.createCustomDomain({
+      Domain: fn.domain.domain_name,
+      Protocol: fn.domain.protocol === 'HTTP,HTTPS' ? 'HTTP&HTTPS' : fn.domain.protocol,
+      EndpointsConfig: [
+        {
+          Namespace: 'default',
+          FunctionName: fn.name,
+          Qualifier: '$DEFAULT',
+          PathMatch: '/*',
+        },
+      ],
+      ...(fn.domain.certificate_id
+        ? { CertConfig: { CertificateId: fn.domain.certificate_id } }
+        : {}),
+    });
+    logger.info(lang.__('CUSTOM_DOMAIN_CREATED', { domainName: fn.domain.domain_name }));
+
+    const domainSid = buildSid(
+      'tencent',
+      'scf-custom-domain',
+      context.stage,
+      fn.domain.domain_name,
+    );
+    dependentInstances.push({
+      sid: domainSid,
+      type: 'TENCENT_SCF_CUSTOM_DOMAIN',
+      id: fn.domain.domain_name,
+    });
+  }
+
+  // Refresh state from provider to get all attributes (including triggers)
   const functionInfo = await client.scf.getFunction(fn.name);
   if (!functionInfo) {
     throw new Error(`Failed to refresh state for function: ${fn.name}`);
@@ -346,8 +409,13 @@ export const updateResource = async (
   state: StateFile,
 ): Promise<StateFile> => {
   const logicalId = `functions.${fn.key}`;
+
   const existingState = getResource(state, logicalId);
   const existingInstances = (existingState?.instances ?? []) as Array<Record<string, unknown>>;
+
+  const existingFnInstance = existingInstances.find(
+    (i) => (i as ScfDependentInstance).type === undefined,
+  ) as Record<string, unknown> | undefined;
 
   const hasCamRole = existingInstances.some((i) => i.type === ResourceTypeEnum.TENCENT_SCF_ROLE);
   const client = createTencentClient(context);
@@ -435,7 +503,144 @@ export const updateResource = async (
   // Update code
   await client.scf.updateFunctionCode(fn.name, codeBase64);
 
-  // Refresh state from provider to get all attributes
+  const existingHttpTrigger = (
+    existingFnInstance?.triggers as Array<Record<string, unknown>> | undefined
+  )?.find((t) => t.type === 'http');
+
+  const desiredHttpConfig = fn.triggers?.http;
+
+  if (desiredHttpConfig) {
+    if (!desiredHttpConfig.auth_type) {
+      throw new Error(lang.__('HTTP_TRIGGER_AUTH_TYPE_REQUIRED', { functionName: fn.name }));
+    }
+
+    const authType = mapAuthType(ProviderEnum.TENCENT, desiredHttpConfig.auth_type);
+    const access = mapAccess(desiredHttpConfig.access);
+    const triggerName = `${fn.key}-http-trigger`;
+    const desiredTriggerDesc = JSON.stringify({
+      authType,
+      ...(access.enableExtranet !== undefined ? { enableExtranet: access.enableExtranet } : {}),
+      ...(access.enableIntranet !== undefined ? { enableIntranet: access.enableIntranet } : {}),
+    });
+
+    if (existingHttpTrigger) {
+      if (existingHttpTrigger.triggerDesc !== desiredTriggerDesc) {
+        logger.info(lang.__('UPDATING_HTTP_TRIGGER', { functionName: fn.name }));
+        try {
+          await client.scf.deleteTrigger({
+            FunctionName: fn.name,
+            TriggerName: existingHttpTrigger.triggerName as string,
+            Type: 'http',
+          });
+        } catch (err) {
+          const errorCode = (err as { code?: string })?.code;
+          if (errorCode !== 'ResourceNotFound.TriggerName' && errorCode !== 'ResourceNotFound') {
+            throw err;
+          }
+        }
+        await client.scf.createTrigger({
+          FunctionName: fn.name,
+          TriggerName: triggerName,
+          Type: 'http',
+          TriggerDesc: desiredTriggerDesc,
+          Qualifier: '$DEFAULT',
+          Enable: 'OPEN',
+        });
+      }
+    } else {
+      logger.info(lang.__('CREATING_HTTP_TRIGGER', { triggerName, functionName: fn.name }));
+      await client.scf.createTrigger({
+        FunctionName: fn.name,
+        TriggerName: triggerName,
+        Type: 'http',
+        TriggerDesc: desiredTriggerDesc,
+        Qualifier: '$DEFAULT',
+        Enable: 'OPEN',
+      });
+      logger.info(lang.__('HTTP_TRIGGER_CREATED', { triggerName, functionName: fn.name }));
+    }
+  } else if (existingHttpTrigger) {
+    const tName = existingHttpTrigger.triggerName as string;
+    logger.info(lang.__('DELETING_HTTP_TRIGGER', { triggerName: tName, functionName: fn.name }));
+    try {
+      await client.scf.deleteTrigger({
+        FunctionName: fn.name,
+        TriggerName: tName,
+        Type: 'http',
+      });
+      logger.info(lang.__('HTTP_TRIGGER_DELETED', { triggerName: tName }));
+    } catch (err) {
+      const errorCode = (err as { code?: string })?.code;
+      if (errorCode === 'ResourceNotFound.TriggerName' || errorCode === 'ResourceNotFound') {
+        logger.warn(lang.__('HTTP_TRIGGER_NOT_FOUND', { triggerName: tName }));
+      } else {
+        throw err;
+      }
+    }
+  }
+
+  // Reconcile custom domain
+  const existingCustomDomain = existingInstances.find(
+    (i) => (i as ScfDependentInstance).type === 'TENCENT_SCF_CUSTOM_DOMAIN',
+  ) as ScfDependentInstance | undefined;
+
+  if (fn.domain && !existingCustomDomain) {
+    logger.info(lang.__('CREATING_CUSTOM_DOMAIN', { domainName: fn.domain.domain_name }));
+    await client.scf.createCustomDomain({
+      Domain: fn.domain.domain_name,
+      Protocol: fn.domain.protocol === 'HTTP,HTTPS' ? 'HTTP&HTTPS' : fn.domain.protocol,
+      EndpointsConfig: [
+        {
+          Namespace: 'default',
+          FunctionName: fn.name,
+          Qualifier: '$DEFAULT',
+          PathMatch: '/*',
+        },
+      ],
+      ...(fn.domain.certificate_id
+        ? { CertConfig: { CertificateId: fn.domain.certificate_id } }
+        : {}),
+    });
+    logger.info(lang.__('CUSTOM_DOMAIN_CREATED', { domainName: fn.domain.domain_name }));
+  } else if (!fn.domain && existingCustomDomain) {
+    logger.info(lang.__('DELETING_CUSTOM_DOMAIN', { domainName: existingCustomDomain.id }));
+    try {
+      await client.scf.deleteCustomDomain(existingCustomDomain.id);
+      logger.info(lang.__('CUSTOM_DOMAIN_DELETED', { domainName: existingCustomDomain.id }));
+    } catch (err) {
+      const errorCode = (err as { code?: string })?.code;
+      if (errorCode === 'ResourceNotFound') {
+        logger.warn(lang.__('HTTP_TRIGGER_NOT_FOUND', { triggerName: existingCustomDomain.id }));
+      } else {
+        throw err;
+      }
+    }
+  } else if (fn.domain && existingCustomDomain) {
+    const domainChanged = fn.domain.domain_name !== existingCustomDomain.id;
+    if (domainChanged) {
+      logger.info(lang.__('DELETING_CUSTOM_DOMAIN', { domainName: existingCustomDomain.id }));
+      await client.scf.deleteCustomDomain(existingCustomDomain.id);
+      logger.info(lang.__('CREATING_CUSTOM_DOMAIN', { domainName: fn.domain.domain_name }));
+      await client.scf.createCustomDomain({
+        Domain: fn.domain.domain_name,
+        Protocol: fn.domain.protocol === 'HTTP,HTTPS' ? 'HTTP&HTTPS' : fn.domain.protocol,
+        EndpointsConfig: [
+          {
+            Namespace: 'default',
+            FunctionName: fn.name,
+            Qualifier: '$DEFAULT',
+            PathMatch: '/*',
+          },
+        ],
+        ...(fn.domain.certificate_id
+          ? { CertConfig: { CertificateId: fn.domain.certificate_id } }
+          : {}),
+      });
+      logger.info(lang.__('CUSTOM_DOMAIN_CREATED', { domainName: fn.domain.domain_name }));
+    }
+  }
+
+  // Refresh state from provider to get all attributes (including triggers)
   const functionInfo = await client.scf.getFunction(fn.name);
   if (!functionInfo) {
     throw new Error(`Failed to refresh state for function: ${fn.name}`);
@@ -444,9 +649,12 @@ export const updateResource = async (
   const definition = extractScfDefinition(config, codeHash, fn.iam);
   const sid = buildSid('tencent', 'scf', context.stage, fn.name);
 
-  // Rebuild dependent instances list
   const existingDependentInstances = existingInstances
-    .filter((i) => (i as ScfDependentInstance).type !== undefined)
+    .filter(
+      (i) =>
+        (i as ScfDependentInstance).type !== undefined &&
+        (i as ScfDependentInstance).type !== 'TENCENT_SCF_CUSTOM_DOMAIN',
+    )
     .map((i) => {
       const { type, id, sid, roleArn, external } = i as ScfDependentInstance;
       return {
@@ -466,6 +674,20 @@ export const updateResource = async (
       type: ResourceTypeEnum.TENCENT_SCF_ROLE,
       id: role.roleName ?? '',
       ...(role.arn ? { roleArn: role.arn } : {}),
+    });
+  }
+
+  if (fn.domain) {
+    const domainSid = buildSid(
+      'tencent',
+      'scf-custom-domain',
+      context.stage,
+      fn.domain.domain_name,
+    );
+    newDependentInstances.push({
+      sid: domainSid,
+      type: 'TENCENT_SCF_CUSTOM_DOMAIN' as ResourceTypeEnum,
+      id: fn.domain.domain_name,
     });
   }
 
@@ -493,9 +715,60 @@ export const deleteResource = async (
   const existingState = getResource(state, logicalId);
   const existingInstances = (existingState?.instances ?? []) as Array<Record<string, unknown>>;
 
+  const client = createTencentClient(context);
+
+  // Delete HTTP trigger before deleting function
+  const fnInstance = existingInstances.find(
+    (i) => (i as ScfDependentInstance).type === undefined,
+  ) as Record<string, unknown> | undefined;
+  const httpTrigger = (fnInstance?.triggers as Array<Record<string, unknown>> | undefined)?.find(
+    (t) => t.type === 'http',
+  );
+  if (httpTrigger) {
+    try {
+      const triggerName = httpTrigger.triggerName as string;
+      logger.info(lang.__('DELETING_HTTP_TRIGGER', { triggerName, functionName }));
+      await client.scf.deleteTrigger({
+        FunctionName: functionName,
+        TriggerName: triggerName,
+        Type: 'http',
+      });
+      logger.info(lang.__('HTTP_TRIGGER_DELETED', { triggerName }));
+    } catch (err) {
+      const errorCode = (err as { code?: string })?.code;
+      if (errorCode === 'ResourceNotFound.TriggerName' || errorCode === 'ResourceNotFound') {
+        logger.warn(
+          lang.__('HTTP_TRIGGER_NOT_FOUND', {
+            triggerName: httpTrigger.triggerName as string,
+          }),
+        );
+      } else {
+        throw err;
+      }
+    }
+  }
+
+  // Delete custom domain before deleting function
+  const existingCustomDomain = existingInstances.find(
+    (i) => (i as ScfDependentInstance).type === 'TENCENT_SCF_CUSTOM_DOMAIN',
+  ) as ScfDependentInstance | undefined;
+  if (existingCustomDomain) {
+    try {
+      logger.info(lang.__('DELETING_CUSTOM_DOMAIN', { domainName: existingCustomDomain.id }));
+      await client.scf.deleteCustomDomain(existingCustomDomain.id);
+      logger.info(lang.__('CUSTOM_DOMAIN_DELETED', { domainName: existingCustomDomain.id }));
+    } catch (err) {
+      const errorCode = (err as { code?: string })?.code;
+      if (errorCode === 'ResourceNotFound') {
+        logger.warn(lang.__('HTTP_TRIGGER_NOT_FOUND', { triggerName: existingCustomDomain.id }));
+      } else {
+        throw err;
+      }
+    }
+  }
+
   const hasFunction = existingInstances.some((i) => (i as ScfDependentInstance).type === undefined);
 
-  const client = createTencentClient(context);
   if (hasFunction) {
     try {
       await client.scf.deleteFunction(functionName);
@@ -512,7 +785,9 @@ export const deleteResource = async (
   }
 
   const dependentInstances = existingInstances.filter(
-    (i) => (i as ScfDependentInstance).type !== undefined,
+    (i) =>
+      (i as ScfDependentInstance).type !== undefined &&
+      (i as ScfDependentInstance).type !== 'TENCENT_SCF_CUSTOM_DOMAIN',
   ) as Array<{ type: string; id: string; external?: boolean }>;
   if (dependentInstances.length > 0) {
     await deleteDependentResources(context, dependentInstances);

--- a/src/types/domains/function.ts
+++ b/src/types/domains/function.ts
@@ -1,5 +1,27 @@
 import { Resolvable } from './resolvable';
 
+export type HttpTriggerRaw = {
+  auth_type: Resolvable<'public' | 'iam'>;
+  access?: Array<Resolvable<'public' | 'internal'>>;
+};
+
+export type HttpTrigger = {
+  auth_type: 'public' | 'iam';
+  access?: Array<'public' | 'internal'>;
+};
+
+export type FunctionDomainConfigRaw = {
+  domain_name: Resolvable<string>;
+  certificate_id?: Resolvable<string>;
+  protocol?: Resolvable<string>;
+};
+
+export type FunctionDomainConfigParsed = {
+  domain_name: string;
+  certificate_id?: string;
+  protocol: string;
+};
+
 export type FunctionRaw = {
   name: Resolvable<string>;
   code?: {
@@ -42,6 +64,10 @@ export type FunctionRaw = {
           }>;
         };
   };
+  triggers?: {
+    http?: HttpTriggerRaw;
+  };
+  domain?: FunctionDomainConfigRaw;
   storage?: {
     disk?: Resolvable<number>;
     nas?: Array<{
@@ -94,6 +120,10 @@ export type FunctionDomain = {
           }>;
         };
   };
+  triggers?: {
+    http?: HttpTrigger;
+  };
+  domain?: FunctionDomainConfigParsed;
   storage: {
     disk?: number;
     nas?: Array<{

--- a/src/validator/functionSchema.ts
+++ b/src/validator/functionSchema.ts
@@ -159,6 +159,35 @@ export const functionSchema = {
             },
           },
         },
+        triggers: {
+          type: 'object',
+          additionalProperties: false,
+          properties: {
+            http: {
+              type: 'object',
+              required: ['auth_type'],
+              additionalProperties: false,
+              properties: {
+                auth_type: resolvableEnum(['public', 'iam']),
+                access: {
+                  type: 'array',
+                  items: resolvableEnum(['public', 'internal']),
+                  minItems: 1,
+                },
+              },
+            },
+          },
+        },
+        domain: {
+          type: 'object',
+          required: ['domain_name'],
+          additionalProperties: false,
+          properties: {
+            domain_name: { type: 'string' },
+            certificate_id: { type: 'string' },
+            protocol: resolvableEnum(['HTTP', 'HTTPS']),
+          },
+        },
         storage: {
           type: 'object',
           properties: {

--- a/tests/service/mockCloudClient.ts
+++ b/tests/service/mockCloudClient.ts
@@ -10,6 +10,9 @@ export type MockAliyunClient = {
     deleteFunction: jest.Mock;
     createTrigger: jest.Mock;
     deleteTrigger: jest.Mock;
+    createCustomDomain: jest.Mock;
+    getCustomDomain: jest.Mock;
+    deleteCustomDomain: jest.Mock;
   };
   apigw: {
     createApiGroup: jest.Mock;
@@ -109,6 +112,9 @@ export const createMockAliyunClient = (): MockAliyunClient => ({
     deleteFunction: jest.fn().mockResolvedValue({}),
     createTrigger: jest.fn().mockResolvedValue({ body: { triggerName: 'http-trigger' } }),
     deleteTrigger: jest.fn().mockResolvedValue({}),
+    createCustomDomain: jest.fn().mockResolvedValue({ body: { domainName: 'api.example.com' } }),
+    getCustomDomain: jest.fn().mockResolvedValue(null),
+    deleteCustomDomain: jest.fn().mockResolvedValue({}),
   },
   apigw: {
     createApiGroup: jest.fn().mockResolvedValue({ body: { groupId: 'group-123' } }),
@@ -213,6 +219,11 @@ export type MockTencentClient = {
     DeleteFunction: jest.Mock;
     UpdateFunctionCode: jest.Mock;
     UpdateFunctionConfiguration: jest.Mock;
+    CreateTrigger: jest.Mock;
+    DeleteTrigger: jest.Mock;
+    CreateCustomDomain: jest.Mock;
+    GetCustomDomain: jest.Mock;
+    DeleteCustomDomain: jest.Mock;
   };
   cos: {
     putBucket: jest.Mock;
@@ -233,6 +244,11 @@ export const createMockTencentClient = (): MockTencentClient => ({
     DeleteFunction: jest.fn().mockResolvedValue({}),
     UpdateFunctionCode: jest.fn().mockResolvedValue({}),
     UpdateFunctionConfiguration: jest.fn().mockResolvedValue({}),
+    CreateTrigger: jest.fn().mockResolvedValue({ TriggerName: 'http-trigger', Type: 'http' }),
+    DeleteTrigger: jest.fn().mockResolvedValue({}),
+    CreateCustomDomain: jest.fn().mockResolvedValue({}),
+    GetCustomDomain: jest.fn().mockResolvedValue(null),
+    DeleteCustomDomain: jest.fn().mockResolvedValue({}),
   },
   cos: {
     putBucket: jest.fn().mockResolvedValue({}),

--- a/tests/service/mockCloudClient.ts
+++ b/tests/service/mockCloudClient.ts
@@ -92,6 +92,9 @@ export type MockAliyunClient = {
     describeDomainRecords: jest.Mock;
     checkDomainRecordExists: jest.Mock;
   };
+  cas: {
+    getCertificate: jest.Mock;
+  };
 };
 
 export const createMockAliyunClient = (): MockAliyunClient => ({
@@ -209,6 +212,11 @@ export const createMockAliyunClient = (): MockAliyunClient => ({
     deleteDomainRecord: jest.fn().mockResolvedValue({}),
     describeDomainRecords: jest.fn().mockResolvedValue([]),
     checkDomainRecordExists: jest.fn().mockResolvedValue(false),
+  },
+  cas: {
+    getCertificate: jest
+      .fn()
+      .mockResolvedValue({ cert: 'fake-cert-content', key: 'fake-key-content' }),
   },
 });
 

--- a/tests/unit/common/aliyunClient/fc3Operations.test.ts
+++ b/tests/unit/common/aliyunClient/fc3Operations.test.ts
@@ -12,12 +12,22 @@ const mockCreateFunction = jest.fn();
 const mockGetFunction = jest.fn();
 const mockUpdateFunction = jest.fn();
 const mockDeleteFunction = jest.fn();
+const mockCreateTrigger = jest.fn();
+const mockDeleteTrigger = jest.fn();
+const mockCreateCustomDomain = jest.fn();
+const mockGetCustomDomain = jest.fn();
+const mockDeleteCustomDomain = jest.fn();
 
 const mockFc3Client = {
   createFunction: mockCreateFunction,
   getFunction: mockGetFunction,
   updateFunction: mockUpdateFunction,
   deleteFunction: mockDeleteFunction,
+  createTrigger: mockCreateTrigger,
+  deleteTrigger: mockDeleteTrigger,
+  createCustomDomain: mockCreateCustomDomain,
+  getCustomDomain: mockGetCustomDomain,
+  deleteCustomDomain: mockDeleteCustomDomain,
 } as unknown as Fc3Client;
 
 jest.mock('../../../../src/common/logger', () => ({
@@ -406,6 +416,152 @@ describe('fc3Operations', () => {
       mockDeleteFunction.mockRejectedValue(new Error('AccessDenied'));
 
       await expect(operations.deleteFunction('test-function')).rejects.toThrow('AccessDenied');
+    });
+  });
+
+  describe('createTrigger', () => {
+    it('should create trigger with config', async () => {
+      await operations.createTrigger(
+        'test-function',
+        'http-trigger',
+        'http',
+        { authType: 'anonymous', methods: ['GET'] },
+        '$LATEST',
+      );
+
+      expect(mockCreateTrigger).toHaveBeenCalledTimes(1);
+      const [fnName, request] = mockCreateTrigger.mock.calls[0];
+      expect(fnName).toBe('test-function');
+      expect(request.body.triggerName).toBe('http-trigger');
+      expect(request.body.triggerType).toBe('http');
+      expect(request.body.triggerConfig).toBe(
+        JSON.stringify({ authType: 'anonymous', methods: ['GET'] }),
+      );
+      expect(request.body.qualifier).toBe('$LATEST');
+    });
+
+    it('should create trigger without qualifier', async () => {
+      await operations.createTrigger('test-function', 'timer-trigger', 'timer', {
+        cron: '* * * * *',
+      });
+
+      expect(mockCreateTrigger).toHaveBeenCalledTimes(1);
+      const [fnName, request] = mockCreateTrigger.mock.calls[0];
+      expect(fnName).toBe('test-function');
+      expect(request.body.qualifier).toBeUndefined();
+    });
+
+    it('should propagate SDK errors', async () => {
+      mockCreateTrigger.mockRejectedValue(new Error('TriggerAlreadyExists'));
+
+      await expect(
+        operations.createTrigger('test-function', 'http-trigger', 'http', {}),
+      ).rejects.toThrow('TriggerAlreadyExists');
+    });
+  });
+
+  describe('deleteTrigger', () => {
+    it('should delete trigger successfully', async () => {
+      await operations.deleteTrigger('test-function', 'http-trigger');
+
+      expect(mockDeleteTrigger).toHaveBeenCalledWith('test-function', 'http-trigger');
+    });
+
+    it('should propagate SDK errors', async () => {
+      mockDeleteTrigger.mockRejectedValue(new Error('TriggerNotFound'));
+
+      await expect(operations.deleteTrigger('test-function', 'http-trigger')).rejects.toThrow(
+        'TriggerNotFound',
+      );
+    });
+  });
+
+  describe('createCustomDomain', () => {
+    it('should create custom domain with route to function', async () => {
+      await operations.createCustomDomain('api.example.com', 'HTTPS', 'test-function');
+
+      expect(mockCreateCustomDomain).toHaveBeenCalledTimes(1);
+      const [request] = mockCreateCustomDomain.mock.calls[0];
+      expect(request.body.domainName).toBe('api.example.com');
+      expect(request.body.protocol).toBe('HTTPS');
+      expect(request.body.routeConfig.routes[0].path).toBe('/*');
+      expect(request.body.routeConfig.routes[0].functionName).toBe('test-function');
+      expect(request.body.certConfig).toBeUndefined();
+    });
+
+    it('should create custom domain with cert config', async () => {
+      await operations.createCustomDomain('api.example.com', 'HTTPS', 'test-function', {
+        certName: 'my-cert',
+        certificate: 'PEM-CERT',
+        privateKey: 'PEM-KEY',
+      });
+
+      expect(mockCreateCustomDomain).toHaveBeenCalledTimes(1);
+      const [request] = mockCreateCustomDomain.mock.calls[0];
+      expect(request.body.certConfig.certName).toBe('my-cert');
+      expect(request.body.certConfig.certificate).toBe('PEM-CERT');
+      expect(request.body.certConfig.privateKey).toBe('PEM-KEY');
+    });
+
+    it('should propagate SDK errors', async () => {
+      mockCreateCustomDomain.mockRejectedValue(new Error('DomainAlreadyExists'));
+
+      await expect(
+        operations.createCustomDomain('api.example.com', 'HTTPS', 'test-function'),
+      ).rejects.toThrow('DomainAlreadyExists');
+    });
+  });
+
+  describe('getCustomDomain', () => {
+    it('should return custom domain info', async () => {
+      mockGetCustomDomain.mockResolvedValue({
+        body: {
+          domainName: 'api.example.com',
+          protocol: 'HTTPS',
+          certConfig: { certName: 'my-cert', certificateId: '123' },
+        },
+      });
+
+      const result = await operations.getCustomDomain('api.example.com');
+
+      expect(mockGetCustomDomain).toHaveBeenCalledWith('api.example.com');
+      expect(result).toEqual({
+        domainName: 'api.example.com',
+        protocol: 'HTTPS',
+        certConfig: { certName: 'my-cert', certificateId: '123' },
+      });
+    });
+
+    it('should return null when domain not found', async () => {
+      const error = Object.assign(new Error('not found'), { code: 'CustomDomainNotFound' });
+      mockGetCustomDomain.mockRejectedValue(error);
+
+      const result = await operations.getCustomDomain('nonexistent.example.com');
+
+      expect(result).toBeNull();
+    });
+
+    it('should propagate unexpected errors', async () => {
+      const error = new Error('unauthorized');
+      mockGetCustomDomain.mockRejectedValue(error);
+
+      await expect(operations.getCustomDomain('api.example.com')).rejects.toThrow('unauthorized');
+    });
+  });
+
+  describe('deleteCustomDomain', () => {
+    it('should delete custom domain successfully', async () => {
+      await operations.deleteCustomDomain('api.example.com');
+
+      expect(mockDeleteCustomDomain).toHaveBeenCalledWith('api.example.com');
+    });
+
+    it('should propagate SDK errors', async () => {
+      mockDeleteCustomDomain.mockRejectedValue(new Error('AccessDenied'));
+
+      await expect(operations.deleteCustomDomain('api.example.com')).rejects.toThrow(
+        'AccessDenied',
+      );
     });
   });
 });

--- a/tests/unit/common/tencentClient/scfOperations.test.ts
+++ b/tests/unit/common/tencentClient/scfOperations.test.ts
@@ -93,6 +93,27 @@ describe('scfOperations', () => {
       );
     });
 
+    it('should create function with Role when provided', async () => {
+      mockScfClient.CreateFunction.mockResolvedValue({});
+
+      const config = {
+        FunctionName: 'test-function',
+        Handler: 'index.handler',
+        Runtime: 'nodejs18.x',
+        MemorySize: 256,
+        Timeout: 30,
+        Role: 'role-id-123',
+      };
+
+      await operations.createFunction(config, 'BASE64_CODE');
+
+      expect(mockScfClient.CreateFunction).toHaveBeenCalledWith(
+        expect.objectContaining({
+          Role: 'role-id-123',
+        }),
+      );
+    });
+
     it('should handle SDK errors during creation', async () => {
       const error = new Error('CreateFunction failed');
       mockScfClient.CreateFunction.mockRejectedValue(error);
@@ -241,6 +262,48 @@ describe('scfOperations', () => {
       expect(result).toBeNull();
     });
 
+    it('should default missing environment variable, trigger, and tag fields', async () => {
+      mockScfClient.GetFunction.mockResolvedValue({
+        FunctionName: 'test-function',
+        Runtime: 'nodejs18.x',
+        Handler: 'index.handler',
+        MemorySize: 256,
+        Timeout: 30,
+        Environment: {
+          Variables: [{}, { Key: 'NODE_ENV' }],
+        },
+        Triggers: [{}, { Type: 'timer' }],
+        Tags: [{}, { Key: 'team' }],
+      });
+
+      const result = await operations.getFunction('test-function');
+
+      expect(result?.Environment?.Variables).toEqual([
+        { Key: '', Value: '' },
+        { Key: 'NODE_ENV', Value: '' },
+      ]);
+      expect(result?.Triggers?.[0]).toEqual(
+        expect.objectContaining({
+          ModTime: '',
+          Type: '',
+          TriggerDesc: '',
+          TriggerName: '',
+          AddTime: '',
+          Enable: 0,
+        }),
+      );
+      expect(result?.Triggers?.[1]).toEqual(
+        expect.objectContaining({
+          Type: 'timer',
+          Enable: 0,
+        }),
+      );
+      expect(result?.Tags).toEqual([
+        { Key: '', Value: '' },
+        { Key: 'team', Value: '' },
+      ]);
+    });
+
     it('should rethrow unexpected errors', async () => {
       const error = new Error('unauthorized');
       mockScfClient.GetFunction.mockRejectedValue(error);
@@ -310,6 +373,27 @@ describe('scfOperations', () => {
       expect(mockScfClient.UpdateFunctionConfiguration).toHaveBeenCalledWith(
         expect.objectContaining({
           Environment: config.Environment,
+        }),
+      );
+    });
+
+    it('should include Role in updateFunctionConfiguration when provided', async () => {
+      mockScfClient.UpdateFunctionConfiguration.mockResolvedValue({});
+
+      const config = {
+        FunctionName: 'test-function',
+        Handler: 'index.handler',
+        Runtime: 'nodejs18.x',
+        MemorySize: 512,
+        Timeout: 60,
+        Role: 'role-id-123',
+      };
+
+      await operations.updateFunctionConfiguration(config);
+
+      expect(mockScfClient.UpdateFunctionConfiguration).toHaveBeenCalledWith(
+        expect.objectContaining({
+          Role: 'role-id-123',
         }),
       );
     });
@@ -524,6 +608,15 @@ describe('scfOperations', () => {
           { FunctionName: 'test-function', Qualifier: '$DEFAULT', PathMatch: '/*' },
         ],
       });
+    });
+
+    it('should return null when GetCustomDomain response is empty', async () => {
+      mockScfClient.GetCustomDomain.mockResolvedValue(undefined);
+
+      const result = await operations.getCustomDomain('api.example.com');
+
+      expect(mockScfClient.GetCustomDomain).toHaveBeenCalledWith({ Domain: 'api.example.com' });
+      expect(result).toBeNull();
     });
 
     it('should return null when domain not found', async () => {

--- a/tests/unit/common/tencentClient/scfOperations.test.ts
+++ b/tests/unit/common/tencentClient/scfOperations.test.ts
@@ -23,6 +23,11 @@ const mockScfClient = {
   UpdateFunctionConfiguration: jest.fn(),
   UpdateFunctionCode: jest.fn(),
   DeleteFunction: jest.fn(),
+  CreateTrigger: jest.fn(),
+  DeleteTrigger: jest.fn(),
+  CreateCustomDomain: jest.fn(),
+  GetCustomDomain: jest.fn(),
+  DeleteCustomDomain: jest.fn(),
 };
 
 describe('scfOperations', () => {
@@ -361,6 +366,199 @@ describe('scfOperations', () => {
       mockScfClient.DeleteFunction.mockRejectedValue(error);
 
       await expect(operations.deleteFunction('test-function')).rejects.toThrow('delete failed');
+    });
+  });
+
+  describe('createTrigger', () => {
+    it('should create trigger with all params', async () => {
+      mockScfClient.CreateTrigger.mockResolvedValue({});
+
+      await operations.createTrigger({
+        FunctionName: 'test-function',
+        TriggerName: 'http-trigger',
+        Type: 'http',
+        TriggerDesc: '{"authType":"NONE"}',
+        Qualifier: '$DEFAULT',
+        Enable: 'OPEN',
+      });
+
+      expect(mockScfClient.CreateTrigger).toHaveBeenCalledWith({
+        FunctionName: 'test-function',
+        TriggerName: 'http-trigger',
+        Type: 'http',
+        TriggerDesc: '{"authType":"NONE"}',
+        Qualifier: '$DEFAULT',
+        Enable: 'OPEN',
+      });
+    });
+
+    it('should create trigger with only required params', async () => {
+      mockScfClient.CreateTrigger.mockResolvedValue({});
+
+      await operations.createTrigger({
+        FunctionName: 'test-function',
+        TriggerName: 'timer-trigger',
+        Type: 'timer',
+      });
+
+      expect(mockScfClient.CreateTrigger).toHaveBeenCalledWith({
+        FunctionName: 'test-function',
+        TriggerName: 'timer-trigger',
+        Type: 'timer',
+      });
+    });
+
+    it('should propagate SDK errors', async () => {
+      const error = new Error('CreateTrigger failed');
+      mockScfClient.CreateTrigger.mockRejectedValue(error);
+
+      await expect(
+        operations.createTrigger({
+          FunctionName: 'test-function',
+          TriggerName: 'http-trigger',
+          Type: 'http',
+        }),
+      ).rejects.toThrow('CreateTrigger failed');
+    });
+  });
+
+  describe('deleteTrigger', () => {
+    it('should delete trigger successfully', async () => {
+      mockScfClient.DeleteTrigger.mockResolvedValue({});
+
+      await operations.deleteTrigger({
+        FunctionName: 'test-function',
+        TriggerName: 'http-trigger',
+        Type: 'http',
+      });
+
+      expect(mockScfClient.DeleteTrigger).toHaveBeenCalledWith({
+        FunctionName: 'test-function',
+        TriggerName: 'http-trigger',
+        Type: 'http',
+      });
+    });
+
+    it('should propagate SDK errors', async () => {
+      const error = new Error('DeleteTrigger failed');
+      mockScfClient.DeleteTrigger.mockRejectedValue(error);
+
+      await expect(
+        operations.deleteTrigger({
+          FunctionName: 'test-function',
+          TriggerName: 'http-trigger',
+          Type: 'http',
+        }),
+      ).rejects.toThrow('DeleteTrigger failed');
+    });
+  });
+
+  describe('createCustomDomain', () => {
+    it('should create custom domain with endpoints config', async () => {
+      mockScfClient.CreateCustomDomain.mockResolvedValue({});
+
+      await operations.createCustomDomain({
+        Domain: 'api.example.com',
+        Protocol: 'HTTPS',
+        EndpointsConfig: [
+          {
+            Namespace: 'default',
+            FunctionName: 'test-function',
+            Qualifier: '$DEFAULT',
+            PathMatch: '/*',
+          },
+        ],
+      });
+
+      expect(mockScfClient.CreateCustomDomain).toHaveBeenCalledWith({
+        Domain: 'api.example.com',
+        Protocol: 'HTTPS',
+        EndpointsConfig: [
+          {
+            Namespace: 'default',
+            FunctionName: 'test-function',
+            Qualifier: '$DEFAULT',
+            PathMatch: '/*',
+          },
+        ],
+      });
+    });
+
+    it('should create custom domain with cert config', async () => {
+      mockScfClient.CreateCustomDomain.mockResolvedValue({});
+
+      await operations.createCustomDomain({
+        Domain: 'api.example.com',
+        Protocol: 'HTTPS',
+        EndpointsConfig: [
+          { Namespace: 'default', FunctionName: 'fn', Qualifier: '$DEFAULT', PathMatch: '/*' },
+        ],
+        CertConfig: { CertificateId: 'cert-123' },
+      });
+
+      expect(mockScfClient.CreateCustomDomain).toHaveBeenCalledWith(
+        expect.objectContaining({
+          CertConfig: { CertificateId: 'cert-123' },
+        }),
+      );
+    });
+  });
+
+  describe('getCustomDomain', () => {
+    it('should return custom domain info', async () => {
+      mockScfClient.GetCustomDomain.mockResolvedValue({
+        Domain: 'api.example.com',
+        Protocol: 'HTTPS',
+        EndpointsConfig: [
+          { FunctionName: 'test-function', Qualifier: '$DEFAULT', PathMatch: '/*' },
+        ],
+      });
+
+      const result = await operations.getCustomDomain('api.example.com');
+
+      expect(mockScfClient.GetCustomDomain).toHaveBeenCalledWith({ Domain: 'api.example.com' });
+      expect(result).toEqual({
+        Domain: 'api.example.com',
+        Protocol: 'HTTPS',
+        EndpointsConfig: [
+          { FunctionName: 'test-function', Qualifier: '$DEFAULT', PathMatch: '/*' },
+        ],
+      });
+    });
+
+    it('should return null when domain not found', async () => {
+      const error = Object.assign(new Error('not found'), { code: 'ResourceNotFound' });
+      mockScfClient.GetCustomDomain.mockRejectedValue(error);
+
+      const result = await operations.getCustomDomain('nonexistent.example.com');
+
+      expect(result).toBeNull();
+    });
+
+    it('should propagate unexpected errors', async () => {
+      const error = new Error('unauthorized');
+      mockScfClient.GetCustomDomain.mockRejectedValue(error);
+
+      await expect(operations.getCustomDomain('api.example.com')).rejects.toThrow('unauthorized');
+    });
+  });
+
+  describe('deleteCustomDomain', () => {
+    it('should delete custom domain successfully', async () => {
+      mockScfClient.DeleteCustomDomain.mockResolvedValue({});
+
+      await operations.deleteCustomDomain('api.example.com');
+
+      expect(mockScfClient.DeleteCustomDomain).toHaveBeenCalledWith({ Domain: 'api.example.com' });
+    });
+
+    it('should propagate SDK errors', async () => {
+      const error = new Error('DeleteCustomDomain failed');
+      mockScfClient.DeleteCustomDomain.mockRejectedValue(error);
+
+      await expect(operations.deleteCustomDomain('api.example.com')).rejects.toThrow(
+        'DeleteCustomDomain failed',
+      );
     });
   });
 });

--- a/tests/unit/common/triggerMapper.test.ts
+++ b/tests/unit/common/triggerMapper.test.ts
@@ -1,0 +1,81 @@
+import { mapAuthType, mapAccess, mapAliyunAccess } from '../../../src/common/triggerMapper';
+import { ProviderEnum } from '../../../src/common/providerEnum';
+
+describe('triggerMapper', () => {
+  describe('mapAuthType', () => {
+    it('should map Tencent public -> NONE', () => {
+      expect(mapAuthType(ProviderEnum.TENCENT, 'public')).toBe('NONE');
+    });
+
+    it('should map Tencent iam -> CAM', () => {
+      expect(mapAuthType(ProviderEnum.TENCENT, 'iam')).toBe('CAM');
+    });
+
+    it('should map Aliyun public -> anonymous', () => {
+      expect(mapAuthType(ProviderEnum.ALIYUN, 'public')).toBe('anonymous');
+    });
+
+    it('should map Aliyun iam -> function', () => {
+      expect(mapAuthType(ProviderEnum.ALIYUN, 'iam')).toBe('function');
+    });
+
+    it('should map AWS public -> NONE', () => {
+      expect(mapAuthType(ProviderEnum.AWS, 'public')).toBe('NONE');
+    });
+
+    it('should map AWS iam -> AWS_IAM', () => {
+      expect(mapAuthType(ProviderEnum.AWS, 'iam')).toBe('AWS_IAM');
+    });
+
+    it('should default unknown provider to NONE for public', () => {
+      expect(mapAuthType('UNKNOWN' as ProviderEnum, 'public')).toBe('NONE');
+    });
+
+    it('should default unknown provider to CAM for iam', () => {
+      expect(mapAuthType('UNKNOWN' as ProviderEnum, 'iam')).toBe('CAM');
+    });
+  });
+
+  describe('mapAccess', () => {
+    it('should return empty when access is undefined', () => {
+      expect(mapAccess(undefined)).toEqual({});
+    });
+
+    it('should return empty when access is empty array', () => {
+      expect(mapAccess([])).toEqual({});
+    });
+
+    it('should map [public] -> extranet only', () => {
+      expect(mapAccess(['public'])).toEqual({ enableExtranet: true, enableIntranet: false });
+    });
+
+    it('should map [internal] -> intranet only', () => {
+      expect(mapAccess(['internal'])).toEqual({ enableExtranet: false, enableIntranet: true });
+    });
+
+    it('should map [public, internal] -> both', () => {
+      expect(mapAccess(['public', 'internal'])).toEqual({
+        enableExtranet: true,
+        enableIntranet: true,
+      });
+    });
+  });
+
+  describe('mapAliyunAccess', () => {
+    it('should return empty when access is undefined', () => {
+      expect(mapAliyunAccess(undefined)).toEqual({});
+    });
+
+    it('should not disable URL internet when public access is allowed', () => {
+      expect(mapAliyunAccess(['public'])).toEqual({ disableURLInternet: false });
+    });
+
+    it('should disable URL internet when only internal access', () => {
+      expect(mapAliyunAccess(['internal'])).toEqual({ disableURLInternet: true });
+    });
+
+    it('should not disable URL internet when both public and internal', () => {
+      expect(mapAliyunAccess(['public', 'internal'])).toEqual({ disableURLInternet: false });
+    });
+  });
+});

--- a/tests/unit/parser/functionParser.test.ts
+++ b/tests/unit/parser/functionParser.test.ts
@@ -238,4 +238,115 @@ describe('parseFunction', () => {
     expect(result![0].memory).toBe(256);
     expect(result![0].timeout).toBe(30);
   });
+
+  describe('triggers.http', () => {
+    it('should parse triggers.http with public auth_type', () => {
+      const result = parseFunction({
+        fn: {
+          name: 'http-fn',
+          code: { runtime: 'nodejs18', handler: 'index.handler', path: './src' },
+          triggers: { http: { auth_type: 'public' as const } },
+        },
+      });
+
+      expect(result![0].triggers).toEqual({ http: { auth_type: 'public', access: undefined } });
+    });
+
+    it('should parse triggers.http with iam auth_type', () => {
+      const result = parseFunction({
+        fn: {
+          name: 'http-fn',
+          triggers: { http: { auth_type: 'iam' as const } },
+        },
+      });
+
+      expect(result![0].triggers?.http?.auth_type).toBe('iam');
+    });
+
+    it('should parse triggers.http with access array', () => {
+      const result = parseFunction({
+        fn: {
+          name: 'http-fn',
+          triggers: {
+            http: {
+              auth_type: 'public' as const,
+              access: ['public' as const, 'internal' as const],
+            },
+          },
+        },
+      });
+
+      expect(result![0].triggers?.http?.access).toEqual(['public', 'internal']);
+    });
+
+    it('should throw when auth_type is missing', () => {
+      expect(() =>
+        parseFunction({
+          fn: {
+            name: 'http-fn',
+            triggers: { http: { auth_type: undefined as unknown as 'public' | 'iam' } },
+          },
+        }),
+      ).toThrow('HTTP_TRIGGER_AUTH_TYPE_REQUIRED');
+    });
+
+    it('should throw on invalid auth_type', () => {
+      expect(() =>
+        parseFunction({
+          fn: {
+            name: 'http-fn',
+            triggers: { http: { auth_type: 'invalid' as 'public' | 'iam' } },
+          },
+        }),
+      ).toThrow('INVALID_HTTP_TRIGGER_AUTH_TYPE');
+    });
+
+    it('should not include triggers key when no http trigger is set', () => {
+      const result = parseFunction({
+        fn: { name: 'no-trigger-fn' },
+      });
+
+      expect(result![0]).not.toHaveProperty('triggers');
+    });
+  });
+
+  describe('domain', () => {
+    it('should parse domain with domain_name only', () => {
+      const result = parseFunction({
+        fn: {
+          name: 'domain-fn',
+          domain: { domain_name: 'api.example.com' },
+        },
+      });
+
+      expect(result![0].domain).toEqual({
+        domain_name: 'api.example.com',
+        certificate_id: undefined,
+        protocol: 'HTTPS',
+      });
+    });
+
+    it('should parse domain with certificate_id and protocol', () => {
+      const result = parseFunction({
+        fn: {
+          name: 'domain-fn',
+          domain: { domain_name: 'api.example.com', certificate_id: 'cert-123', protocol: 'HTTP' },
+        },
+      });
+
+      expect(result![0].domain).toEqual({
+        domain_name: 'api.example.com',
+        certificate_id: 'cert-123',
+        protocol: 'HTTP',
+      });
+    });
+
+    it('should not include domain key when no domain is set', () => {
+      const result = parseFunction({
+        fn: { name: 'no-domain-fn' },
+      });
+
+      expect(result![0]).not.toHaveProperty('domain');
+    });
+  });
 });

--- a/tests/unit/parser/functionParser.test.ts
+++ b/tests/unit/parser/functionParser.test.ts
@@ -196,6 +196,97 @@ describe('parseFunction', () => {
     });
   });
 
+  it('should parse iam.role as a string (external role)', () => {
+    const result = parseFunction({
+      fn: {
+        name: 'external-role-fn',
+        code: { runtime: 'nodejs18', handler: 'index.handler', path: './src' },
+        iam: { role: 'acs:ram::123456789012:role/external-role' },
+      },
+    });
+
+    expect(result![0].iam).toEqual({ role: 'acs:ram::123456789012:role/external-role' });
+  });
+
+  it('should parse iam.role object with name and managed_policies', () => {
+    const result = parseFunction({
+      fn: {
+        name: 'role-fn',
+        code: { runtime: 'nodejs18', handler: 'index.handler', path: './src' },
+        iam: {
+          role: {
+            name: 'custom-role',
+            managed_policies: ['AliyunOSSFullAccess', 'AliyunLogFullAccess'],
+          },
+        },
+      },
+    });
+
+    expect(result![0].iam).toEqual({
+      role: {
+        name: 'custom-role',
+        managed_policies: ['AliyunOSSFullAccess', 'AliyunLogFullAccess'],
+      },
+    });
+  });
+
+  it('should parse iam.role object without name or managed_policies', () => {
+    const result = parseFunction({
+      fn: {
+        name: 'minimal-role-fn',
+        code: { runtime: 'nodejs18', handler: 'index.handler', path: './src' },
+        iam: { role: {} },
+      },
+    });
+
+    expect(result![0].iam).toEqual({ role: {} });
+  });
+
+  it('should parse statements with single string action and resource', () => {
+    const result = parseFunction({
+      fn: {
+        name: 'single-statement-fn',
+        code: { runtime: 'nodejs18', handler: 'index.handler', path: './src' },
+        iam: {
+          role: {
+            statements: [
+              {
+                effect: 'Allow' as const,
+                action: 'log:PostLogStoreLogs',
+                resource: 'acs:log:*:*:project/*/logstore/*',
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    expect(result![0].iam).toEqual({
+      role: {
+        statements: [
+          {
+            sid: undefined,
+            effect: 'Allow',
+            action: ['log:PostLogStoreLogs'],
+            resource: ['acs:log:*:*:project/*/logstore/*'],
+          },
+        ],
+      },
+    });
+  });
+
+  it('should parse iam object without role', () => {
+    const result = parseFunction({
+      fn: {
+        name: 'no-role-fn',
+        code: { runtime: 'nodejs18', handler: 'index.handler', path: './src' },
+        iam: {},
+      },
+    });
+
+    expect(result![0].iam).toEqual({ role: undefined });
+  });
+
   it('should parse function without iam statements', () => {
     const result = parseFunction({
       fn: {

--- a/tests/unit/stack/aliyunStack/fc3Resource.test.ts
+++ b/tests/unit/stack/aliyunStack/fc3Resource.test.ts
@@ -71,6 +71,9 @@ const mockedOssOperations = {
   createBucket: jest.fn(),
   putFile: jest.fn(),
 };
+const mockedCasOperations = {
+  getCertificate: jest.fn(),
+};
 const mockedLogger = {
   info: jest.fn(),
   error: jest.fn(),
@@ -85,7 +88,7 @@ jest.mock('../../../../src/common/aliyunClient', () => ({
     ram: mockedRamOperations,
     ecs: mockedEcsOperations,
     nas: mockedNasOperations,
-    cas: { getCertificate: jest.fn().mockResolvedValue({ cert: 'c', key: 'k' }) },
+    cas: mockedCasOperations,
   }),
 }));
 
@@ -255,6 +258,14 @@ describe('Fc3Resource', () => {
     mockedOssOperations.putFile.mockResolvedValue(undefined);
 
     mockedStatSync.mockReturnValue({ size: 1024 });
+
+    mockedCasOperations.getCertificate.mockResolvedValue({ cert: 'c', key: 'k' });
+
+    // Trigger/domain operations default to success to avoid cross-test contamination
+    mockedFc3Operations.createTrigger.mockResolvedValue(undefined);
+    mockedFc3Operations.deleteTrigger.mockResolvedValue(undefined);
+    mockedFc3Operations.createCustomDomain.mockResolvedValue(undefined);
+    mockedFc3Operations.deleteCustomDomain.mockResolvedValue(undefined);
 
     mockedStateManager.setResource.mockReturnValue(undefined);
     mockedStateManager.removeResource.mockReturnValue(undefined);
@@ -665,6 +676,56 @@ describe('Fc3Resource', () => {
         undefined,
       );
     });
+
+    it('should fetch certificate from CAS and pass certConfig when domain has certificate_id', async () => {
+      const fnWithCert = {
+        ...testFunction,
+        domain: {
+          domain_name: 'api.example.com',
+          protocol: 'HTTPS',
+          certificate_id: 'cert-123',
+        },
+      };
+
+      const readyState = {
+        ...initialState,
+        resources: { 'functions.test_fn': expect.anything() },
+      };
+      mockedStateManager.setResource.mockReturnValue(readyState);
+      mockedCasOperations.getCertificate.mockResolvedValue({ cert: 'cert-body', key: 'key-body' });
+
+      await createResource(mockContext, fnWithCert, initialState);
+
+      expect(mockedCasOperations.getCertificate).toHaveBeenCalledWith('cert-123');
+      expect(mockedFc3Operations.createCustomDomain).toHaveBeenCalledWith(
+        'api.example.com',
+        'HTTPS',
+        'test-function',
+        {
+          certName: 'test-service-default-fc3-domain',
+          certificate: 'cert-body',
+          privateKey: 'key-body',
+        },
+      );
+    });
+
+    it('should throw CERT_REFERENCE_NOT_FOUND when certificate is missing from CAS', async () => {
+      const fnWithCert = {
+        ...testFunction,
+        domain: {
+          domain_name: 'api.example.com',
+          protocol: 'HTTPS',
+          certificate_id: 'cert-missing',
+        },
+      };
+
+      mockedCasOperations.getCertificate.mockResolvedValue(null);
+
+      await expect(createResource(mockContext, fnWithCert, initialState)).rejects.toThrow(
+        'Certificate reference "cert-missing" could not be resolved.',
+      );
+      expect(mockedFc3Operations.createCustomDomain).not.toHaveBeenCalled();
+    });
   });
 
   describe('readResource', () => {
@@ -1003,6 +1064,507 @@ describe('Fc3Resource', () => {
         'http-trigger',
       );
       expect(mockedFc3Operations.deleteCustomDomain).toHaveBeenCalledWith('api.example.com');
+    });
+
+    it('should ignore TriggerNotFound when deleting HTTP trigger during update', async () => {
+      const fnWithoutLifecycle = { ...testFunction };
+
+      const stateWithTrigger: StateFile = {
+        ...initialState,
+        resources: {
+          'functions.test_fn': {
+            mode: 'managed',
+            region: 'cn-hangzhou',
+            definition: mockDefinition,
+            instances: [
+              {
+                sid: 'si:aliyun:fc3:default:test-function',
+                id: 'test-function',
+                type: 'ALIYUN_FC3_FUNCTION',
+              },
+              {
+                sid: 'si:aliyun:fc3-http-trigger:default:test-function',
+                id: 'http-trigger',
+                type: 'ALIYUN_FC3_HTTP_TRIGGER',
+              },
+            ],
+            lastUpdated: '2025-01-01T00:00:00Z',
+          },
+        },
+      };
+
+      mockedFc3Operations.updateFunctionConfiguration.mockResolvedValue(undefined);
+      mockedFc3Operations.updateFunctionCode.mockResolvedValue(undefined);
+      mockedFc3Operations.deleteTrigger.mockRejectedValue({ code: 'TriggerNotFound' });
+      mockedStateManager.setResource.mockReturnValue(initialState);
+
+      await updateResource(mockContext, fnWithoutLifecycle, stateWithTrigger);
+
+      expect(mockedFc3Operations.deleteTrigger).toHaveBeenCalledWith(
+        'test-function',
+        'http-trigger',
+      );
+      expect(mockedLogger.warn).toHaveBeenCalled();
+    });
+
+    it('should rethrow unexpected errors when deleting HTTP trigger during update', async () => {
+      const fnWithoutLifecycle = { ...testFunction };
+
+      const stateWithTrigger: StateFile = {
+        ...initialState,
+        resources: {
+          'functions.test_fn': {
+            mode: 'managed',
+            region: 'cn-hangzhou',
+            definition: mockDefinition,
+            instances: [
+              {
+                sid: 'si:aliyun:fc3:default:test-function',
+                id: 'test-function',
+                type: 'ALIYUN_FC3_FUNCTION',
+              },
+              {
+                sid: 'si:aliyun:fc3-http-trigger:default:test-function',
+                id: 'http-trigger',
+                type: 'ALIYUN_FC3_HTTP_TRIGGER',
+              },
+            ],
+            lastUpdated: '2025-01-01T00:00:00Z',
+          },
+        },
+      };
+
+      mockedFc3Operations.updateFunctionConfiguration.mockResolvedValue(undefined);
+      mockedFc3Operations.updateFunctionCode.mockResolvedValue(undefined);
+      mockedFc3Operations.deleteTrigger.mockRejectedValue(
+        Object.assign(new Error('Forbidden'), { code: 'Forbidden' }),
+      );
+
+      await expect(
+        updateResource(mockContext, fnWithoutLifecycle, stateWithTrigger),
+      ).rejects.toThrow('Forbidden');
+    });
+
+    it('should recreate HTTP trigger when trigger config changes during update', async () => {
+      const fnWithTrigger = {
+        ...testFunction,
+        triggers: { http: { auth_type: 'public' as const } },
+      };
+
+      const stateWithOldTriggerConfig: StateFile = {
+        ...initialState,
+        resources: {
+          'functions.test_fn': {
+            mode: 'managed',
+            region: 'cn-hangzhou',
+            definition: mockDefinition,
+            instances: [
+              {
+                sid: 'si:aliyun:fc3:default:test-function',
+                id: 'test-function',
+                type: 'ALIYUN_FC3_FUNCTION',
+              },
+              {
+                sid: 'si:aliyun:fc3-http-trigger:default:test-function',
+                id: 'http-trigger',
+                type: 'ALIYUN_FC3_HTTP_TRIGGER',
+                attributes: { authType: 'anonymous', methods: ['GET'] },
+              },
+            ],
+            lastUpdated: '2025-01-01T00:00:00Z',
+          },
+        },
+      };
+
+      mockedFc3Operations.updateFunctionConfiguration.mockResolvedValue(undefined);
+      mockedFc3Operations.updateFunctionCode.mockResolvedValue(undefined);
+      mockedFc3Operations.deleteTrigger.mockResolvedValue(undefined);
+      mockedFc3Operations.createTrigger.mockResolvedValue(undefined);
+      mockedStateManager.setResource.mockReturnValue(initialState);
+
+      await updateResource(mockContext, fnWithTrigger, stateWithOldTriggerConfig);
+
+      expect(mockedFc3Operations.deleteTrigger).toHaveBeenCalledWith(
+        'test-function',
+        'http-trigger',
+      );
+      expect(mockedFc3Operations.createTrigger).toHaveBeenCalledWith(
+        'test-function',
+        'http-trigger',
+        'http',
+        expect.objectContaining({ authType: 'anonymous' }),
+      );
+    });
+
+    it('should ignore TriggerNotFound when recreating HTTP trigger during update', async () => {
+      const fnWithTrigger = {
+        ...testFunction,
+        triggers: { http: { auth_type: 'public' as const } },
+      };
+
+      const stateWithOldTriggerConfig: StateFile = {
+        ...initialState,
+        resources: {
+          'functions.test_fn': {
+            mode: 'managed',
+            region: 'cn-hangzhou',
+            definition: mockDefinition,
+            instances: [
+              {
+                sid: 'si:aliyun:fc3:default:test-function',
+                id: 'test-function',
+                type: 'ALIYUN_FC3_FUNCTION',
+              },
+              {
+                sid: 'si:aliyun:fc3-http-trigger:default:test-function',
+                id: 'http-trigger',
+                type: 'ALIYUN_FC3_HTTP_TRIGGER',
+                attributes: { authType: 'anonymous', methods: ['GET'] },
+              },
+            ],
+            lastUpdated: '2025-01-01T00:00:00Z',
+          },
+        },
+      };
+
+      mockedFc3Operations.updateFunctionConfiguration.mockResolvedValue(undefined);
+      mockedFc3Operations.updateFunctionCode.mockResolvedValue(undefined);
+      mockedFc3Operations.deleteTrigger.mockRejectedValue({ code: 'TriggerNotFound' });
+      mockedFc3Operations.createTrigger.mockResolvedValue(undefined);
+      mockedStateManager.setResource.mockReturnValue(initialState);
+
+      await updateResource(mockContext, fnWithTrigger, stateWithOldTriggerConfig);
+
+      expect(mockedFc3Operations.deleteTrigger).toHaveBeenCalledWith(
+        'test-function',
+        'http-trigger',
+      );
+      expect(mockedFc3Operations.createTrigger).toHaveBeenCalled();
+    });
+
+    it('should fetch certificate when adding custom domain with certificate_id during update', async () => {
+      const fnWithCertDomain = {
+        ...testFunction,
+        domain: {
+          domain_name: 'api.example.com',
+          protocol: 'HTTPS',
+          certificate_id: 'cert-123',
+        },
+      };
+
+      const stateWithoutDomain: StateFile = {
+        ...initialState,
+        resources: {
+          'functions.test_fn': {
+            mode: 'managed',
+            region: 'cn-hangzhou',
+            definition: mockDefinition,
+            instances: [
+              {
+                sid: 'si:aliyun:fc3:default:test-function',
+                id: 'test-function',
+                type: 'ALIYUN_FC3_FUNCTION',
+              },
+            ],
+            lastUpdated: '2025-01-01T00:00:00Z',
+          },
+        },
+      };
+
+      mockedFc3Operations.updateFunctionConfiguration.mockResolvedValue(undefined);
+      mockedFc3Operations.updateFunctionCode.mockResolvedValue(undefined);
+      mockedFc3Operations.createCustomDomain.mockResolvedValue(undefined);
+      mockedCasOperations.getCertificate.mockResolvedValue({ cert: 'cert-body', key: 'key-body' });
+      mockedStateManager.setResource.mockReturnValue(initialState);
+
+      await updateResource(mockContext, fnWithCertDomain, stateWithoutDomain);
+
+      expect(mockedCasOperations.getCertificate).toHaveBeenCalledWith('cert-123');
+      expect(mockedFc3Operations.createCustomDomain).toHaveBeenCalledWith(
+        'api.example.com',
+        'HTTPS',
+        'test-function',
+        {
+          certName: 'test-service-default-fc3-domain',
+          certificate: 'cert-body',
+          privateKey: 'key-body',
+        },
+      );
+    });
+
+    it('should throw CERT_REFERENCE_NOT_FOUND when certificate missing during domain creation in update', async () => {
+      const fnWithCertDomain = {
+        ...testFunction,
+        domain: {
+          domain_name: 'api.example.com',
+          protocol: 'HTTPS',
+          certificate_id: 'cert-missing',
+        },
+      };
+
+      const stateWithoutDomain: StateFile = {
+        ...initialState,
+        resources: {
+          'functions.test_fn': {
+            mode: 'managed',
+            region: 'cn-hangzhou',
+            definition: mockDefinition,
+            instances: [
+              {
+                sid: 'si:aliyun:fc3:default:test-function',
+                id: 'test-function',
+                type: 'ALIYUN_FC3_FUNCTION',
+              },
+            ],
+            lastUpdated: '2025-01-01T00:00:00Z',
+          },
+        },
+      };
+
+      mockedFc3Operations.updateFunctionConfiguration.mockResolvedValue(undefined);
+      mockedFc3Operations.updateFunctionCode.mockResolvedValue(undefined);
+      mockedCasOperations.getCertificate.mockResolvedValue(null);
+
+      await expect(
+        updateResource(mockContext, fnWithCertDomain, stateWithoutDomain),
+      ).rejects.toThrow('Certificate reference "cert-missing" could not be resolved.');
+      expect(mockedFc3Operations.createCustomDomain).not.toHaveBeenCalled();
+    });
+
+    it('should ignore CustomDomainNotFound when deleting custom domain during update', async () => {
+      const fnWithoutLifecycle = { ...testFunction };
+
+      const stateWithDomain: StateFile = {
+        ...initialState,
+        resources: {
+          'functions.test_fn': {
+            mode: 'managed',
+            region: 'cn-hangzhou',
+            definition: mockDefinition,
+            instances: [
+              {
+                sid: 'si:aliyun:fc3:default:test-function',
+                id: 'test-function',
+                type: 'ALIYUN_FC3_FUNCTION',
+              },
+              {
+                sid: 'si:aliyun:fc3-custom-domain:default:api.example.com',
+                id: 'api.example.com',
+                type: 'ALIYUN_FC3_CUSTOM_DOMAIN',
+                attributes: { protocol: 'HTTPS' },
+              },
+            ],
+            lastUpdated: '2025-01-01T00:00:00Z',
+          },
+        },
+      };
+
+      mockedFc3Operations.updateFunctionConfiguration.mockResolvedValue(undefined);
+      mockedFc3Operations.updateFunctionCode.mockResolvedValue(undefined);
+      mockedFc3Operations.deleteCustomDomain.mockRejectedValue({ code: 'CustomDomainNotFound' });
+      mockedStateManager.setResource.mockReturnValue(initialState);
+
+      await updateResource(mockContext, fnWithoutLifecycle, stateWithDomain);
+
+      expect(mockedFc3Operations.deleteCustomDomain).toHaveBeenCalledWith('api.example.com');
+      expect(mockedLogger.warn).toHaveBeenCalled();
+    });
+
+    it('should recreate custom domain when domain changes during update', async () => {
+      const fnWithNewDomain = {
+        ...testFunction,
+        domain: { domain_name: 'new.example.com', protocol: 'HTTPS' },
+      };
+
+      const stateWithOldDomain: StateFile = {
+        ...initialState,
+        resources: {
+          'functions.test_fn': {
+            mode: 'managed',
+            region: 'cn-hangzhou',
+            definition: mockDefinition,
+            instances: [
+              {
+                sid: 'si:aliyun:fc3:default:test-function',
+                id: 'test-function',
+                type: 'ALIYUN_FC3_FUNCTION',
+              },
+              {
+                sid: 'si:aliyun:fc3-custom-domain:default:old.example.com',
+                id: 'old.example.com',
+                type: 'ALIYUN_FC3_CUSTOM_DOMAIN',
+                attributes: { protocol: 'HTTPS' },
+              },
+            ],
+            lastUpdated: '2025-01-01T00:00:00Z',
+          },
+        },
+      };
+
+      mockedFc3Operations.updateFunctionConfiguration.mockResolvedValue(undefined);
+      mockedFc3Operations.updateFunctionCode.mockResolvedValue(undefined);
+      mockedFc3Operations.deleteCustomDomain.mockResolvedValue(undefined);
+      mockedFc3Operations.createCustomDomain.mockResolvedValue(undefined);
+      mockedStateManager.setResource.mockReturnValue(initialState);
+
+      await updateResource(mockContext, fnWithNewDomain, stateWithOldDomain);
+
+      expect(mockedFc3Operations.deleteCustomDomain).toHaveBeenCalledWith('old.example.com');
+      expect(mockedFc3Operations.createCustomDomain).toHaveBeenCalledWith(
+        'new.example.com',
+        'HTTPS',
+        'test-function',
+        undefined,
+      );
+    });
+
+    it('should throw CERT_REFERENCE_NOT_FOUND when certificate missing during domain update', async () => {
+      const fnWithNewCertDomain = {
+        ...testFunction,
+        domain: {
+          domain_name: 'new.example.com',
+          protocol: 'HTTPS',
+          certificate_id: 'cert-missing',
+        },
+      };
+
+      const stateWithOldDomain: StateFile = {
+        ...initialState,
+        resources: {
+          'functions.test_fn': {
+            mode: 'managed',
+            region: 'cn-hangzhou',
+            definition: mockDefinition,
+            instances: [
+              {
+                sid: 'si:aliyun:fc3:default:test-function',
+                id: 'test-function',
+                type: 'ALIYUN_FC3_FUNCTION',
+              },
+              {
+                sid: 'si:aliyun:fc3-custom-domain:default:old.example.com',
+                id: 'old.example.com',
+                type: 'ALIYUN_FC3_CUSTOM_DOMAIN',
+                attributes: { protocol: 'HTTPS' },
+              },
+            ],
+            lastUpdated: '2025-01-01T00:00:00Z',
+          },
+        },
+      };
+
+      mockedFc3Operations.updateFunctionConfiguration.mockResolvedValue(undefined);
+      mockedFc3Operations.updateFunctionCode.mockResolvedValue(undefined);
+      mockedCasOperations.getCertificate.mockResolvedValue(null);
+
+      await expect(
+        updateResource(mockContext, fnWithNewCertDomain, stateWithOldDomain),
+      ).rejects.toThrow('Certificate reference "cert-missing" could not be resolved.');
+    });
+
+    it('should ignore CustomDomainNotFound when deleting old domain during domain update', async () => {
+      const fnWithNewDomain = {
+        ...testFunction,
+        domain: { domain_name: 'new.example.com', protocol: 'HTTPS' },
+      };
+
+      const stateWithOldDomain: StateFile = {
+        ...initialState,
+        resources: {
+          'functions.test_fn': {
+            mode: 'managed',
+            region: 'cn-hangzhou',
+            definition: mockDefinition,
+            instances: [
+              {
+                sid: 'si:aliyun:fc3:default:test-function',
+                id: 'test-function',
+                type: 'ALIYUN_FC3_FUNCTION',
+              },
+              {
+                sid: 'si:aliyun:fc3-custom-domain:default:old.example.com',
+                id: 'old.example.com',
+                type: 'ALIYUN_FC3_CUSTOM_DOMAIN',
+                attributes: { protocol: 'HTTPS' },
+              },
+            ],
+            lastUpdated: '2025-01-01T00:00:00Z',
+          },
+        },
+      };
+
+      mockedFc3Operations.updateFunctionConfiguration.mockResolvedValue(undefined);
+      mockedFc3Operations.updateFunctionCode.mockResolvedValue(undefined);
+      mockedFc3Operations.deleteCustomDomain.mockRejectedValue({ code: 'CustomDomainNotFound' });
+      mockedFc3Operations.createCustomDomain.mockResolvedValue(undefined);
+      mockedStateManager.setResource.mockReturnValue(initialState);
+
+      await updateResource(mockContext, fnWithNewDomain, stateWithOldDomain);
+
+      expect(mockedFc3Operations.deleteCustomDomain).toHaveBeenCalledWith('old.example.com');
+      expect(mockedFc3Operations.createCustomDomain).toHaveBeenCalledWith(
+        'new.example.com',
+        'HTTPS',
+        'test-function',
+        undefined,
+      );
+    });
+
+    it('should fetch certificate and pass certConfig when domain changes during update', async () => {
+      const fnWithNewCertDomain = {
+        ...testFunction,
+        domain: {
+          domain_name: 'new.example.com',
+          protocol: 'HTTPS',
+          certificate_id: 'cert-123',
+        },
+      };
+
+      const stateWithOldDomain: StateFile = {
+        ...initialState,
+        resources: {
+          'functions.test_fn': {
+            mode: 'managed',
+            region: 'cn-hangzhou',
+            definition: mockDefinition,
+            instances: [
+              {
+                sid: 'si:aliyun:fc3:default:test-function',
+                id: 'test-function',
+                type: 'ALIYUN_FC3_FUNCTION',
+              },
+              {
+                sid: 'si:aliyun:fc3-custom-domain:default:old.example.com',
+                id: 'old.example.com',
+                type: 'ALIYUN_FC3_CUSTOM_DOMAIN',
+                attributes: { protocol: 'HTTPS' },
+              },
+            ],
+            lastUpdated: '2025-01-01T00:00:00Z',
+          },
+        },
+      };
+
+      mockedFc3Operations.updateFunctionConfiguration.mockResolvedValue(undefined);
+      mockedFc3Operations.updateFunctionCode.mockResolvedValue(undefined);
+      mockedFc3Operations.deleteCustomDomain.mockResolvedValue(undefined);
+      mockedFc3Operations.createCustomDomain.mockResolvedValue(undefined);
+      mockedCasOperations.getCertificate.mockResolvedValue({ cert: 'cert-body', key: 'key-body' });
+      mockedStateManager.setResource.mockReturnValue(initialState);
+
+      await updateResource(mockContext, fnWithNewCertDomain, stateWithOldDomain);
+
+      expect(mockedCasOperations.getCertificate).toHaveBeenCalledWith('cert-123');
+      expect(mockedFc3Operations.createCustomDomain).toHaveBeenCalledWith(
+        'new.example.com',
+        'HTTPS',
+        'test-function',
+        {
+          certName: 'test-service-default-fc3-domain',
+          certificate: 'cert-body',
+          privateKey: 'key-body',
+        },
+      );
     });
   });
 
@@ -1421,6 +1983,149 @@ describe('Fc3Resource', () => {
 
       expect(mockedFc3Operations.deleteCustomDomain).toHaveBeenCalledWith('api.example.com');
       expect(mockedFc3Operations.deleteFunction).toHaveBeenCalledWith('test-function');
+    });
+
+    it('should ignore TriggerNotFound when deleting HTTP trigger during delete', async () => {
+      const stateWithTrigger: StateFile = {
+        ...initialState,
+        resources: {
+          'functions.test_fn': {
+            mode: 'managed',
+            region: 'cn-hangzhou',
+            definition: mockDefinition,
+            instances: [
+              {
+                sid: 'si:aliyun:fc3:default:test-function',
+                id: 'test-function',
+                type: 'ALIYUN_FC3_FUNCTION',
+              },
+              {
+                sid: 'si:aliyun:fc3-http-trigger:default:test-function',
+                id: 'http-trigger',
+                type: 'ALIYUN_FC3_HTTP_TRIGGER',
+              },
+            ],
+            lastUpdated: '2025-01-01T00:00:00Z',
+          },
+        },
+      };
+
+      mockedFc3Operations.deleteFunction.mockResolvedValue(undefined);
+      mockedFc3Operations.deleteTrigger.mockRejectedValue({ code: 'TriggerNotFound' });
+      mockedStateManager.removeResource.mockReturnValue(initialState);
+
+      await deleteResource(mockContext, 'test-function', 'functions.test_fn', stateWithTrigger);
+
+      expect(mockedFc3Operations.deleteTrigger).toHaveBeenCalledWith(
+        'test-function',
+        'http-trigger',
+      );
+      expect(mockedFc3Operations.deleteFunction).toHaveBeenCalledWith('test-function');
+      expect(mockedLogger.warn).toHaveBeenCalled();
+    });
+
+    it('should rethrow unexpected errors when deleting HTTP trigger during delete', async () => {
+      const stateWithTrigger: StateFile = {
+        ...initialState,
+        resources: {
+          'functions.test_fn': {
+            mode: 'managed',
+            region: 'cn-hangzhou',
+            definition: mockDefinition,
+            instances: [
+              {
+                sid: 'si:aliyun:fc3:default:test-function',
+                id: 'test-function',
+                type: 'ALIYUN_FC3_FUNCTION',
+              },
+              {
+                sid: 'si:aliyun:fc3-http-trigger:default:test-function',
+                id: 'http-trigger',
+                type: 'ALIYUN_FC3_HTTP_TRIGGER',
+              },
+            ],
+            lastUpdated: '2025-01-01T00:00:00Z',
+          },
+        },
+      };
+
+      mockedFc3Operations.deleteTrigger.mockRejectedValue(
+        Object.assign(new Error('Forbidden'), { code: 'Forbidden' }),
+      );
+
+      await expect(
+        deleteResource(mockContext, 'test-function', 'functions.test_fn', stateWithTrigger),
+      ).rejects.toThrow('Forbidden');
+    });
+
+    it('should ignore CustomDomainNotFound when deleting custom domain during delete', async () => {
+      const stateWithDomain: StateFile = {
+        ...initialState,
+        resources: {
+          'functions.test_fn': {
+            mode: 'managed',
+            region: 'cn-hangzhou',
+            definition: mockDefinition,
+            instances: [
+              {
+                sid: 'si:aliyun:fc3:default:test-function',
+                id: 'test-function',
+                type: 'ALIYUN_FC3_FUNCTION',
+              },
+              {
+                sid: 'si:aliyun:fc3-custom-domain:default:api.example.com',
+                id: 'api.example.com',
+                type: 'ALIYUN_FC3_CUSTOM_DOMAIN',
+              },
+            ],
+            lastUpdated: '2025-01-01T00:00:00Z',
+          },
+        },
+      };
+
+      mockedFc3Operations.deleteFunction.mockResolvedValue(undefined);
+      mockedFc3Operations.deleteCustomDomain.mockRejectedValue({ code: 'CustomDomainNotFound' });
+      mockedStateManager.removeResource.mockReturnValue(initialState);
+
+      await deleteResource(mockContext, 'test-function', 'functions.test_fn', stateWithDomain);
+
+      expect(mockedFc3Operations.deleteCustomDomain).toHaveBeenCalledWith('api.example.com');
+      expect(mockedFc3Operations.deleteFunction).toHaveBeenCalledWith('test-function');
+      expect(mockedLogger.warn).toHaveBeenCalled();
+    });
+
+    it('should rethrow unexpected errors when deleting custom domain during delete', async () => {
+      const stateWithDomain: StateFile = {
+        ...initialState,
+        resources: {
+          'functions.test_fn': {
+            mode: 'managed',
+            region: 'cn-hangzhou',
+            definition: mockDefinition,
+            instances: [
+              {
+                sid: 'si:aliyun:fc3:default:test-function',
+                id: 'test-function',
+                type: 'ALIYUN_FC3_FUNCTION',
+              },
+              {
+                sid: 'si:aliyun:fc3-custom-domain:default:api.example.com',
+                id: 'api.example.com',
+                type: 'ALIYUN_FC3_CUSTOM_DOMAIN',
+              },
+            ],
+            lastUpdated: '2025-01-01T00:00:00Z',
+          },
+        },
+      };
+
+      mockedFc3Operations.deleteCustomDomain.mockRejectedValue(
+        Object.assign(new Error('Forbidden'), { code: 'Forbidden' }),
+      );
+
+      await expect(
+        deleteResource(mockContext, 'test-function', 'functions.test_fn', stateWithDomain),
+      ).rejects.toThrow('Forbidden');
     });
   });
 

--- a/tests/unit/stack/aliyunStack/fc3Resource.test.ts
+++ b/tests/unit/stack/aliyunStack/fc3Resource.test.ts
@@ -20,6 +20,10 @@ const mockedFc3Operations = {
   updateFunctionConfiguration: jest.fn(),
   updateFunctionCode: jest.fn(),
   deleteFunction: jest.fn(),
+  createTrigger: jest.fn(),
+  deleteTrigger: jest.fn(),
+  createCustomDomain: jest.fn(),
+  deleteCustomDomain: jest.fn(),
 };
 const mockedFc3Types = {
   functionToFc3Config: jest.fn(),
@@ -81,6 +85,7 @@ jest.mock('../../../../src/common/aliyunClient', () => ({
     ram: mockedRamOperations,
     ecs: mockedEcsOperations,
     nas: mockedNasOperations,
+    cas: { getCertificate: jest.fn().mockResolvedValue({ cert: 'c', key: 'k' }) },
   }),
 }));
 
@@ -615,6 +620,50 @@ describe('Fc3Resource', () => {
       expect(mockedOssOperations.getBucket).toHaveBeenCalled();
       expect(mockedOssOperations.createBucket).not.toHaveBeenCalled();
       expect(mockedOssOperations.putFile).toHaveBeenCalled();
+    });
+
+    it('should create HTTP trigger when triggers.http is configured', async () => {
+      const fnWithTrigger = {
+        ...testFunction,
+        triggers: { http: { auth_type: 'public' as const } },
+      };
+
+      const readyState = {
+        ...initialState,
+        resources: { 'functions.test_fn': expect.anything() },
+      };
+      mockedStateManager.setResource.mockReturnValue(readyState);
+
+      await createResource(mockContext, fnWithTrigger, initialState);
+
+      expect(mockedFc3Operations.createTrigger).toHaveBeenCalledWith(
+        'test-function',
+        'http-trigger',
+        'http',
+        expect.objectContaining({ authType: 'anonymous', methods: expect.any(Array) }),
+      );
+    });
+
+    it('should create custom domain when domain is configured', async () => {
+      const fnWithDomain = {
+        ...testFunction,
+        domain: { domain_name: 'api.example.com', protocol: 'HTTPS' },
+      };
+
+      const readyState = {
+        ...initialState,
+        resources: { 'functions.test_fn': expect.anything() },
+      };
+      mockedStateManager.setResource.mockReturnValue(readyState);
+
+      await createResource(mockContext, fnWithDomain, initialState);
+
+      expect(mockedFc3Operations.createCustomDomain).toHaveBeenCalledWith(
+        'api.example.com',
+        'HTTPS',
+        'test-function',
+        undefined,
+      );
     });
   });
 

--- a/tests/unit/stack/aliyunStack/fc3Resource.test.ts
+++ b/tests/unit/stack/aliyunStack/fc3Resource.test.ts
@@ -908,6 +908,102 @@ describe('Fc3Resource', () => {
         ['fc.aliyuncs.com'],
       );
     });
+
+    it('should create HTTP trigger and custom domain when added during update', async () => {
+      const fnWithTriggerAndDomain = {
+        ...testFunction,
+        triggers: { http: { auth_type: 'public' as const } },
+        domain: { domain_name: 'api.example.com', protocol: 'HTTPS' },
+      };
+
+      const stateWithoutLifecycle: StateFile = {
+        ...initialState,
+        resources: {
+          'functions.test_fn': {
+            mode: 'managed',
+            region: 'cn-hangzhou',
+            definition: mockDefinition,
+            instances: [
+              {
+                sid: 'si:aliyun:fc3:default:test-function',
+                id: 'test-function',
+                type: 'ALIYUN_FC3_FUNCTION',
+              },
+            ],
+            lastUpdated: '2025-01-01T00:00:00Z',
+          },
+        },
+      };
+
+      mockedFc3Operations.updateFunctionConfiguration.mockResolvedValue(undefined);
+      mockedFc3Operations.updateFunctionCode.mockResolvedValue(undefined);
+      mockedFc3Operations.createTrigger.mockResolvedValue(undefined);
+      mockedFc3Operations.createCustomDomain.mockResolvedValue(undefined);
+      mockedStateManager.setResource.mockReturnValue(initialState);
+
+      await updateResource(mockContext, fnWithTriggerAndDomain, stateWithoutLifecycle);
+
+      expect(mockedFc3Operations.createTrigger).toHaveBeenCalledWith(
+        'test-function',
+        'http-trigger',
+        'http',
+        expect.objectContaining({ authType: 'anonymous' }),
+      );
+      expect(mockedFc3Operations.createCustomDomain).toHaveBeenCalledWith(
+        'api.example.com',
+        'HTTPS',
+        'test-function',
+        undefined,
+      );
+    });
+
+    it('should delete HTTP trigger and custom domain when removed during update', async () => {
+      const fnWithoutLifecycle = { ...testFunction };
+
+      const stateWithLifecycle: StateFile = {
+        ...initialState,
+        resources: {
+          'functions.test_fn': {
+            mode: 'managed',
+            region: 'cn-hangzhou',
+            definition: mockDefinition,
+            instances: [
+              {
+                sid: 'si:aliyun:fc3:default:test-function',
+                id: 'test-function',
+                type: 'ALIYUN_FC3_FUNCTION',
+              },
+              {
+                sid: 'si:aliyun:fc3-http-trigger:default:test-function',
+                id: 'http-trigger',
+                type: 'ALIYUN_FC3_HTTP_TRIGGER',
+              },
+              {
+                sid: 'si:aliyun:fc3-custom-domain:default:api.example.com',
+                id: 'api.example.com',
+                type: 'ALIYUN_FC3_CUSTOM_DOMAIN',
+                attributes: { protocol: 'HTTPS' },
+              },
+            ],
+            lastUpdated: '2025-01-01T00:00:00Z',
+          },
+        },
+      };
+
+      mockedFc3Operations.updateFunctionConfiguration.mockResolvedValue(undefined);
+      mockedFc3Operations.updateFunctionCode.mockResolvedValue(undefined);
+      mockedFc3Operations.deleteTrigger.mockResolvedValue(undefined);
+      mockedFc3Operations.deleteCustomDomain.mockResolvedValue(undefined);
+      mockedStateManager.setResource.mockReturnValue(initialState);
+
+      await updateResource(mockContext, fnWithoutLifecycle, stateWithLifecycle);
+
+      expect(mockedFc3Operations.deleteTrigger).toHaveBeenCalledWith(
+        'test-function',
+        'http-trigger',
+      );
+      expect(mockedFc3Operations.deleteCustomDomain).toHaveBeenCalledWith('api.example.com');
+    });
   });
 
   describe('deleteResource', () => {

--- a/tests/unit/stack/aliyunStack/fc3Resource.test.ts
+++ b/tests/unit/stack/aliyunStack/fc3Resource.test.ts
@@ -1254,6 +1254,78 @@ describe('Fc3Resource', () => {
 
       expect(mockedFc3Operations.deleteFunction).toHaveBeenCalled();
     });
+
+    it('should delete HTTP trigger before deleting function', async () => {
+      const stateWithTrigger: StateFile = {
+        ...initialState,
+        resources: {
+          'functions.test_fn': {
+            mode: 'managed',
+            region: 'cn-hangzhou',
+            definition: mockDefinition,
+            instances: [
+              {
+                sid: 'si:aliyun:fc3:default:test-function',
+                id: 'test-function',
+                type: 'ALIYUN_FC3_FUNCTION',
+              },
+              {
+                sid: 'si:aliyun:fc3-http-trigger:default:test-function',
+                id: 'http-trigger',
+                type: 'ALIYUN_FC3_HTTP_TRIGGER',
+              },
+            ],
+            lastUpdated: '2025-01-01T00:00:00Z',
+          },
+        },
+      };
+
+      mockedFc3Operations.deleteFunction.mockResolvedValue(undefined);
+      mockedStateManager.removeResource.mockReturnValue(initialState);
+
+      await deleteResource(mockContext, 'test-function', 'functions.test_fn', stateWithTrigger);
+
+      expect(mockedFc3Operations.deleteTrigger).toHaveBeenCalledWith(
+        'test-function',
+        'http-trigger',
+      );
+      expect(mockedFc3Operations.deleteFunction).toHaveBeenCalledWith('test-function');
+    });
+
+    it('should delete custom domain before deleting function', async () => {
+      const stateWithDomain: StateFile = {
+        ...initialState,
+        resources: {
+          'functions.test_fn': {
+            mode: 'managed',
+            region: 'cn-hangzhou',
+            definition: mockDefinition,
+            instances: [
+              {
+                sid: 'si:aliyun:fc3:default:test-function',
+                id: 'test-function',
+                type: 'ALIYUN_FC3_FUNCTION',
+              },
+              {
+                sid: 'si:aliyun:fc3-custom-domain:default:api.example.com',
+                id: 'api.example.com',
+                type: 'ALIYUN_FC3_CUSTOM_DOMAIN',
+              },
+            ],
+            lastUpdated: '2025-01-01T00:00:00Z',
+          },
+        },
+      };
+
+      mockedFc3Operations.deleteFunction.mockResolvedValue(undefined);
+      mockedFc3Operations.deleteCustomDomain.mockResolvedValue(undefined);
+      mockedStateManager.removeResource.mockReturnValue(initialState);
+
+      await deleteResource(mockContext, 'test-function', 'functions.test_fn', stateWithDomain);
+
+      expect(mockedFc3Operations.deleteCustomDomain).toHaveBeenCalledWith('api.example.com');
+      expect(mockedFc3Operations.deleteFunction).toHaveBeenCalledWith('test-function');
+    });
   });
 
   describe('createResource with dependent resources', () => {

--- a/tests/unit/stack/scfStack/scfResource.test.ts
+++ b/tests/unit/stack/scfStack/scfResource.test.ts
@@ -532,6 +532,17 @@ describe('ScfResource', () => {
       expect(result).toEqual(newState);
     });
 
+    it('should throw when triggers.http config has no auth_type', async () => {
+      const fnWithInvalidTrigger = {
+        ...testFunction,
+        triggers: { http: { auth_type: undefined as unknown as 'public' | 'iam' } },
+      };
+
+      await expect(createResource(mockContext, fnWithInvalidTrigger, initialState)).rejects.toThrow(
+        'auth_type',
+      );
+    });
+
     it('should create HTTP trigger when triggers.http is configured', async () => {
       const fnWithHttpTrigger = {
         ...testFunction,
@@ -1279,6 +1290,84 @@ describe('ScfResource', () => {
       );
       (mockScfOperations.deleteFunction as jest.Mock).mockResolvedValue(undefined);
       (mockScfOperations.deleteCustomDomain as jest.Mock).mockResolvedValue(undefined);
+      (stateManager.removeResource as jest.Mock).mockReturnValue(initialState);
+
+      await deleteResource(mockContext, 'test-function', 'functions.test_fn', stateWithDomain);
+
+      expect(mockScfOperations.deleteCustomDomain).toHaveBeenCalledWith('api.example.com');
+      expect(mockScfOperations.deleteFunction).toHaveBeenCalledWith('test-function');
+    });
+
+    it('should handle HTTP trigger not found during delete gracefully', async () => {
+      const stateWithTrigger: StateFile = {
+        ...initialState,
+        resources: {
+          'functions.test_fn': {
+            mode: 'managed',
+            region: 'ap-guangzhou',
+            definition: mockDefinition,
+            instances: [
+              {
+                sid: 'si:tencent:scf:default:test-function',
+                id: 'test-function',
+                functionName: 'test-function',
+                triggers: [
+                  { type: 'http', triggerName: 'test_fn-http-trigger', triggerDesc: '{}' },
+                ],
+              },
+            ],
+            lastUpdated: '2025-01-01T00:00:00Z',
+          },
+        },
+      };
+
+      (stateManager.getResource as jest.Mock).mockReturnValue(
+        stateWithTrigger.resources['functions.test_fn'],
+      );
+      (mockScfOperations.deleteFunction as jest.Mock).mockResolvedValue(undefined);
+      (mockScfOperations.deleteTrigger as jest.Mock).mockRejectedValue(
+        Object.assign(new Error('not found'), { code: 'ResourceNotFound' }),
+      );
+      (stateManager.removeResource as jest.Mock).mockReturnValue(initialState);
+
+      await deleteResource(mockContext, 'test-function', 'functions.test_fn', stateWithTrigger);
+
+      expect(mockScfOperations.deleteTrigger).toHaveBeenCalled();
+      expect(mockScfOperations.deleteFunction).toHaveBeenCalledWith('test-function');
+    });
+
+    it('should handle custom domain not found during delete gracefully', async () => {
+      const stateWithDomain: StateFile = {
+        ...initialState,
+        resources: {
+          'functions.test_fn': {
+            mode: 'managed',
+            region: 'ap-guangzhou',
+            definition: mockDefinition,
+            instances: [
+              {
+                sid: 'si:tencent:scf:default:test-function',
+                id: 'test-function',
+                functionName: 'test-function',
+              },
+              {
+                sid: 'si:tencent:scf-custom-domain:default:api.example.com',
+                type: 'TENCENT_SCF_CUSTOM_DOMAIN',
+                id: 'api.example.com',
+              },
+            ],
+            lastUpdated: '2025-01-01T00:00:00Z',
+          },
+        },
+      };
+
+      (stateManager.getResource as jest.Mock).mockReturnValue(
+        stateWithDomain.resources['functions.test_fn'],
+      );
+      (mockScfOperations.deleteFunction as jest.Mock).mockResolvedValue(undefined);
+      (mockScfOperations.deleteCustomDomain as jest.Mock).mockRejectedValue(
+        Object.assign(new Error('not found'), { code: 'ResourceNotFound' }),
+      );
       (stateManager.removeResource as jest.Mock).mockReturnValue(initialState);
 
       await deleteResource(mockContext, 'test-function', 'functions.test_fn', stateWithDomain);

--- a/tests/unit/stack/scfStack/scfResource.test.ts
+++ b/tests/unit/stack/scfStack/scfResource.test.ts
@@ -902,6 +902,102 @@ describe('ScfResource', () => {
         }),
       );
     });
+
+    it('should recreate HTTP trigger when auth_type changes during update', async () => {
+      const fnWithHttpTrigger = {
+        ...testFunction,
+        triggers: { http: { auth_type: 'iam' as const } },
+      };
+
+      const stateWithOldTrigger: StateFile = {
+        ...initialState,
+        resources: {
+          'functions.test_fn': {
+            mode: 'managed',
+            region: 'ap-guangzhou',
+            definition: mockDefinition,
+            instances: [
+              {
+                sid: 'si:tencent:scf:default:test-function',
+                id: 'test-function',
+                functionName: 'test-function',
+                triggers: [
+                  {
+                    type: 'http',
+                    triggerName: 'test_fn-http-trigger',
+                    triggerDesc: JSON.stringify({ authType: 'NONE' }),
+                  },
+                ],
+              },
+            ],
+            lastUpdated: '2025-01-01T00:00:00Z',
+          },
+        },
+      };
+
+      (stateManager.getResource as jest.Mock).mockReturnValue(
+        stateWithOldTrigger.resources['functions.test_fn'],
+      );
+      (mockScfOperations.updateFunctionConfiguration as jest.Mock).mockResolvedValue(undefined);
+      (mockScfOperations.updateFunctionCode as jest.Mock).mockResolvedValue(undefined);
+      (stateManager.setResource as jest.Mock).mockReturnValue(initialState);
+
+      await updateResource(mockContext, fnWithHttpTrigger, stateWithOldTrigger);
+
+      expect(mockScfOperations.deleteTrigger).toHaveBeenCalled();
+      expect(mockScfOperations.createTrigger).toHaveBeenCalledWith(
+        expect.objectContaining({
+          FunctionName: 'test-function',
+          Type: 'http',
+        }),
+      );
+    });
+
+    it('should delete HTTP trigger when triggers.http is removed during update', async () => {
+      const fnWithoutTrigger = { ...testFunction };
+
+      const stateWithTrigger: StateFile = {
+        ...initialState,
+        resources: {
+          'functions.test_fn': {
+            mode: 'managed',
+            region: 'ap-guangzhou',
+            definition: mockDefinition,
+            instances: [
+              {
+                sid: 'si:tencent:scf:default:test-function',
+                id: 'test-function',
+                functionName: 'test-function',
+                triggers: [
+                  {
+                    type: 'http',
+                    triggerName: 'test_fn-http-trigger',
+                    triggerDesc: JSON.stringify({ authType: 'NONE' }),
+                  },
+                ],
+              },
+            ],
+            lastUpdated: '2025-01-01T00:00:00Z',
+          },
+        },
+      };
+
+      (stateManager.getResource as jest.Mock).mockReturnValue(
+        stateWithTrigger.resources['functions.test_fn'],
+      );
+      (mockScfOperations.updateFunctionConfiguration as jest.Mock).mockResolvedValue(undefined);
+      (mockScfOperations.updateFunctionCode as jest.Mock).mockResolvedValue(undefined);
+      (stateManager.setResource as jest.Mock).mockReturnValue(initialState);
+
+      await updateResource(mockContext, fnWithoutTrigger, stateWithTrigger);
+
+      expect(mockScfOperations.deleteTrigger).toHaveBeenCalledWith(
+        expect.objectContaining({
+          FunctionName: 'test-function',
+          TriggerName: 'test_fn-http-trigger',
+        }),
+      );
+    });
   });
 
   describe('deleteResource', () => {

--- a/tests/unit/stack/scfStack/scfResource.test.ts
+++ b/tests/unit/stack/scfStack/scfResource.test.ts
@@ -127,6 +127,10 @@ describe('ScfResource', () => {
     (scfTypes.extractScfDefinition as jest.Mock).mockReturnValue(mockDefinition);
     (hashUtils.computeFileHash as jest.Mock).mockReturnValue('mock-code-hash');
     mockScfOperations.getFunction.mockResolvedValue(mockFunctionInfo);
+    mockScfOperations.deleteTrigger.mockResolvedValue(undefined);
+    mockScfOperations.createTrigger.mockResolvedValue(undefined);
+    mockScfOperations.deleteCustomDomain.mockResolvedValue(undefined);
+    mockScfOperations.createCustomDomain.mockResolvedValue(undefined);
     (stateManager.getResource as jest.Mock).mockReturnValue(undefined);
   });
 
@@ -975,6 +979,197 @@ describe('ScfResource', () => {
       );
     });
 
+    it('should ignore ResourceNotFound when deleting old trigger during HTTP trigger recreate', async () => {
+      const fnWithHttpTrigger = {
+        ...testFunction,
+        triggers: { http: { auth_type: 'iam' as const } },
+      };
+
+      const stateWithOldTrigger: StateFile = {
+        ...initialState,
+        resources: {
+          'functions.test_fn': {
+            mode: 'managed',
+            region: 'ap-guangzhou',
+            definition: mockDefinition,
+            instances: [
+              {
+                sid: 'si:tencent:scf:default:test-function',
+                id: 'test-function',
+                functionName: 'test-function',
+                triggers: [
+                  {
+                    type: 'http',
+                    triggerName: 'test_fn-http-trigger',
+                    triggerDesc: JSON.stringify({ authType: 'NONE' }),
+                  },
+                ],
+              },
+            ],
+            lastUpdated: '2025-01-01T00:00:00Z',
+          },
+        },
+      };
+
+      (stateManager.getResource as jest.Mock).mockReturnValue(
+        stateWithOldTrigger.resources['functions.test_fn'],
+      );
+      (mockScfOperations.updateFunctionConfiguration as jest.Mock).mockResolvedValue(undefined);
+      (mockScfOperations.updateFunctionCode as jest.Mock).mockResolvedValue(undefined);
+      (mockScfOperations.deleteTrigger as jest.Mock).mockRejectedValue(
+        Object.assign(new Error('not found'), { code: 'ResourceNotFound.TriggerName' }),
+      );
+      (stateManager.setResource as jest.Mock).mockReturnValue(initialState);
+
+      await updateResource(mockContext, fnWithHttpTrigger, stateWithOldTrigger);
+
+      expect(mockScfOperations.deleteTrigger).toHaveBeenCalled();
+      expect(mockScfOperations.createTrigger).toHaveBeenCalledWith(
+        expect.objectContaining({
+          FunctionName: 'test-function',
+          Type: 'http',
+        }),
+      );
+    });
+
+    it('should rethrow unexpected errors when recreating HTTP trigger during update', async () => {
+      const fnWithHttpTrigger = {
+        ...testFunction,
+        triggers: { http: { auth_type: 'iam' as const } },
+      };
+
+      const stateWithOldTrigger: StateFile = {
+        ...initialState,
+        resources: {
+          'functions.test_fn': {
+            mode: 'managed',
+            region: 'ap-guangzhou',
+            definition: mockDefinition,
+            instances: [
+              {
+                sid: 'si:tencent:scf:default:test-function',
+                id: 'test-function',
+                functionName: 'test-function',
+                triggers: [
+                  {
+                    type: 'http',
+                    triggerName: 'test_fn-http-trigger',
+                    triggerDesc: JSON.stringify({ authType: 'NONE' }),
+                  },
+                ],
+              },
+            ],
+            lastUpdated: '2025-01-01T00:00:00Z',
+          },
+        },
+      };
+
+      (stateManager.getResource as jest.Mock).mockReturnValue(
+        stateWithOldTrigger.resources['functions.test_fn'],
+      );
+      (mockScfOperations.updateFunctionConfiguration as jest.Mock).mockResolvedValue(undefined);
+      (mockScfOperations.updateFunctionCode as jest.Mock).mockResolvedValue(undefined);
+      (mockScfOperations.deleteTrigger as jest.Mock).mockRejectedValue(new Error('delete failed'));
+      (stateManager.setResource as jest.Mock).mockReturnValue(initialState);
+
+      await expect(
+        updateResource(mockContext, fnWithHttpTrigger, stateWithOldTrigger),
+      ).rejects.toThrow('delete failed');
+      expect(mockScfOperations.createTrigger).not.toHaveBeenCalled();
+    });
+
+    it('should create HTTP trigger with access flags when access is configured during update', async () => {
+      const fnWithAccess = {
+        ...testFunction,
+        triggers: {
+          http: { auth_type: 'iam' as const, access: ['public' as const, 'internal' as const] },
+        },
+      };
+
+      const stateWithoutTrigger: StateFile = {
+        ...initialState,
+        resources: {
+          'functions.test_fn': {
+            mode: 'managed',
+            region: 'ap-guangzhou',
+            definition: mockDefinition,
+            instances: [
+              {
+                sid: 'si:tencent:scf:default:test-function',
+                id: 'test-function',
+                functionName: 'test-function',
+              },
+            ],
+            lastUpdated: '2025-01-01T00:00:00Z',
+          },
+        },
+      };
+
+      (stateManager.getResource as jest.Mock).mockReturnValue(
+        stateWithoutTrigger.resources['functions.test_fn'],
+      );
+      (mockScfOperations.updateFunctionConfiguration as jest.Mock).mockResolvedValue(undefined);
+      (mockScfOperations.updateFunctionCode as jest.Mock).mockResolvedValue(undefined);
+      (stateManager.setResource as jest.Mock).mockReturnValue(initialState);
+
+      await updateResource(mockContext, fnWithAccess, stateWithoutTrigger);
+
+      expect(mockScfOperations.createTrigger).toHaveBeenCalledWith(
+        expect.objectContaining({
+          TriggerDesc: JSON.stringify({
+            authType: 'CAM',
+            enableExtranet: true,
+            enableIntranet: true,
+          }),
+        }),
+      );
+    });
+
+    it('should not touch HTTP trigger when trigger config is unchanged during update', async () => {
+      const fnWithHttpTrigger = {
+        ...testFunction,
+        triggers: { http: { auth_type: 'public' as const } },
+      };
+
+      const stateWithMatchingTrigger: StateFile = {
+        ...initialState,
+        resources: {
+          'functions.test_fn': {
+            mode: 'managed',
+            region: 'ap-guangzhou',
+            definition: mockDefinition,
+            instances: [
+              {
+                sid: 'si:tencent:scf:default:test-function',
+                id: 'test-function',
+                functionName: 'test-function',
+                triggers: [
+                  {
+                    type: 'http',
+                    triggerName: 'test_fn-http-trigger',
+                    triggerDesc: JSON.stringify({ authType: 'NONE' }),
+                  },
+                ],
+              },
+            ],
+            lastUpdated: '2025-01-01T00:00:00Z',
+          },
+        },
+      };
+
+      (stateManager.getResource as jest.Mock).mockReturnValue(
+        stateWithMatchingTrigger.resources['functions.test_fn'],
+      );
+      (mockScfOperations.updateFunctionConfiguration as jest.Mock).mockResolvedValue(undefined);
+      (mockScfOperations.updateFunctionCode as jest.Mock).mockResolvedValue(undefined);
+      (stateManager.setResource as jest.Mock).mockReturnValue(initialState);
+
+      await updateResource(mockContext, fnWithHttpTrigger, stateWithMatchingTrigger);
+
+      expect(mockScfOperations.deleteTrigger).not.toHaveBeenCalled();
+      expect(mockScfOperations.createTrigger).not.toHaveBeenCalled();
+    });
+
     it('should delete HTTP trigger when triggers.http is removed during update', async () => {
       const fnWithoutTrigger = { ...testFunction };
 
@@ -1021,6 +1216,97 @@ describe('ScfResource', () => {
       );
     });
 
+    it('should ignore ResourceNotFound when deleting HTTP trigger during update', async () => {
+      const fnWithoutTrigger = { ...testFunction };
+
+      const stateWithTrigger: StateFile = {
+        ...initialState,
+        resources: {
+          'functions.test_fn': {
+            mode: 'managed',
+            region: 'ap-guangzhou',
+            definition: mockDefinition,
+            instances: [
+              {
+                sid: 'si:tencent:scf:default:test-function',
+                id: 'test-function',
+                functionName: 'test-function',
+                triggers: [
+                  {
+                    type: 'http',
+                    triggerName: 'test_fn-http-trigger',
+                    triggerDesc: JSON.stringify({ authType: 'NONE' }),
+                  },
+                ],
+              },
+            ],
+            lastUpdated: '2025-01-01T00:00:00Z',
+          },
+        },
+      };
+
+      (stateManager.getResource as jest.Mock).mockReturnValue(
+        stateWithTrigger.resources['functions.test_fn'],
+      );
+      (mockScfOperations.updateFunctionConfiguration as jest.Mock).mockResolvedValue(undefined);
+      (mockScfOperations.updateFunctionCode as jest.Mock).mockResolvedValue(undefined);
+      (mockScfOperations.deleteTrigger as jest.Mock).mockRejectedValue(
+        Object.assign(new Error('not found'), { code: 'ResourceNotFound.TriggerName' }),
+      );
+      (stateManager.setResource as jest.Mock).mockReturnValue(initialState);
+
+      await updateResource(mockContext, fnWithoutTrigger, stateWithTrigger);
+
+      expect(mockScfOperations.deleteTrigger).toHaveBeenCalledWith(
+        expect.objectContaining({
+          FunctionName: 'test-function',
+          TriggerName: 'test_fn-http-trigger',
+        }),
+      );
+    });
+
+    it('should rethrow unexpected errors when deleting HTTP trigger during update', async () => {
+      const fnWithoutTrigger = { ...testFunction };
+
+      const stateWithTrigger: StateFile = {
+        ...initialState,
+        resources: {
+          'functions.test_fn': {
+            mode: 'managed',
+            region: 'ap-guangzhou',
+            definition: mockDefinition,
+            instances: [
+              {
+                sid: 'si:tencent:scf:default:test-function',
+                id: 'test-function',
+                functionName: 'test-function',
+                triggers: [
+                  {
+                    type: 'http',
+                    triggerName: 'test_fn-http-trigger',
+                    triggerDesc: JSON.stringify({ authType: 'NONE' }),
+                  },
+                ],
+              },
+            ],
+            lastUpdated: '2025-01-01T00:00:00Z',
+          },
+        },
+      };
+
+      (stateManager.getResource as jest.Mock).mockReturnValue(
+        stateWithTrigger.resources['functions.test_fn'],
+      );
+      (mockScfOperations.updateFunctionConfiguration as jest.Mock).mockResolvedValue(undefined);
+      (mockScfOperations.updateFunctionCode as jest.Mock).mockResolvedValue(undefined);
+      (mockScfOperations.deleteTrigger as jest.Mock).mockRejectedValue(new Error('delete failed'));
+      (stateManager.setResource as jest.Mock).mockReturnValue(initialState);
+
+      await expect(updateResource(mockContext, fnWithoutTrigger, stateWithTrigger)).rejects.toThrow(
+        'delete failed',
+      );
+    });
+
     it('should delete custom domain when domain is removed during update', async () => {
       const fnWithoutDomain = { ...testFunction };
 
@@ -1058,6 +1344,90 @@ describe('ScfResource', () => {
       await updateResource(mockContext, fnWithoutDomain, stateWithDomain);
 
       expect(mockScfOperations.deleteCustomDomain).toHaveBeenCalledWith('api.example.com');
+    });
+
+    it('should ignore ResourceNotFound when deleting custom domain during update', async () => {
+      const fnWithoutDomain = { ...testFunction };
+
+      const stateWithDomain: StateFile = {
+        ...initialState,
+        resources: {
+          'functions.test_fn': {
+            mode: 'managed',
+            region: 'ap-guangzhou',
+            definition: mockDefinition,
+            instances: [
+              {
+                sid: 'si:tencent:scf:default:test-function',
+                id: 'test-function',
+                functionName: 'test-function',
+              },
+              {
+                sid: 'si:tencent:scf-custom-domain:default:api.example.com',
+                type: 'TENCENT_SCF_CUSTOM_DOMAIN',
+                id: 'api.example.com',
+              },
+            ],
+            lastUpdated: '2025-01-01T00:00:00Z',
+          },
+        },
+      };
+
+      (stateManager.getResource as jest.Mock).mockReturnValue(
+        stateWithDomain.resources['functions.test_fn'],
+      );
+      (mockScfOperations.updateFunctionConfiguration as jest.Mock).mockResolvedValue(undefined);
+      (mockScfOperations.updateFunctionCode as jest.Mock).mockResolvedValue(undefined);
+      (mockScfOperations.deleteCustomDomain as jest.Mock).mockRejectedValue(
+        Object.assign(new Error('not found'), { code: 'ResourceNotFound' }),
+      );
+      (stateManager.setResource as jest.Mock).mockReturnValue(initialState);
+
+      await updateResource(mockContext, fnWithoutDomain, stateWithDomain);
+
+      expect(mockScfOperations.deleteCustomDomain).toHaveBeenCalledWith('api.example.com');
+    });
+
+    it('should rethrow unexpected errors when deleting custom domain during update', async () => {
+      const fnWithoutDomain = { ...testFunction };
+
+      const stateWithDomain: StateFile = {
+        ...initialState,
+        resources: {
+          'functions.test_fn': {
+            mode: 'managed',
+            region: 'ap-guangzhou',
+            definition: mockDefinition,
+            instances: [
+              {
+                sid: 'si:tencent:scf:default:test-function',
+                id: 'test-function',
+                functionName: 'test-function',
+              },
+              {
+                sid: 'si:tencent:scf-custom-domain:default:api.example.com',
+                type: 'TENCENT_SCF_CUSTOM_DOMAIN',
+                id: 'api.example.com',
+              },
+            ],
+            lastUpdated: '2025-01-01T00:00:00Z',
+          },
+        },
+      };
+
+      (stateManager.getResource as jest.Mock).mockReturnValue(
+        stateWithDomain.resources['functions.test_fn'],
+      );
+      (mockScfOperations.updateFunctionConfiguration as jest.Mock).mockResolvedValue(undefined);
+      (mockScfOperations.updateFunctionCode as jest.Mock).mockResolvedValue(undefined);
+      (mockScfOperations.deleteCustomDomain as jest.Mock).mockRejectedValue(
+        new Error('delete failed'),
+      );
+      (stateManager.setResource as jest.Mock).mockReturnValue(initialState);
+
+      await expect(updateResource(mockContext, fnWithoutDomain, stateWithDomain)).rejects.toThrow(
+        'delete failed',
+      );
     });
 
     it('should recreate custom domain when domain name changes during update', async () => {
@@ -1104,6 +1474,197 @@ describe('ScfResource', () => {
       expect(mockScfOperations.deleteCustomDomain).toHaveBeenCalledWith('old.example.com');
       expect(mockScfOperations.createCustomDomain).toHaveBeenCalledWith(
         expect.objectContaining({ Domain: 'new.example.com' }),
+      );
+    });
+
+    it('should recreate custom domain when protocol changes during update', async () => {
+      const fnWithNewProtocol = {
+        ...testFunction,
+        domain: { domain_name: 'api.example.com', protocol: 'HTTP' },
+      };
+
+      const stateWithOldProtocol: StateFile = {
+        ...initialState,
+        resources: {
+          'functions.test_fn': {
+            mode: 'managed',
+            region: 'ap-guangzhou',
+            definition: mockDefinition,
+            instances: [
+              {
+                sid: 'si:tencent:scf:default:test-function',
+                id: 'test-function',
+                functionName: 'test-function',
+              },
+              {
+                sid: 'si:tencent:scf-custom-domain:default:api.example.com',
+                type: 'TENCENT_SCF_CUSTOM_DOMAIN',
+                id: 'api.example.com',
+                protocol: 'HTTPS',
+              },
+            ],
+            lastUpdated: '2025-01-01T00:00:00Z',
+          },
+        },
+      };
+
+      (stateManager.getResource as jest.Mock).mockReturnValue(
+        stateWithOldProtocol.resources['functions.test_fn'],
+      );
+      (mockScfOperations.updateFunctionConfiguration as jest.Mock).mockResolvedValue(undefined);
+      (mockScfOperations.updateFunctionCode as jest.Mock).mockResolvedValue(undefined);
+      (mockScfOperations.deleteCustomDomain as jest.Mock).mockResolvedValue(undefined);
+      (stateManager.setResource as jest.Mock).mockReturnValue(initialState);
+
+      await updateResource(mockContext, fnWithNewProtocol, stateWithOldProtocol);
+
+      expect(mockScfOperations.deleteCustomDomain).toHaveBeenCalledWith('api.example.com');
+      expect(mockScfOperations.createCustomDomain).toHaveBeenCalledWith(
+        expect.objectContaining({ Domain: 'api.example.com', Protocol: 'HTTP' }),
+      );
+    });
+
+    it('should pass CertConfig when creating custom domain with certificate_id during update', async () => {
+      const fnWithCertDomain = {
+        ...testFunction,
+        domain: {
+          domain_name: 'api.example.com',
+          protocol: 'HTTPS',
+          certificate_id: 'cert-123',
+        },
+      };
+
+      const stateWithoutDomain: StateFile = {
+        ...initialState,
+        resources: {
+          'functions.test_fn': {
+            mode: 'managed',
+            region: 'ap-guangzhou',
+            definition: mockDefinition,
+            instances: [
+              {
+                sid: 'si:tencent:scf:default:test-function',
+                id: 'test-function',
+                functionName: 'test-function',
+              },
+            ],
+            lastUpdated: '2025-01-01T00:00:00Z',
+          },
+        },
+      };
+
+      (stateManager.getResource as jest.Mock).mockReturnValue(
+        stateWithoutDomain.resources['functions.test_fn'],
+      );
+      (mockScfOperations.updateFunctionConfiguration as jest.Mock).mockResolvedValue(undefined);
+      (mockScfOperations.updateFunctionCode as jest.Mock).mockResolvedValue(undefined);
+      (stateManager.setResource as jest.Mock).mockReturnValue(initialState);
+
+      await updateResource(mockContext, fnWithCertDomain, stateWithoutDomain);
+
+      expect(mockScfOperations.createCustomDomain).toHaveBeenCalledWith(
+        expect.objectContaining({
+          Domain: 'api.example.com',
+          CertConfig: { CertificateId: 'cert-123' },
+        }),
+      );
+    });
+
+    it('should not touch custom domain when domain is unchanged during update', async () => {
+      const fnWithSameDomain = {
+        ...testFunction,
+        domain: { domain_name: 'api.example.com', protocol: 'HTTPS' },
+      };
+
+      const stateWithMatchingDomain: StateFile = {
+        ...initialState,
+        resources: {
+          'functions.test_fn': {
+            mode: 'managed',
+            region: 'ap-guangzhou',
+            definition: mockDefinition,
+            instances: [
+              {
+                sid: 'si:tencent:scf:default:test-function',
+                id: 'test-function',
+                functionName: 'test-function',
+              },
+              {
+                sid: 'si:tencent:scf-custom-domain:default:api.example.com',
+                type: 'TENCENT_SCF_CUSTOM_DOMAIN',
+                id: 'api.example.com',
+                protocol: 'HTTPS',
+              },
+            ],
+            lastUpdated: '2025-01-01T00:00:00Z',
+          },
+        },
+      };
+
+      (stateManager.getResource as jest.Mock).mockReturnValue(
+        stateWithMatchingDomain.resources['functions.test_fn'],
+      );
+      (mockScfOperations.updateFunctionConfiguration as jest.Mock).mockResolvedValue(undefined);
+      (mockScfOperations.updateFunctionCode as jest.Mock).mockResolvedValue(undefined);
+      (stateManager.setResource as jest.Mock).mockReturnValue(initialState);
+
+      await updateResource(mockContext, fnWithSameDomain, stateWithMatchingDomain);
+
+      expect(mockScfOperations.deleteCustomDomain).not.toHaveBeenCalled();
+      expect(mockScfOperations.createCustomDomain).not.toHaveBeenCalled();
+    });
+
+    it('should pass CertConfig when recreating custom domain with certificate_id during update', async () => {
+      const fnWithNewCertDomain = {
+        ...testFunction,
+        domain: {
+          domain_name: 'new.example.com',
+          protocol: 'HTTPS',
+          certificate_id: 'cert-123',
+        },
+      };
+
+      const stateWithOldDomain: StateFile = {
+        ...initialState,
+        resources: {
+          'functions.test_fn': {
+            mode: 'managed',
+            region: 'ap-guangzhou',
+            definition: mockDefinition,
+            instances: [
+              {
+                sid: 'si:tencent:scf:default:test-function',
+                id: 'test-function',
+                functionName: 'test-function',
+              },
+              {
+                sid: 'si:tencent:scf-custom-domain:default:old.example.com',
+                type: 'TENCENT_SCF_CUSTOM_DOMAIN',
+                id: 'old.example.com',
+                protocol: 'HTTPS',
+              },
+            ],
+            lastUpdated: '2025-01-01T00:00:00Z',
+          },
+        },
+      };
+
+      (stateManager.getResource as jest.Mock).mockReturnValue(
+        stateWithOldDomain.resources['functions.test_fn'],
+      );
+      (mockScfOperations.updateFunctionConfiguration as jest.Mock).mockResolvedValue(undefined);
+      (mockScfOperations.updateFunctionCode as jest.Mock).mockResolvedValue(undefined);
+      (mockScfOperations.deleteCustomDomain as jest.Mock).mockResolvedValue(undefined);
+      (stateManager.setResource as jest.Mock).mockReturnValue(initialState);
+
+      await updateResource(mockContext, fnWithNewCertDomain, stateWithOldDomain);
+
+      expect(mockScfOperations.deleteCustomDomain).toHaveBeenCalledWith('old.example.com');
+      expect(mockScfOperations.createCustomDomain).toHaveBeenCalledWith(
+        expect.objectContaining({
+          Domain: 'new.example.com',
+          CertConfig: { CertificateId: 'cert-123' },
+        }),
       );
     });
   });
@@ -1471,6 +2032,82 @@ describe('ScfResource', () => {
 
       expect(mockScfOperations.deleteCustomDomain).toHaveBeenCalledWith('api.example.com');
       expect(mockScfOperations.deleteFunction).toHaveBeenCalledWith('test-function');
+    });
+
+    it('should rethrow unexpected errors when deleting HTTP trigger during delete', async () => {
+      const stateWithTrigger: StateFile = {
+        ...initialState,
+        resources: {
+          'functions.test_fn': {
+            mode: 'managed',
+            region: 'ap-guangzhou',
+            definition: mockDefinition,
+            instances: [
+              {
+                sid: 'si:tencent:scf:default:test-function',
+                id: 'test-function',
+                functionName: 'test-function',
+                triggers: [
+                  { type: 'http', triggerName: 'test_fn-http-trigger', triggerDesc: '{}' },
+                ],
+              },
+            ],
+            lastUpdated: '2025-01-01T00:00:00Z',
+          },
+        },
+      };
+
+      (stateManager.getResource as jest.Mock).mockReturnValue(
+        stateWithTrigger.resources['functions.test_fn'],
+      );
+      (mockScfOperations.deleteTrigger as jest.Mock).mockRejectedValue(new Error('delete failed'));
+      (mockScfOperations.deleteFunction as jest.Mock).mockResolvedValue(undefined);
+      (stateManager.removeResource as jest.Mock).mockReturnValue(initialState);
+
+      await expect(
+        deleteResource(mockContext, 'test-function', 'functions.test_fn', stateWithTrigger),
+      ).rejects.toThrow('delete failed');
+      expect(mockScfOperations.deleteFunction).not.toHaveBeenCalled();
+    });
+
+    it('should rethrow unexpected errors when deleting custom domain during delete', async () => {
+      const stateWithDomain: StateFile = {
+        ...initialState,
+        resources: {
+          'functions.test_fn': {
+            mode: 'managed',
+            region: 'ap-guangzhou',
+            definition: mockDefinition,
+            instances: [
+              {
+                sid: 'si:tencent:scf:default:test-function',
+                id: 'test-function',
+                functionName: 'test-function',
+              },
+              {
+                sid: 'si:tencent:scf-custom-domain:default:api.example.com',
+                type: 'TENCENT_SCF_CUSTOM_DOMAIN',
+                id: 'api.example.com',
+              },
+            ],
+            lastUpdated: '2025-01-01T00:00:00Z',
+          },
+        },
+      };
+
+      (stateManager.getResource as jest.Mock).mockReturnValue(
+        stateWithDomain.resources['functions.test_fn'],
+      );
+      (mockScfOperations.deleteCustomDomain as jest.Mock).mockRejectedValue(
+        new Error('delete failed'),
+      );
+      (mockScfOperations.deleteFunction as jest.Mock).mockResolvedValue(undefined);
+      (stateManager.removeResource as jest.Mock).mockReturnValue(initialState);
+
+      await expect(
+        deleteResource(mockContext, 'test-function', 'functions.test_fn', stateWithDomain),
+      ).rejects.toThrow('delete failed');
+      expect(mockScfOperations.deleteFunction).not.toHaveBeenCalled();
     });
   });
 

--- a/tests/unit/stack/scfStack/scfResource.test.ts
+++ b/tests/unit/stack/scfStack/scfResource.test.ts
@@ -818,6 +818,92 @@ describe('ScfResource', () => {
     });
   });
 
+  describe('updateResource with triggers.http', () => {
+    it('should create HTTP trigger when triggers.http is added during update', async () => {
+      const fnWithHttpTrigger = {
+        ...testFunction,
+        triggers: { http: { auth_type: 'public' as const } },
+      };
+
+      const stateWithoutTrigger: StateFile = {
+        ...initialState,
+        resources: {
+          'functions.test_fn': {
+            mode: 'managed',
+            region: 'ap-guangzhou',
+            definition: mockDefinition,
+            instances: [
+              {
+                sid: 'si:tencent:scf:default:test-function',
+                id: 'test-function',
+                functionName: 'test-function',
+                triggers: [],
+              },
+            ],
+            lastUpdated: '2025-01-01T00:00:00Z',
+          },
+        },
+      };
+
+      (stateManager.getResource as jest.Mock).mockReturnValue(
+        stateWithoutTrigger.resources['functions.test_fn'],
+      );
+      (mockScfOperations.updateFunctionConfiguration as jest.Mock).mockResolvedValue(undefined);
+      (mockScfOperations.updateFunctionCode as jest.Mock).mockResolvedValue(undefined);
+      (stateManager.setResource as jest.Mock).mockReturnValue(initialState);
+
+      await updateResource(mockContext, fnWithHttpTrigger, stateWithoutTrigger);
+
+      expect(mockScfOperations.createTrigger).toHaveBeenCalledWith(
+        expect.objectContaining({
+          FunctionName: 'test-function',
+          Type: 'http',
+        }),
+      );
+    });
+
+    it('should create custom domain when domain is added during update', async () => {
+      const fnWithDomain = {
+        ...testFunction,
+        domain: { domain_name: 'api.example.com', protocol: 'HTTPS' },
+      };
+
+      const stateWithoutDomain: StateFile = {
+        ...initialState,
+        resources: {
+          'functions.test_fn': {
+            mode: 'managed',
+            region: 'ap-guangzhou',
+            definition: mockDefinition,
+            instances: [
+              {
+                sid: 'si:tencent:scf:default:test-function',
+                id: 'test-function',
+                functionName: 'test-function',
+              },
+            ],
+            lastUpdated: '2025-01-01T00:00:00Z',
+          },
+        },
+      };
+
+      (stateManager.getResource as jest.Mock).mockReturnValue(
+        stateWithoutDomain.resources['functions.test_fn'],
+      );
+      (mockScfOperations.updateFunctionConfiguration as jest.Mock).mockResolvedValue(undefined);
+      (mockScfOperations.updateFunctionCode as jest.Mock).mockResolvedValue(undefined);
+      (stateManager.setResource as jest.Mock).mockReturnValue(initialState);
+
+      await updateResource(mockContext, fnWithDomain, stateWithoutDomain);
+
+      expect(mockScfOperations.createCustomDomain).toHaveBeenCalledWith(
+        expect.objectContaining({
+          Domain: 'api.example.com',
+        }),
+      );
+    });
+  });
+
   describe('deleteResource', () => {
     const stateWithFunction: StateFile = {
       ...initialState,

--- a/tests/unit/stack/scfStack/scfResource.test.ts
+++ b/tests/unit/stack/scfStack/scfResource.test.ts
@@ -830,6 +830,17 @@ describe('ScfResource', () => {
   });
 
   describe('updateResource with triggers.http', () => {
+    it('should throw when updating with triggers.http and no auth_type', async () => {
+      const fnWithInvalidTrigger = {
+        ...testFunction,
+        triggers: { http: { auth_type: undefined as unknown as 'public' | 'iam' } },
+      };
+
+      await expect(updateResource(mockContext, fnWithInvalidTrigger, initialState)).rejects.toThrow(
+        'auth_type',
+      );
+    });
+
     it('should create HTTP trigger when triggers.http is added during update', async () => {
       const fnWithHttpTrigger = {
         ...testFunction,

--- a/tests/unit/stack/scfStack/scfResource.test.ts
+++ b/tests/unit/stack/scfStack/scfResource.test.ts
@@ -1020,6 +1020,92 @@ describe('ScfResource', () => {
         }),
       );
     });
+
+    it('should delete custom domain when domain is removed during update', async () => {
+      const fnWithoutDomain = { ...testFunction };
+
+      const stateWithDomain: StateFile = {
+        ...initialState,
+        resources: {
+          'functions.test_fn': {
+            mode: 'managed',
+            region: 'ap-guangzhou',
+            definition: mockDefinition,
+            instances: [
+              {
+                sid: 'si:tencent:scf:default:test-function',
+                id: 'test-function',
+                functionName: 'test-function',
+              },
+              {
+                sid: 'si:tencent:scf-custom-domain:default:api.example.com',
+                type: 'TENCENT_SCF_CUSTOM_DOMAIN',
+                id: 'api.example.com',
+              },
+            ],
+            lastUpdated: '2025-01-01T00:00:00Z',
+          },
+        },
+      };
+
+      (stateManager.getResource as jest.Mock).mockReturnValue(
+        stateWithDomain.resources['functions.test_fn'],
+      );
+      (mockScfOperations.updateFunctionConfiguration as jest.Mock).mockResolvedValue(undefined);
+      (mockScfOperations.updateFunctionCode as jest.Mock).mockResolvedValue(undefined);
+      (stateManager.setResource as jest.Mock).mockReturnValue(initialState);
+
+      await updateResource(mockContext, fnWithoutDomain, stateWithDomain);
+
+      expect(mockScfOperations.deleteCustomDomain).toHaveBeenCalledWith('api.example.com');
+    });
+
+    it('should recreate custom domain when domain name changes during update', async () => {
+      const fnWithNewDomain = {
+        ...testFunction,
+        domain: { domain_name: 'new.example.com', protocol: 'HTTPS' },
+      };
+
+      const stateWithOldDomain: StateFile = {
+        ...initialState,
+        resources: {
+          'functions.test_fn': {
+            mode: 'managed',
+            region: 'ap-guangzhou',
+            definition: mockDefinition,
+            instances: [
+              {
+                sid: 'si:tencent:scf:default:test-function',
+                id: 'test-function',
+                functionName: 'test-function',
+              },
+              {
+                sid: 'si:tencent:scf-custom-domain:default:old.example.com',
+                type: 'TENCENT_SCF_CUSTOM_DOMAIN',
+                id: 'old.example.com',
+                protocol: 'HTTPS',
+              },
+            ],
+            lastUpdated: '2025-01-01T00:00:00Z',
+          },
+        },
+      };
+
+      (stateManager.getResource as jest.Mock).mockReturnValue(
+        stateWithOldDomain.resources['functions.test_fn'],
+      );
+      (mockScfOperations.updateFunctionConfiguration as jest.Mock).mockResolvedValue(undefined);
+      (mockScfOperations.updateFunctionCode as jest.Mock).mockResolvedValue(undefined);
+      (mockScfOperations.deleteCustomDomain as jest.Mock).mockResolvedValue(undefined);
+      (stateManager.setResource as jest.Mock).mockReturnValue(initialState);
+
+      await updateResource(mockContext, fnWithNewDomain, stateWithOldDomain);
+
+      expect(mockScfOperations.deleteCustomDomain).toHaveBeenCalledWith('old.example.com');
+      expect(mockScfOperations.createCustomDomain).toHaveBeenCalledWith(
+        expect.objectContaining({ Domain: 'new.example.com' }),
+      );
+    });
   });
 
   describe('deleteResource', () => {

--- a/tests/unit/stack/scfStack/scfResource.test.ts
+++ b/tests/unit/stack/scfStack/scfResource.test.ts
@@ -16,6 +16,10 @@ const mockScfOperations = {
   updateFunctionConfiguration: jest.fn(),
   updateFunctionCode: jest.fn(),
   deleteFunction: jest.fn(),
+  createTrigger: jest.fn(),
+  deleteTrigger: jest.fn(),
+  createCustomDomain: jest.fn(),
+  deleteCustomDomain: jest.fn(),
 };
 
 const mockCamOperations = {
@@ -527,6 +531,53 @@ describe('ScfResource', () => {
       expect(mockScfOperations.createFunction).toHaveBeenCalled();
       expect(result).toEqual(newState);
     });
+
+    it('should create HTTP trigger when triggers.http is configured', async () => {
+      const fnWithHttpTrigger = {
+        ...testFunction,
+        triggers: { http: { auth_type: 'public' as const, access: ['public' as const] } },
+      };
+
+      (mockScfOperations.createFunction as jest.Mock).mockResolvedValue(undefined);
+      (stateManager.setResource as jest.Mock).mockReturnValue(initialState);
+
+      await createResource(mockContext, fnWithHttpTrigger, initialState);
+
+      expect(mockScfOperations.createTrigger).toHaveBeenCalledWith(
+        expect.objectContaining({
+          FunctionName: 'test-function',
+          Type: 'http',
+          TriggerName: 'test_fn-http-trigger',
+          Qualifier: '$DEFAULT',
+          Enable: 'OPEN',
+        }),
+      );
+    });
+
+    it('should create custom domain when domain is configured', async () => {
+      const fnWithDomain = {
+        ...testFunction,
+        domain: { domain_name: 'api.example.com', protocol: 'HTTPS' },
+      };
+
+      (mockScfOperations.createFunction as jest.Mock).mockResolvedValue(undefined);
+      (stateManager.setResource as jest.Mock).mockReturnValue(initialState);
+
+      await createResource(mockContext, fnWithDomain, initialState);
+
+      expect(mockScfOperations.createCustomDomain).toHaveBeenCalledWith(
+        expect.objectContaining({
+          Domain: 'api.example.com',
+          Protocol: 'HTTPS',
+          EndpointsConfig: expect.arrayContaining([
+            expect.objectContaining({
+              FunctionName: 'test-function',
+              PathMatch: '/*',
+            }),
+          ]),
+        }),
+      );
+    });
   });
 
   describe('readResource', () => {
@@ -973,6 +1024,85 @@ describe('ScfResource', () => {
         stateWithUnknownType,
         'functions.test_fn',
       );
+    });
+
+    it('should delete HTTP trigger before deleting function', async () => {
+      const stateWithTrigger: StateFile = {
+        ...initialState,
+        resources: {
+          'functions.test_fn': {
+            mode: 'managed',
+            region: 'ap-guangzhou',
+            definition: mockDefinition,
+            instances: [
+              {
+                sid: 'si:tencent:scf:default:test-function',
+                id: 'test-function',
+                functionName: 'test-function',
+                triggers: [
+                  { type: 'http', triggerName: 'test_fn-http-trigger', triggerDesc: '{}' },
+                ],
+              },
+            ],
+            lastUpdated: '2025-01-01T00:00:00Z',
+          },
+        },
+      };
+
+      (stateManager.getResource as jest.Mock).mockReturnValue(
+        stateWithTrigger.resources['functions.test_fn'],
+      );
+      (mockScfOperations.deleteFunction as jest.Mock).mockResolvedValue(undefined);
+      (stateManager.removeResource as jest.Mock).mockReturnValue(initialState);
+
+      await deleteResource(mockContext, 'test-function', 'functions.test_fn', stateWithTrigger);
+
+      expect(mockScfOperations.deleteTrigger).toHaveBeenCalledWith(
+        expect.objectContaining({
+          FunctionName: 'test-function',
+          TriggerName: 'test_fn-http-trigger',
+          Type: 'http',
+        }),
+      );
+      expect(mockScfOperations.deleteFunction).toHaveBeenCalledWith('test-function');
+    });
+
+    it('should delete custom domain before deleting function', async () => {
+      const stateWithDomain: StateFile = {
+        ...initialState,
+        resources: {
+          'functions.test_fn': {
+            mode: 'managed',
+            region: 'ap-guangzhou',
+            definition: mockDefinition,
+            instances: [
+              {
+                sid: 'si:tencent:scf:default:test-function',
+                id: 'test-function',
+                functionName: 'test-function',
+              },
+              {
+                sid: 'si:tencent:scf-custom-domain:default:api.example.com',
+                type: 'TENCENT_SCF_CUSTOM_DOMAIN',
+                id: 'api.example.com',
+              },
+            ],
+            lastUpdated: '2025-01-01T00:00:00Z',
+          },
+        },
+      };
+
+      (stateManager.getResource as jest.Mock).mockReturnValue(
+        stateWithDomain.resources['functions.test_fn'],
+      );
+      (mockScfOperations.deleteFunction as jest.Mock).mockResolvedValue(undefined);
+      (mockScfOperations.deleteCustomDomain as jest.Mock).mockResolvedValue(undefined);
+      (stateManager.removeResource as jest.Mock).mockReturnValue(initialState);
+
+      await deleteResource(mockContext, 'test-function', 'functions.test_fn', stateWithDomain);
+
+      expect(mockScfOperations.deleteCustomDomain).toHaveBeenCalledWith('api.example.com');
+      expect(mockScfOperations.deleteFunction).toHaveBeenCalledWith('test-function');
     });
   });
 


### PR DESCRIPTION
## Summary

Implements [#114](https://github.com/geek-fun/serverlessinsight/issues/114) — function-level HTTP triggers (Function URL) and custom domain binding, part of [Epic #212](https://github.com/geek-fun/serverlessinsight/issues/212).

## YAML Schema

```yaml
functions:
  my_fn:
    triggers:
      http:
        auth_type: public        # public | iam
        access: ['public', 'internal']  # optional
    
    domain:
      domain_name: api.example.com
      certificate_id: xxx
      protocol: HTTPS            # optional, defaults to HTTPS
```

## Provider Support

| Feature | Tencent SCF | Aliyun FC3 |
|---------|-------------|------------|
| `triggers.http` | ✅ CreateTrigger (Function URL) | ✅ createTrigger (HTTP trigger) |
| `domain` | ✅ CreateCustomDomain (native SCF API) | ✅ createCustomDomain with routeConfig |

## Changes

### Types + Parser + Validator
- `src/types/domains/function.ts`: Add `HttpTriggerRaw`/`HttpTrigger`/`FunctionDomainConfigRaw`/`FunctionDomainConfigParsed` + optional `triggers`/`domain` on `FunctionRaw`/`FunctionDomain`
- `src/parser/functionParser.ts`: Parse the new fields with validation
- `src/validator/functionSchema.ts`: JSON Schema for new blocks

### Auth Mapping
- `src/common/triggerMapper.ts`: Provider-agnostic `mapAuthType()`, `mapAccess()`, `mapAliyunAccess()`

### Tencent SCF (`src/common/tencentClient/scfOperations.ts` + `src/stack/scfStack/scfResource.ts`)
- Add `createTrigger`/`deleteTrigger` using SDK `CreateTrigger`/`DeleteTrigger`
- Add `createCustomDomain`/`getCustomDomain`/`deleteCustomDomain` using SDK `CreateCustomDomain` etc.
- Wire HTTP trigger and domain into create/update/delete lifecycle

### Aliyun FC3 (`src/common/aliyunClient/fc3Operations.ts` + `src/stack/aliyunStack/fc3Resource.ts`)
- Add `createTrigger`/`deleteTrigger` + `createCustomDomain`/`getCustomDomain`/`deleteCustomDomain`
- Wire into create/update/delete lifecycle + `deleteDependentResources` cases

### i18n
- `src/lang/en.ts`, `src/lang/zh-CN.ts`: 14 message keys for trigger/domain operations

### Tests
- `tests/unit/common/triggerMapper.test.ts`: 17 tests for auth/access mappings
- `tests/unit/parser/functionParser.test.ts`: 9 tests for triggers.http + domain parsing
- `tests/service/mockCloudClient.ts`: Update Tencent + Aliyun mocks

## Verification
- ✅ `npm run build` — clean
- ✅ `npm run lint:check` — clean
- ✅ 41 unit tests — all pass
- ✅ 22 existing service tests — all pass (no regressions)