### PR TITLE
fix: make Volcengine stack destroy complete

### DIFF
--- a/src/commands/destroy.ts
+++ b/src/commands/destroy.ts
@@ -42,6 +42,10 @@ export const destroyStack = async (options: {
 
   const backend = createStateBackend(iac.backend, context);
 
+  // Initialize backend stage/deployment context before withLock. SaaS backends
+  // need loadState() to provision the deployment and set the active stage.
+  await backend.loadState(iac.provider.name, context.app, context.service, context.stage);
+
   // ADR-005: wire the backend's event reporter into the global context so
   // executors can emit per-resource deployment events via context.reportEvent.
   if (backend.reportEvent) {

--- a/src/stack/volcengineStack/destroyer.ts
+++ b/src/stack/volcengineStack/destroyer.ts
@@ -24,7 +24,7 @@ export const destroyVolcengineStack = async (backend: StateBackend) => {
     ([logicalId, resourceState]) =>
       logicalId.startsWith('events.') &&
       resourceState.instances?.some(
-        (i) => i.type === 'VOLCENGINE_APIGW_GROUP' || i.type === 'VOLCENGINE_APIGW_API',
+        (i) => typeof i.type === 'string' && i.type.startsWith('VOLCENGINE_APIGW_'),
       ),
   );
 

--- a/src/stack/volcengineStack/vefaasPlanner.ts
+++ b/src/stack/volcengineStack/vefaasPlanner.ts
@@ -57,6 +57,34 @@ export const generateFunctionPlan = async (
           config.role = roleInstance.trn;
         }
       }
+      // Mirror the executor's TLS log-resource behavior: functionToVefaasConfig(fn)
+      // never sets logConfig on its own (it's only populated via the second
+      // `options` argument), so without this the diff below always compares
+      // desiredDefinition.logConfig === undefined regardless of `fn.log` in the
+      // YAML — meaning `log: true` could never be detected as drift and the
+      // planner would report `noop` forever, so `UpdateFunction`'s `TlsConfig`
+      // never gets sent. Derive the same project/topic names
+      // createDependentResources would use (existing TLS instances in state
+      // take priority; otherwise the deterministic `{service}-{stage}-tls` /
+      // `{service}-{stage}-logs` names) so the diff can see the field change.
+      if (fn.log) {
+        if (currentState?.instances?.length) {
+          const tlsTopicInstance = currentState.instances.find(
+            (i) => (i as { type?: string }).type === 'VOLCENGINE_TLS_TOPIC',
+          ) as { id?: string } | undefined;
+          if (tlsTopicInstance?.id) {
+            const [projectName, topicName] = tlsTopicInstance.id.split('/');
+            config.logConfig = { project: projectName, topic: topicName };
+          }
+        }
+        if (!config.logConfig) {
+          const serviceName = `${context.app}-${context.service}`;
+          config.logConfig = {
+            project: `${serviceName}-${context.stage}-tls`,
+            topic: `${serviceName}-${context.stage}-logs`,
+          };
+        }
+      }
       const baseDefinition = extractVefaasDefinition(config, desiredCodeHash);
       const desiredDefinition = fn.iam ? { ...baseDefinition, iam: fn.iam } : baseDefinition;
 

--- a/tests/unit/commands/deploy.test.ts
+++ b/tests/unit/commands/deploy.test.ts
@@ -392,5 +392,71 @@ describe('unit test for deploy command', () => {
       expect(process.listenerCount('SIGINT')).toBe(baselineSigint);
       expect(process.listenerCount('SIGTERM')).toBe(baselineSigterm);
     });
+
+    it('should wire the backend event reporter into context', async () => {
+      setupAliyunMocks();
+      const context = { provider: 'aliyun', region: 'cn-hangzhou' };
+      const reportEvent = jest.fn();
+      mockedGetContext.mockReturnValue(context);
+      mockedCreateStateBackend.mockReturnValue({
+        ...mockBackend,
+        reportEvent,
+        replayOrphanedEvents: jest.fn().mockResolvedValue(undefined),
+      });
+
+      await deploy(baseOptions);
+
+      expect(context).toHaveProperty('reportEvent', reportEvent);
+    });
+
+    it('should flush buffered events before exiting after a signal', async () => {
+      setupAliyunMocks();
+      const releaseLock = jest.fn().mockResolvedValue(undefined);
+      const flushEvents = jest.fn().mockResolvedValue(undefined);
+      mockedCreateStateBackend.mockReturnValue({
+        withLock: jest.fn(
+          (
+            _op: string,
+            fn: () => Promise<unknown>,
+            _options?: unknown,
+            onLockAcquired?: (id: string) => void,
+          ) => {
+            onLockAcquired?.('deploy-lock-id');
+            return fn();
+          },
+        ),
+        releaseLock,
+        flushEvents,
+        loadState: jest.fn().mockResolvedValue({ resources: {} }),
+        replayOrphanedEvents: jest.fn().mockResolvedValue(undefined),
+      });
+      const exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+      let releaseDeploy: (() => void) | undefined;
+      mockedDeployStack.mockImplementation(
+        () =>
+          new Promise<void>((resolve) => {
+            releaseDeploy = resolve;
+          }),
+      );
+
+      const deployPromise = deploy(baseOptions);
+      await new Promise<void>((resolve) => {
+        const timer = setInterval(() => {
+          if (releaseDeploy) {
+            clearInterval(timer);
+            resolve();
+          }
+        }, 5);
+      });
+
+      process.emit('SIGTERM');
+      await Promise.resolve();
+      expect(flushEvents).toHaveBeenCalled();
+      expect(exitSpy).toHaveBeenCalledWith(130);
+
+      releaseDeploy?.();
+      await deployPromise;
+      exitSpy.mockRestore();
+    });
   });
 });

--- a/tests/unit/commands/destroy.test.ts
+++ b/tests/unit/commands/destroy.test.ts
@@ -266,4 +266,72 @@ describe('destroy command', () => {
 
     exitSpy.mockRestore();
   });
+
+  it('should wire the backend event reporter into context', async () => {
+    const reportEvent = jest.fn();
+    const context = { ...mockContext };
+    (getContext as jest.Mock).mockReturnValue(context);
+    (
+      jest.requireMock('../../../src/stack/aliyunStack').destroyAliyunStack as jest.Mock
+    ).mockResolvedValue(undefined);
+    (createStateBackend as jest.Mock).mockReturnValue({
+      ...mockBackend,
+      reportEvent,
+      replayOrphanedEvents: jest.fn().mockResolvedValue(undefined),
+    });
+
+    await destroyStack({ location: '/test/path' });
+
+    expect(context).toHaveProperty('reportEvent', reportEvent);
+  });
+
+  it('should flush buffered events before exiting after a signal', async () => {
+    const releaseLock = jest.fn().mockResolvedValue(undefined);
+    const flushEvents = jest.fn().mockResolvedValue(undefined);
+    (createStateBackend as jest.Mock).mockReturnValue({
+      loadState: jest.fn().mockResolvedValue({}),
+      withLock: jest.fn(
+        (
+          _op: string,
+          fn: () => Promise<unknown>,
+          _options?: unknown,
+          onLockAcquired?: (id: string) => void,
+        ) => {
+          onLockAcquired?.('destroy-lock-id');
+          return fn();
+        },
+      ),
+      releaseLock,
+      flushEvents,
+    });
+    const exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+    let releaseDestroy: (() => void) | undefined;
+    (
+      jest.requireMock('../../../src/stack/aliyunStack').destroyAliyunStack as jest.Mock
+    ).mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseDestroy = resolve;
+        }),
+    );
+
+    const destroyPromise = destroyStack({ location: '/test/path' });
+    await new Promise<void>((resolve) => {
+      const timer = setInterval(() => {
+        if (releaseDestroy) {
+          clearInterval(timer);
+          resolve();
+        }
+      }, 5);
+    });
+
+    process.emit('SIGTERM');
+    await Promise.resolve();
+    expect(flushEvents).toHaveBeenCalled();
+    expect(exitSpy).toHaveBeenCalledWith(130);
+
+    releaseDestroy?.();
+    await destroyPromise;
+    exitSpy.mockRestore();
+  });
 });

--- a/tests/unit/commands/destroy.test.ts
+++ b/tests/unit/commands/destroy.test.ts
@@ -52,6 +52,7 @@ jest.mock('../../../src/lang', () => ({
 
 describe('destroy command', () => {
   const mockBackend = {
+    loadState: jest.fn().mockResolvedValue({}),
     withLock: jest.fn((_: string, fn: () => Promise<void>) => fn()),
   };
 
@@ -140,6 +141,31 @@ describe('destroy command', () => {
     ).toHaveBeenCalledWith(mockBackend);
   });
 
+  it('loads state before acquiring the destroy lock', async () => {
+    const calls: Array<string> = [];
+    const backend = {
+      loadState: jest.fn(async () => {
+        calls.push('loadState');
+        return {};
+      }),
+      withLock: jest.fn(async (_operation: string, fn: () => Promise<void>) => {
+        calls.push('withLock');
+        await fn();
+      }),
+    };
+    (createStateBackend as jest.Mock).mockReturnValue(backend);
+
+    await destroyStack({ location: '/test/path' });
+
+    expect(calls).toEqual(['loadState', 'withLock']);
+    expect(backend.loadState).toHaveBeenCalledWith(
+      ProviderEnum.ALIYUN,
+      'test-app',
+      'test-service',
+      'dev',
+    );
+  });
+
   it('should throw error for unsupported provider', async () => {
     (parseYaml as jest.Mock).mockReturnValue({
       app: 'test-app',
@@ -184,6 +210,7 @@ describe('destroy command', () => {
   it('should release the active lock and exit(130) when SIGINT is received', async () => {
     const releaseLock = jest.fn().mockResolvedValue(undefined);
     (createStateBackend as jest.Mock).mockReturnValue({
+      loadState: jest.fn().mockResolvedValue({}),
       withLock: jest.fn(
         (
           _op: string,

--- a/tests/unit/commands/forceUnlock.test.ts
+++ b/tests/unit/commands/forceUnlock.test.ts
@@ -5,6 +5,13 @@ import { LOCK_FILE_SUFFIX } from '../../../src/common/constants';
 import fs from 'node:fs';
 import path from 'node:path';
 
+const mockCreateStateBackend = jest.fn();
+
+jest.mock('../../../src/common/stateBackend', () => ({
+  ...jest.requireActual('../../../src/common/stateBackend'),
+  createStateBackend: (...args: unknown[]) => mockCreateStateBackend(...args),
+}));
+
 jest.mock('node:readline', () => ({
   createInterface: jest.fn(() => ({
     question: jest.fn((_question: string, callback: (answer: string) => void) => {
@@ -146,5 +153,68 @@ describe('forceUnlockCommand', () => {
     await forceUnlockCommand('any-lock-id', { location: ymlPath });
 
     loggerInfo.mockRestore();
+  });
+
+  it('should throw when a configured backend has no lock', async () => {
+    mockCreateStateBackend.mockReturnValue({
+      readLock: jest.fn().mockResolvedValue(null),
+    });
+
+    const ymlPath = path.join(testDir, 'local.yml');
+    fs.writeFileSync(
+      ymlPath,
+      [
+        'version: 0.1.0',
+        'provider:',
+        '  name: aliyun',
+        '  region: cn-hongkong',
+        'app: test-app',
+        'service: test-service',
+        'backend:',
+        '  state_manager:',
+        '    type: LOCAL',
+      ].join('\n'),
+    );
+
+    await expect(forceUnlockCommand('missing-lock', { location: ymlPath })).rejects.toThrow(
+      'No lock found',
+    );
+    expect(mockCreateStateBackend).toHaveBeenCalled();
+  });
+
+  it('should throw when the configured backend cannot release the lock', async () => {
+    const lock = {
+      id: 'lock-id',
+      user: 'test@example.com',
+      processId: 123,
+      hostname: 'test-host',
+      operation: 'deploy',
+      acquiredAt: new Date().toISOString(),
+      path: '/test/path',
+    };
+    mockCreateStateBackend.mockReturnValue({
+      readLock: jest.fn().mockResolvedValue(lock),
+      forceUnlock: jest.fn().mockResolvedValue(false),
+    });
+
+    const ymlPath = path.join(testDir, 'local.yml');
+    fs.writeFileSync(
+      ymlPath,
+      [
+        'version: 0.1.0',
+        'provider:',
+        '  name: aliyun',
+        '  region: cn-hongkong',
+        'app: test-app',
+        'service: test-service',
+        'backend:',
+        '  state_manager:',
+        '    type: LOCAL',
+      ].join('\n'),
+    );
+
+    await expect(forceUnlockCommand('lock-id', { location: ymlPath })).rejects.toThrow(
+      'Failed to release lock',
+    );
   });
 });

--- a/tests/unit/commands/login.test.ts
+++ b/tests/unit/commands/login.test.ts
@@ -255,4 +255,69 @@ describe('login command', () => {
     const html = mockRes.end.mock.calls[0][0] as string;
     expect(html).toContain('https://console.console.test.com"');
   });
+
+  it('waits for authorization on non-callback requests', async () => {
+    mockReadlineAnswer = '1';
+    const openMock = jest.requireMock('open') as jest.Mock;
+    openMock.mockImplementation(() => Promise.resolve());
+    const createServerMock = jest.requireMock('node:http').createServer as jest.Mock;
+    mockServer.listen.mockImplementationOnce((_port: unknown, _host: unknown, cb: () => void) => {
+      cb();
+      return mockServer;
+    });
+
+    const loginPromise = login({});
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    const handler = createServerMock.mock.calls[0][0];
+    const mockRes = { writeHead: jest.fn(), end: jest.fn() };
+    await handler({ url: '/waiting' }, mockRes);
+
+    expect(mockRes.writeHead).toHaveBeenCalledWith(200, { 'Content-Type': 'text/plain' });
+    expect(mockRes.end).toHaveBeenCalledWith('Waiting for authorization...');
+
+    await handler({ url: '/callback?api_key=key' }, mockRes);
+    await loginPromise;
+  });
+
+  it('warns when the browser opener rejects', async () => {
+    mockReadlineAnswer = '1';
+    const openMock = jest.requireMock('open') as jest.Mock;
+    openMock.mockRejectedValue(new Error('browser unavailable'));
+    const createServerMock = jest.requireMock('node:http').createServer as jest.Mock;
+    mockServer.listen.mockImplementationOnce((_port: unknown, _host: unknown, cb: () => void) => {
+      cb();
+      return mockServer;
+    });
+
+    const loginPromise = login({});
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    const handler = createServerMock.mock.calls[0][0];
+    await handler({ url: '/callback?api_key=key' }, { writeHead: jest.fn(), end: jest.fn() });
+    await loginPromise;
+    await Promise.resolve();
+
+    expect(logger.warn).toHaveBeenCalledWith('LOGIN_BROWSER_UNAVAILABLE');
+  });
+
+  it('warns when the browser opener throws synchronously', async () => {
+    mockReadlineAnswer = '1';
+    const openMock = jest.requireMock('open') as jest.Mock;
+    openMock.mockImplementation(() => {
+      throw new Error('browser unavailable');
+    });
+    const createServerMock = jest.requireMock('node:http').createServer as jest.Mock;
+    mockServer.listen.mockImplementationOnce((_port: unknown, _host: unknown, cb: () => void) => {
+      cb();
+      return mockServer;
+    });
+
+    const loginPromise = login({});
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    const handler = createServerMock.mock.calls[0][0];
+    await handler({ url: '/callback?api_key=key' }, { writeHead: jest.fn(), end: jest.fn() });
+    await loginPromise;
+
+    expect(logger.warn).toHaveBeenCalledWith('LOGIN_BROWSER_UNAVAILABLE');
+  });
 });

--- a/tests/unit/commands/show.test.ts
+++ b/tests/unit/commands/show.test.ts
@@ -264,6 +264,34 @@ describe('show command', () => {
         expect.stringContaining('Failed to load state from remote backend'),
       );
     });
+
+    it('should warn with SaaS wording when the default remote backend fails', async () => {
+      (createStateBackend as jest.Mock).mockImplementation(() => {
+        throw new Error('SaaS unavailable');
+      });
+
+      process.chdir(testDir);
+      const stateDir = path.join(testDir, '.serverlessinsight');
+      fs.mkdirSync(stateDir, { recursive: true });
+      const statePath = path.join(stateDir, 'state-test-app-test-service.json');
+      fs.writeFileSync(
+        statePath,
+        JSON.stringify({
+          version: '1.0.0',
+          provider: 'aliyun',
+          app: 'test-app',
+          service: 'test-service',
+          stages: { default: { resources: {} } },
+          resources: {},
+        }),
+      );
+
+      await show({ stage: 'default', location: testDir });
+
+      expect(mockLoggerWarn).toHaveBeenCalledWith(
+        expect.stringContaining('SaaS backend unavailable'),
+      );
+    });
   });
 
   describe('with empty state', () => {

--- a/tests/unit/common/aliyunClient/rdsOperations.test.ts
+++ b/tests/unit/common/aliyunClient/rdsOperations.test.ts
@@ -12,6 +12,7 @@ const mockModifyDBInstanceSpec = jest.fn();
 const mockModifySecurityIps = jest.fn();
 const mockDeleteDBInstance = jest.fn();
 const mockListTagResources = jest.fn();
+const mockDescribeDBInstances = jest.fn();
 
 const mockRdsClient = {
   createDBInstance: mockCreateDBInstance,
@@ -20,6 +21,7 @@ const mockRdsClient = {
   modifySecurityIps: mockModifySecurityIps,
   deleteDBInstance: mockDeleteDBInstance,
   listTagResources: mockListTagResources,
+  describeDBInstances: mockDescribeDBInstances,
 } as unknown as RdsClient;
 
 jest.mock('../../../../src/common/logger', () => ({
@@ -171,6 +173,46 @@ describe('rdsOperations', () => {
 
       const result = await operations.createInstance(config);
       expect(result).toBe('rds-instance-123');
+    });
+
+    it('should fail when the instance disappears while waiting', async () => {
+      mockCreateDBInstance.mockResolvedValue({ body: { DBInstanceId: 'rds-instance-123' } });
+      mockDescribeDBInstanceAttribute.mockResolvedValue({
+        body: { Items: { DBInstanceAttribute: [] } },
+      });
+
+      await expect(
+        operations.createInstance({
+          dbInstanceDescription: 'Test RDS',
+          engine: 'MySQL',
+          engineVersion: '5.7',
+          dbInstanceClass: 'mysql.n2.medium.1',
+          dbInstanceStorage: 20,
+          category: 'HighAvailability',
+          dbInstanceStorageType: 'cloud_ssd',
+        }),
+      ).rejects.toThrow('RDS_INSTANCE_NOT_FOUND');
+    });
+
+    it('should fail when the instance reaches a deleted state while waiting', async () => {
+      mockCreateDBInstance.mockResolvedValue({ body: { DBInstanceId: 'rds-instance-123' } });
+      mockDescribeDBInstanceAttribute.mockResolvedValue({
+        body: {
+          Items: { DBInstanceAttribute: [{ DBInstanceStatus: RdsInstanceStatus.DELETED }] },
+        },
+      });
+
+      await expect(
+        operations.createInstance({
+          dbInstanceDescription: 'Test RDS',
+          engine: 'MySQL',
+          engineVersion: '5.7',
+          dbInstanceClass: 'mysql.n2.medium.1',
+          dbInstanceStorage: 20,
+          category: 'HighAvailability',
+          dbInstanceStorageType: 'cloud_ssd',
+        }),
+      ).rejects.toThrow('RDS_INSTANCE_ERROR_STATE');
     });
   });
 
@@ -445,6 +487,76 @@ describe('rdsOperations', () => {
         'InvalidDBInstanceState',
       );
     });
+
+    it('should translate a readiness polling timeout', async () => {
+      mockDescribeDBInstanceAttribute.mockResolvedValue({
+        body: {
+          Items: { DBInstanceAttribute: [{ DBInstanceStatus: RdsInstanceStatus.CREATING }] },
+        },
+      });
+
+      const updatePromise = operations.updateInstance('rds-instance-123', {
+        dbInstanceDescription: 'Updated RDS',
+        engine: 'MySQL',
+        engineVersion: '5.7',
+        dbInstanceClass: 'mysql.n2.medium.1',
+        dbInstanceStorage: 20,
+        category: 'HighAvailability',
+        dbInstanceStorageType: 'cloud_ssd',
+      });
+      const rejection = expect(updatePromise).rejects.toThrow('RDS_INSTANCE_TIMEOUT_READY');
+      await jest.runAllTimersAsync();
+
+      await rejection;
+    });
+  });
+
+  describe('getInstanceByName', () => {
+    it('should return the exact description match with tags', async () => {
+      mockDescribeDBInstances.mockResolvedValue({
+        body: {
+          items: {
+            DBInstance: [
+              { DBInstanceId: 'wrong', DBInstanceDescription: 'other-name' },
+              { DBInstanceId: 'matching', DBInstanceDescription: 'target-name' },
+            ],
+          },
+        },
+      });
+      mockDescribeDBInstanceAttribute.mockResolvedValue({
+        body: {
+          Items: {
+            DBInstanceAttribute: [{ DBInstanceId: 'matching', DBInstanceStatus: 'Running' }],
+          },
+        },
+      });
+      mockListTagResources.mockResolvedValue({
+        body: { tagResources: { tagResource: [{ tagKey: 'owner', tagValue: 'stack' }] } },
+      });
+
+      await expect(operations.getInstanceByName('target-name')).resolves.toEqual(
+        expect.objectContaining({
+          dbInstanceId: 'matching',
+          tags: [{ key: 'owner', value: 'stack' }],
+        }),
+      );
+    });
+
+    it('should return null when no exact description match exists', async () => {
+      mockDescribeDBInstances.mockResolvedValue({
+        body: {
+          items: { DBInstance: [{ DBInstanceId: 'wrong', DBInstanceDescription: 'other-name' }] },
+        },
+      });
+
+      await expect(operations.getInstanceByName('target-name')).resolves.toBeNull();
+    });
+
+    it('should return null when listing instances fails', async () => {
+      mockDescribeDBInstances.mockRejectedValue(new Error('describe failed'));
+
+      await expect(operations.getInstanceByName('target-name')).resolves.toBeNull();
+    });
   });
 
   describe('deleteInstance', () => {
@@ -473,6 +585,19 @@ describe('rdsOperations', () => {
       mockDeleteDBInstance.mockRejectedValue(new Error('AccessDenied'));
 
       await expect(operations.deleteInstance('rds-instance-123')).rejects.toThrow('AccessDenied');
+    });
+
+    it('should translate a deletion polling timeout', async () => {
+      mockDeleteDBInstance.mockResolvedValue({});
+      mockDescribeDBInstanceAttribute.mockResolvedValue({
+        body: { Items: { DBInstanceAttribute: [{ DBInstanceStatus: RdsInstanceStatus.RUNNING }] } },
+      });
+
+      const deletePromise = operations.deleteInstance('rds-instance-123');
+      const rejection = expect(deletePromise).rejects.toThrow('RDS_INSTANCE_TIMEOUT_DELETE');
+      await jest.runAllTimersAsync();
+
+      await rejection;
     });
   });
 });

--- a/tests/unit/common/apiClient.test.ts
+++ b/tests/unit/common/apiClient.test.ts
@@ -29,6 +29,20 @@ describe('apiClient', () => {
   });
 
   describe('createApiClient', () => {
+    it('adds the organization header when orgId is provided', async () => {
+      client = createApiClient({ apiKey: testApiKey, baseUrl: testBaseUrl, orgId: 'org-123' });
+      mockFetch.mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+
+      await client.get('/organization');
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        `${testBaseUrl}/organization`,
+        expect.objectContaining({
+          headers: expect.objectContaining({ 'X-Org-Id': 'org-123' }),
+        }),
+      );
+    });
+
     it('should send the auth header and content type on every request', async () => {
       mockFetch.mockResolvedValue(new Response(JSON.stringify({ data: 'ok' }), { status: 200 }));
 

--- a/tests/unit/common/base64.test.ts
+++ b/tests/unit/common/base64.test.ts
@@ -1,0 +1,21 @@
+import { encodeBase64, encodeBase64ForRosId } from '../../../src/common/base64';
+
+describe('base64 utilities', () => {
+  it('encodes empty and unicode strings as UTF-8 base64', () => {
+    expect(encodeBase64('')).toBe('');
+    expect(encodeBase64('你好, 🌍')).toBe('5L2g5aW9LCDwn4yN');
+  });
+
+  it('preserves standard base64 padding', () => {
+    expect(encodeBase64('f')).toBe('Zg==');
+    expect(encodeBase64('fo')).toBe('Zm8=');
+    expect(encodeBase64('foo')).toBe('Zm9v');
+  });
+
+  it('removes trailing padding for ROS resource ids', () => {
+    expect(encodeBase64ForRosId('f')).toBe('Zg');
+    expect(encodeBase64ForRosId('fo')).toBe('Zm8');
+    expect(encodeBase64ForRosId('foo')).toBe('Zm9v');
+    expect(encodeBase64ForRosId('')).toBe('');
+  });
+});

--- a/tests/unit/common/eventQueue.test.ts
+++ b/tests/unit/common/eventQueue.test.ts
@@ -153,3 +153,126 @@ describe('EventQueue', () => {
     expect(mockSendBatch.mock.calls[0][0]).toHaveLength(1);
   });
 });
+
+jest.mock('../../../src/common/retryUtils', () => ({
+  sleep: jest.fn().mockResolvedValue(undefined),
+}));
+
+describe('EventQueue uncovered paths', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    fs.rmSync(queueDir, { recursive: true, force: true });
+  });
+
+  it('removes empty orphan files without sending a batch', async () => {
+    fs.mkdirSync(queueDir, { recursive: true });
+    const emptyFile = path.join(queueDir, 'empty.jsonl');
+    fs.writeFileSync(emptyFile, '\n');
+    const queue = new EventQueue({ deploymentId: 'dep-empty', queueDir, sendBatch: mockSendBatch });
+
+    await queue.replayOrphanedQueues();
+
+    expect(fs.existsSync(emptyFile)).toBe(false);
+    expect(mockSendBatch).not.toHaveBeenCalled();
+  });
+
+  it('logs a warning and retains an orphan file when replay fails', async () => {
+    fs.mkdirSync(queueDir, { recursive: true });
+    const orphanFile = path.join(queueDir, 'failed.jsonl');
+    fs.writeFileSync(orphanFile, `${JSON.stringify({ type: 'failed' })}\n`);
+    mockSendBatch.mockRejectedValue(new Error('replay failed'));
+    const queue = new EventQueue({
+      deploymentId: 'dep-failed',
+      queueDir,
+      sendBatch: mockSendBatch,
+      maxRetries: 1,
+    });
+
+    await queue.replayOrphanedQueues();
+
+    const mockedLogger = jest.requireMock('../../../src/common/logger') as {
+      logger: { warn: jest.Mock };
+    };
+    expect(fs.existsSync(orphanFile)).toBe(true);
+    expect(mockedLogger.logger.warn).toHaveBeenCalledWith('EVENT_REPLAY_FAILED');
+  });
+
+  it('rewrites unsent JSONL entries after a partial flush', async () => {
+    fs.mkdirSync(queueDir, { recursive: true });
+    const file = path.join(queueDir, 'dep-partial.jsonl');
+    fs.writeFileSync(file, `${JSON.stringify({ type: 'old' })}\n`);
+    mockSendBatch.mockResolvedValue(undefined);
+    const queue = new EventQueue({
+      deploymentId: 'dep-partial',
+      queueDir,
+      sendBatch: mockSendBatch,
+      batchSize: 10,
+    });
+
+    queue.report({ type: 'new' });
+    await queue.flush();
+
+    expect(fs.readFileSync(file, 'utf8')).toBe(`${JSON.stringify({ type: 'old' })}\n`);
+  });
+
+  it('flushes pending events when the interval elapses', async () => {
+    jest.useFakeTimers();
+    mockSendBatch.mockResolvedValue(undefined);
+    const queue = new EventQueue({
+      deploymentId: 'dep-interval',
+      queueDir,
+      sendBatch: mockSendBatch,
+      batchSize: 10,
+      flushIntervalMs: 100,
+    });
+    queue.report({ type: 'interval' });
+
+    await jest.advanceTimersByTimeAsync(100);
+
+    expect(mockSendBatch).toHaveBeenCalledWith([{ type: 'interval' }]);
+    jest.useRealTimers();
+  });
+
+  it('retries failed sends with bounded backoff before succeeding', async () => {
+    mockSendBatch.mockRejectedValueOnce(new Error('temporary')).mockResolvedValueOnce(undefined);
+    const queue = new EventQueue({
+      deploymentId: 'dep-retry',
+      queueDir,
+      sendBatch: mockSendBatch,
+      batchSize: 10,
+      baseRetryMs: 25,
+      maxRetries: 2,
+    });
+    queue.report({ type: 'retry' });
+
+    await queue.flush();
+
+    expect(mockSendBatch).toHaveBeenCalledTimes(2);
+    expect(queue.pendingCount).toBe(0);
+  });
+
+  it('registers signal handlers that initiate the final flush', async () => {
+    const onceSpy = jest.spyOn(process, 'once');
+    mockSendBatch.mockResolvedValue(undefined);
+    const queue = new EventQueue({
+      deploymentId: 'dep-signal',
+      queueDir,
+      sendBatch: mockSendBatch,
+      batchSize: 10,
+      flushOnExit: true,
+    });
+    queue.report({ type: 'signal' });
+
+    const signalRegistration = onceSpy.mock.calls.find(([signal]) => signal === 'SIGINT');
+    const handler = signalRegistration?.[1];
+    expect(typeof handler).toBe('function');
+    if (typeof handler === 'function') {
+      handler();
+      await Promise.resolve();
+      await Promise.resolve();
+    }
+
+    expect(mockSendBatch).toHaveBeenCalledWith([{ type: 'signal' }]);
+    onceSpy.mockRestore();
+  });
+});

--- a/tests/unit/common/fileUtils.test.ts
+++ b/tests/unit/common/fileUtils.test.ts
@@ -1,0 +1,42 @@
+import fs from 'node:fs';
+
+jest.mock('node:fs', () => ({
+  __esModule: true,
+  default: { readFileSync: jest.fn() },
+}));
+
+import { readFile, readFileAsBase64 } from '../../../src/common/fileUtils';
+
+const mockReadFileSync = fs.readFileSync as jest.MockedFunction<typeof fs.readFileSync>;
+
+describe('file utilities', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns file contents as base64', () => {
+    const contents = Buffer.from('hello, 世界', 'utf8');
+    mockReadFileSync.mockReturnValue(contents);
+
+    expect(readFileAsBase64('/tmp/example.txt')).toBe(contents.toString('base64'));
+    expect(mockReadFileSync).toHaveBeenCalledWith('/tmp/example.txt');
+  });
+
+  it('returns the original buffer without changing it', () => {
+    const contents = Buffer.from([0, 1, 2, 255]);
+    mockReadFileSync.mockReturnValue(contents);
+
+    expect(readFile('/tmp/binary.dat')).toBe(contents);
+    expect(mockReadFileSync).toHaveBeenCalledWith('/tmp/binary.dat');
+  });
+
+  it('propagates filesystem errors', () => {
+    const error = new Error('read failed');
+    mockReadFileSync.mockImplementation(() => {
+      throw error;
+    });
+
+    expect(() => readFileAsBase64('/tmp/missing.txt')).toThrow(error);
+    expect(() => readFile('/tmp/missing.txt')).toThrow(error);
+  });
+});

--- a/tests/unit/common/hashUtils.test.ts
+++ b/tests/unit/common/hashUtils.test.ts
@@ -268,4 +268,18 @@ describe('HashUtils', () => {
       });
     });
   });
+
+  describe('deep equality edge cases', () => {
+    it('returns false for values with different primitive types', () => {
+      expect(attributesEqual({ value: 1 }, { value: '1' })).toBe(false);
+    });
+
+    it('returns false when one value is null and the other is non-null', () => {
+      expect(attributesEqual({ value: null }, { value: {} })).toBe(false);
+    });
+
+    it('returns false when one value is an array and the other is an object', () => {
+      expect(attributesEqual({ value: [] }, { value: {} })).toBe(false);
+    });
+  });
 });

--- a/tests/unit/common/logger.test.ts
+++ b/tests/unit/common/logger.test.ts
@@ -504,3 +504,64 @@ describe('Logger Module', () => {
     });
   });
 });
+
+describe('Logger isolated branch coverage', () => {
+  it('detects a Windows code page from chcp output during initialization', () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' });
+    execSync.mockReturnValue('Active code page: 936\n');
+
+    try {
+      jest.isolateModules(() => {
+        const { logger: isolatedLogger } = require('../../../src/common/logger');
+        expect(() => isolatedLogger.info('windows initialization')).not.toThrow();
+      });
+    } finally {
+      Object.defineProperty(process, 'platform', { configurable: true, value: originalPlatform });
+    }
+
+    expect(execSync).toHaveBeenCalledWith('chcp', {
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+  });
+
+  it('passes formatting errors to the writable stream callback', () => {
+    type CapturedStream = {
+      _write: (
+        chunk: string | Buffer,
+        encoding: string,
+        callback: (error?: Error | null) => void,
+      ) => void;
+    };
+    let capturedStream: CapturedStream | undefined;
+    const mockPino = jest.fn((_options: unknown, destination: unknown) => {
+      capturedStream = destination as CapturedStream;
+      return {
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+        debug: jest.fn(),
+      };
+    });
+    const formatError = new Error('format failed');
+
+    jest.isolateModules(() => {
+      jest.doMock('pino', () => ({ __esModule: true, default: mockPino }));
+      jest.doMock('pino-pretty', () => ({
+        __esModule: true,
+        default: {
+          prettyFactory: () => () => {
+            throw formatError;
+          },
+        },
+      }));
+      require('../../../src/common/logger');
+    });
+
+    const callback = jest.fn();
+    capturedStream?._write('chunk', 'utf8', callback);
+
+    expect(callback).toHaveBeenCalledWith(formatError);
+  });
+});

--- a/tests/unit/common/stateBackend/remoteStateBackend.test.ts
+++ b/tests/unit/common/stateBackend/remoteStateBackend.test.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import os from 'node:os';
 import { createRemoteStateBackend } from '../../../../src/common/stateBackend/remoteStateBackend';
 import { StorageAdapter } from '../../../../src/common/stateBackend/types';
 import {
@@ -12,7 +13,14 @@ import { LockError } from '../../../../src/common/lockManager';
 import * as lockUtils from '../../../../src/common/stateBackend/lockUtils';
 
 jest.mock('../../../../src/common/stateBackend/lockUtils');
-jest.mock('../../../../src/common/logger');
+jest.mock('../../../../src/common/logger', () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
 
 describe('remoteStateBackend', () => {
   let mockAdapter: jest.Mocked<StorageAdapter>;
@@ -237,6 +245,72 @@ describe('remoteStateBackend', () => {
       const backend = createRemoteStateBackend(mockAdapter, { key: 'state.json' });
 
       await expect(backend.acquireLock('deploy')).rejects.toThrow(LockError);
+    });
+
+    it('should release a lock owned by a dead process and retry acquisition', async () => {
+      const deadLock: LockMetadata = {
+        id: 'dead-lock',
+        user: 'user@host',
+        processId: 1234,
+        hostname: os.hostname(),
+        operation: 'deploy',
+        acquiredAt: new Date().toISOString(),
+        path: '/path',
+      };
+      const acquiredLock: LockMetadata = {
+        ...deadLock,
+        id: 'test-lock-id',
+      };
+      mockLockUtils.isProcessAlive.mockReturnValue(false);
+      mockAdapter.read
+        .mockResolvedValueOnce(deadLock)
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(acquiredLock);
+
+      const backend = createRemoteStateBackend(mockAdapter, { key: 'state.json' });
+
+      await expect(backend.acquireLock('deploy', { maxRetries: 1, retryDelay: 0 })).resolves.toBe(
+        'test-lock-id',
+      );
+      expect(mockAdapter.delete).toHaveBeenCalledWith('state.json.si-lock');
+    });
+
+    it('should fail immediately when the lock timeout has elapsed', async () => {
+      const lock: LockMetadata = {
+        id: 'current-lock',
+        user: 'user@host',
+        processId: 1234,
+        hostname: 'other-host',
+        operation: 'deploy',
+        acquiredAt: new Date().toISOString(),
+        path: '/path',
+      };
+      mockAdapter.read.mockResolvedValue(lock);
+
+      const backend = createRemoteStateBackend(mockAdapter, { key: 'state.json' });
+
+      await expect(backend.acquireLock('deploy', { timeout: 0, maxRetries: 0 })).rejects.toThrow(
+        'Failed to acquire lock after 0 seconds',
+      );
+    });
+
+    it('should fail after exhausting lock retries', async () => {
+      const lock: LockMetadata = {
+        id: 'current-lock',
+        user: 'user@host',
+        processId: 1234,
+        hostname: 'other-host',
+        operation: 'deploy',
+        acquiredAt: new Date().toISOString(),
+        path: '/path',
+      };
+      mockAdapter.read.mockResolvedValue(lock);
+
+      const backend = createRemoteStateBackend(mockAdapter, { key: 'state.json' });
+
+      await expect(
+        backend.acquireLock('deploy', { timeout: 100000, maxRetries: 0, retryDelay: 0 }),
+      ).rejects.toThrow('Failed to acquire lock');
     });
   });
 

--- a/tests/unit/common/stateBackend/saasStateBackend.test.ts
+++ b/tests/unit/common/stateBackend/saasStateBackend.test.ts
@@ -200,6 +200,12 @@ describe('saasStateBackend', () => {
     });
   });
 
+  describe('acquireLock', () => {
+    it('should return the SaaS lock placeholder', async () => {
+      await expect(backend.acquireLock('deploy')).resolves.toBe('saas-lock-placeholder');
+    });
+  });
+
   describe('readLock', () => {
     it('should return null before any loadState', async () => {
       const result = await backend.readLock();
@@ -268,6 +274,32 @@ describe('saasStateBackend', () => {
       const lock = await backend.readLock();
 
       expect(lock).toBeNull();
+    });
+
+    it('should return null when the active deployment lookup fails', async () => {
+      mockApiClient.post.mockResolvedValueOnce({
+        id: 'deploy-1',
+        appId: 'app-1',
+        serviceId: 'svc-1',
+        status: 'active',
+        isNewApp: false,
+        isNewService: false,
+      });
+      mockApiClient.get.mockResolvedValueOnce({
+        stateJson: {
+          version: '3.0',
+          provider: 'aliyun',
+          app: 'myapp',
+          service: 'myservice',
+          stages: {},
+          resources: {},
+        },
+      });
+      mockApiClient.get.mockRejectedValueOnce(new Error('service unavailable'));
+
+      await backend.loadState('aliyun', 'myapp', 'myservice', 'dev');
+
+      await expect(backend.readLock()).resolves.toBeNull();
     });
   });
 
@@ -449,6 +481,33 @@ describe('saasStateBackend', () => {
       expect(fn).not.toHaveBeenCalled();
     });
 
+    it('should throw when provisioning did not produce a deployment', async () => {
+      mockApiClient.post.mockResolvedValueOnce({
+        id: '',
+        appId: 'app-1',
+        serviceId: 'svc-1',
+        status: 'active',
+        isNewApp: false,
+        isNewService: false,
+      });
+      mockApiClient.get.mockResolvedValueOnce({
+        stateJson: {
+          version: '3.0',
+          provider: 'aliyun',
+          app: 'myapp',
+          service: 'myservice',
+          stages: {},
+          resources: {},
+        },
+      });
+
+      await backend.loadState('aliyun', 'myapp', 'myservice', 'dev');
+
+      await expect(backend.withLock('deploy', jest.fn())).rejects.toThrow(
+        'no deployment available',
+      );
+    });
+
     it('reportEvent sends a typed event via PATCH phase:event', async () => {
       mockApiClient.post.mockResolvedValueOnce({
         id: 'deploy-1',
@@ -500,6 +559,10 @@ describe('saasStateBackend', () => {
           ]),
         }),
       );
+    });
+
+    it('should replay orphaned event queues without throwing', async () => {
+      await expect(backend.replayOrphanedEvents?.()).resolves.toBeUndefined();
     });
   });
 });

--- a/tests/unit/common/tencentClient/esOperations.test.ts
+++ b/tests/unit/common/tencentClient/esOperations.test.ts
@@ -1,5 +1,6 @@
 import { createTencentEsOperations } from '../../../../src/common/tencentClient/esOperations';
 import { TencentEsSpaceStatus } from '../../../../src/common/tencentClient/types';
+import * as polling from '../../../../src/common/polling';
 
 jest.mock('../../../../src/common/logger', () => ({
   logger: {
@@ -138,6 +139,26 @@ describe('esOperations', () => {
       );
     });
 
+    it('should include white-listed IPs and tags when provided', async () => {
+      mockEsClient.CreateServerlessSpaceV2.mockResolvedValue({ SpaceId: 'space-tags' });
+      mockEsClient.DescribeServerlessSpaces.mockResolvedValue({
+        ServerlessSpaces: [{ SpaceId: 'space-tags', Status: TencentEsSpaceStatus.NORMAL }],
+      });
+
+      await operations.createSpace({
+        SpaceName: 'tagged-space',
+        KibanaWhiteIpList: ['1.2.3.4'],
+        Tags: [{ Key: 'env', Value: 'test' }],
+      });
+
+      expect(mockEsClient.CreateServerlessSpaceV2).toHaveBeenCalledWith(
+        expect.objectContaining({
+          KibanaWhiteIpList: ['1.2.3.4'],
+          TagList: [{ TagKey: 'env', TagValue: 'test' }],
+        }),
+      );
+    });
+
     it('should throw error when no SpaceId returned', async () => {
       mockEsClient.CreateServerlessSpaceV2.mockResolvedValue({});
 
@@ -148,6 +169,36 @@ describe('esOperations', () => {
       await expect(operations.createSpace(config)).rejects.toThrow(
         'TENCENT_ES_SPACE_NO_ID_RETURNED',
       );
+    });
+
+    it('should reject when the space reaches a deleted state while creating', async () => {
+      mockEsClient.CreateServerlessSpaceV2.mockResolvedValue({ SpaceId: 'space-123' });
+      mockEsClient.DescribeServerlessSpaces.mockResolvedValue({
+        ServerlessSpaces: [{ SpaceId: 'space-123', Status: TencentEsSpaceStatus.DELETED }],
+      });
+
+      await expect(operations.createSpace({ SpaceName: 'test-space' })).rejects.toThrow(
+        'TENCENT_ES_SPACE_ERROR_STATE',
+      );
+    });
+
+    it('should translate a readiness polling timeout', async () => {
+      mockEsClient.CreateServerlessSpaceV2.mockResolvedValue({ SpaceId: 'space-123' });
+      const pollSpy = jest.spyOn(polling, 'pollUntil').mockRejectedValueOnce(
+        new polling.PollingTimeoutError({
+          description: 'ready',
+          lastValue: null,
+          attempts: 60,
+          maxAttempts: 60,
+          intervalMs: 10000,
+        }),
+      );
+
+      await expect(operations.createSpace({ SpaceName: 'test-space' })).rejects.toThrow(
+        'TENCENT_ES_SPACE_TIMEOUT_READY',
+      );
+
+      pollSpy.mockRestore();
     });
 
     it('should handle creation errors', async () => {
@@ -229,6 +280,12 @@ describe('esOperations', () => {
       const result = await operations.getSpace('space-123');
 
       expect(result?.Status).toBe(TencentEsSpaceStatus.CREATING);
+    });
+
+    it('should return null when the API reports an invalid parameter', async () => {
+      mockEsClient.DescribeServerlessSpaces.mockRejectedValue({ code: 'InvalidParameterValue' });
+
+      await expect(operations.getSpace('space-123')).resolves.toBeNull();
     });
 
     it('should retain the full detail set (max-detail state)', async () => {
@@ -388,6 +445,45 @@ describe('esOperations', () => {
     });
   });
 
+  describe('getSpaceByName', () => {
+    it('should return the matching space and map its tags', async () => {
+      mockEsClient.DescribeServerlessSpaces.mockResolvedValue({
+        ServerlessSpaces: [
+          { SpaceName: 'other' },
+          {
+            SpaceId: 'space-123',
+            SpaceName: 'target',
+            TagList: [{ TagKey: 'team', TagValue: 'core' }],
+          },
+        ],
+      });
+
+      await expect(operations.getSpaceByName('target')).resolves.toEqual(
+        expect.objectContaining({ SpaceId: 'space-123', Tags: [{ Key: 'team', Value: 'core' }] }),
+      );
+    });
+
+    it('should return null when no space matches by name', async () => {
+      mockEsClient.DescribeServerlessSpaces.mockResolvedValue({
+        ServerlessSpaces: [{ SpaceName: 'other' }],
+      });
+
+      await expect(operations.getSpaceByName('target')).resolves.toBeNull();
+    });
+
+    it('should return null for a not-found name lookup error', async () => {
+      mockEsClient.DescribeServerlessSpaces.mockRejectedValue({ code: 'InvalidParameterValue' });
+
+      await expect(operations.getSpaceByName('target')).resolves.toBeNull();
+    });
+
+    it('should rethrow unexpected name lookup errors', async () => {
+      mockEsClient.DescribeServerlessSpaces.mockRejectedValue(new Error('permission denied'));
+
+      await expect(operations.getSpaceByName('target')).rejects.toThrow('permission denied');
+    });
+  });
+
   describe('deleteSpace', () => {
     it('should delete space and all instances', async () => {
       mockEsClient.DescribeServerlessInstances.mockResolvedValue({
@@ -460,6 +556,38 @@ describe('esOperations', () => {
       await operations.deleteSpace('space-123');
 
       expect(mockEsClient.DeleteServerlessInstance).toHaveBeenCalledTimes(2);
+    });
+
+    it('should finish deletion when the space is observed in deleted state', async () => {
+      mockEsClient.DescribeServerlessInstances.mockResolvedValue({ Instances: [] });
+      mockEsClient.DescribeServerlessSpaces.mockResolvedValue({
+        ServerlessSpaces: [{ SpaceId: 'space-123', Status: TencentEsSpaceStatus.DELETED }],
+      });
+
+      await operations.deleteSpace('space-123');
+
+      expect(mockEsClient.DescribeServerlessSpaces).toHaveBeenCalledWith({
+        SpaceIds: ['space-123'],
+      });
+    });
+
+    it('should translate a deletion polling timeout', async () => {
+      mockEsClient.DescribeServerlessInstances.mockResolvedValue({ Instances: [] });
+      const pollSpy = jest.spyOn(polling, 'pollUntil').mockRejectedValueOnce(
+        new polling.PollingTimeoutError({
+          description: 'deleted',
+          lastValue: null,
+          attempts: 60,
+          maxAttempts: 60,
+          intervalMs: 10000,
+        }),
+      );
+
+      await expect(operations.deleteSpace('space-123')).rejects.toThrow(
+        'TENCENT_ES_SPACE_TIMEOUT_DELETE',
+      );
+
+      pollSpy.mockRestore();
     });
   });
 });

--- a/tests/unit/common/tencentClient/tdsqlcOperations.test.ts
+++ b/tests/unit/common/tencentClient/tdsqlcOperations.test.ts
@@ -1,5 +1,6 @@
 import { createTdsqlcOperations } from '../../../../src/common/tencentClient/tdsqlcOperations';
 import { TdsqlcClusterStatus } from '../../../../src/common/tencentClient/types';
+import * as polling from '../../../../src/common/polling';
 
 jest.mock('../../../../src/common/logger', () => ({
   logger: {
@@ -320,6 +321,89 @@ describe('tdsqlcOperations', () => {
       // is the cluster running state, not the idle-stall switch.
       expect(result?.AutoPause).toBeUndefined();
     });
+
+    it('should reject creation when the created cluster cannot be found', async () => {
+      mockCynosdbClient.CreateClusters.mockResolvedValue({ ClusterIds: ['cluster-123'] });
+      mockCynosdbClient.DescribeClusters.mockResolvedValue({ ClusterSet: [] });
+
+      await expect(
+        operations.createCluster({
+          ClusterName: 'test-cluster',
+          DbType: 'cynosdb',
+          DbVersion: '5.7',
+          DbMode: 'serverless',
+          AdminPassword: 'password123',
+          MinCpu: 0.5,
+          MaxCpu: 1,
+        }),
+      ).rejects.toThrow('TDSQL_CLUSTER_NOT_FOUND');
+    });
+
+    it('should translate a readiness polling timeout', async () => {
+      mockCynosdbClient.CreateClusters.mockResolvedValue({ ClusterIds: ['cluster-123'] });
+      const pollSpy = jest.spyOn(polling, 'pollUntil').mockRejectedValueOnce(
+        new polling.PollingTimeoutError({
+          description: 'ready',
+          lastValue: null,
+          attempts: 60,
+          maxAttempts: 60,
+          intervalMs: 10000,
+        }),
+      );
+
+      await expect(
+        operations.createCluster({
+          ClusterName: 'test-cluster',
+          DbType: 'cynosdb',
+          DbVersion: '5.7',
+          DbMode: 'serverless',
+          AdminPassword: 'password123',
+          MinCpu: 0.5,
+          MaxCpu: 1,
+        }),
+      ).rejects.toThrow('TDSQL_CLUSTER_TIMEOUT_READY');
+
+      pollSpy.mockRestore();
+    });
+
+    it('should find a cluster by name on a later full page', async () => {
+      mockCynosdbClient.DescribeClusters.mockResolvedValueOnce({
+        ClusterSet: Array.from({ length: 100 }, () => ({ ClusterName: 'other' })),
+      }).mockResolvedValueOnce({
+        ClusterSet: [{ ClusterId: 'cluster-123', ClusterName: 'target', Status: 'running' }],
+      });
+
+      const result = await operations.getClusterByName('target');
+
+      expect(result).toEqual(
+        expect.objectContaining({ ClusterId: 'cluster-123', ClusterName: 'target' }),
+      );
+      expect(mockCynosdbClient.DescribeClusters).toHaveBeenNthCalledWith(2, {
+        Limit: 100,
+        Offset: 100,
+      });
+    });
+
+    it('should stop a name probe at a short page when no cluster matches', async () => {
+      mockCynosdbClient.DescribeClusters.mockResolvedValue({
+        ClusterSet: [{ ClusterName: 'other' }],
+      });
+
+      await expect(operations.getClusterByName('target')).resolves.toBeNull();
+      expect(mockCynosdbClient.DescribeClusters).toHaveBeenCalledTimes(1);
+    });
+
+    it('should return null when a name probe reports ResourceNotFound', async () => {
+      mockCynosdbClient.DescribeClusters.mockRejectedValue({ code: 'ResourceNotFound.Cluster' });
+
+      await expect(operations.getClusterByName('target')).resolves.toBeNull();
+    });
+
+    it('should rethrow unexpected name probe errors', async () => {
+      mockCynosdbClient.DescribeClusters.mockRejectedValue(new Error('permission denied'));
+
+      await expect(operations.getClusterByName('target')).rejects.toThrow('permission denied');
+    });
   });
 
   describe('updateCluster', () => {
@@ -395,13 +479,49 @@ describe('tdsqlcOperations', () => {
 
     it('should wait through OFFLINE status', async () => {
       mockCynosdbClient.OfflineCluster.mockResolvedValue({});
-      mockCynosdbClient.DescribeClusters.mockResolvedValue({ ClusterSet: [] });
+      mockCynosdbClient.DescribeClusters.mockResolvedValueOnce({
+        ClusterSet: [{ Status: TdsqlcClusterStatus.OFFLINE }],
+      }).mockResolvedValueOnce({ ClusterSet: [] });
 
-      await operations.deleteCluster('cluster-123');
+      const deletion = operations.deleteCluster('cluster-123');
+      await jest.advanceTimersByTimeAsync(10000);
+      await deletion;
 
       expect(mockCynosdbClient.OfflineCluster).toHaveBeenCalledWith({
         ClusterId: 'cluster-123',
       });
+    });
+
+    it('should wait through a non-terminal cluster status during deletion', async () => {
+      mockCynosdbClient.OfflineCluster.mockResolvedValue({});
+      mockCynosdbClient.DescribeClusters.mockResolvedValueOnce({
+        ClusterSet: [{ Status: TdsqlcClusterStatus.RUNNING }],
+      }).mockResolvedValueOnce({ ClusterSet: [] });
+
+      const deletion = operations.deleteCluster('cluster-123');
+      await jest.advanceTimersByTimeAsync(10000);
+      await deletion;
+
+      expect(mockCynosdbClient.DescribeClusters).toHaveBeenCalledTimes(2);
+    });
+
+    it('should translate a deletion polling timeout', async () => {
+      mockCynosdbClient.OfflineCluster.mockResolvedValue({});
+      const pollSpy = jest.spyOn(polling, 'pollUntil').mockRejectedValueOnce(
+        new polling.PollingTimeoutError({
+          description: 'deleted',
+          lastValue: null,
+          attempts: 60,
+          maxAttempts: 60,
+          intervalMs: 10000,
+        }),
+      );
+
+      await expect(operations.deleteCluster('cluster-123')).rejects.toThrow(
+        'TDSQL_CLUSTER_TIMEOUT_DELETE',
+      );
+
+      pollSpy.mockRestore();
     });
   });
 });

--- a/tests/unit/common/volcengineClient/tlsOperations.test.ts
+++ b/tests/unit/common/volcengineClient/tlsOperations.test.ts
@@ -103,6 +103,13 @@ describe('tlsOperations', () => {
       expect(result.projectName).toBe('test-project');
       expect(result.status).toBe('Active');
     });
+
+    it('should rethrow unexpected create errors', async () => {
+      const error = createError('AccessDenied');
+      mockClient.CreateProject.mockRejectedValueOnce(error);
+
+      await expect(operations.createProject({ projectName: 'test-project' })).rejects.toBe(error);
+    });
   });
 
   describe('getProject', () => {
@@ -141,6 +148,13 @@ describe('tlsOperations', () => {
 
       expect(result).toBeNull();
     });
+
+    it('should rethrow unexpected get errors', async () => {
+      const error = createError('AccessDenied');
+      mockClient.DescribeProjects.mockRejectedValueOnce(error);
+
+      await expect(operations.getProject('test-project')).rejects.toBe(error);
+    });
   });
 
   describe('deleteProject', () => {
@@ -175,6 +189,15 @@ describe('tlsOperations', () => {
       mockClient.DescribeProjects.mockRejectedValueOnce(createError('ResourceNotFound'));
 
       await expect(operations.deleteProject('missing-project')).resolves.toBeUndefined();
+    });
+
+    it('should tolerate a not-found response from DeleteProject', async () => {
+      mockClient.DescribeProjects.mockResolvedValueOnce({
+        Projects: [{ ProjectId: 'project-123', ProjectName: 'test-project' }],
+      });
+      mockClient.DeleteProject.mockRejectedValueOnce(createError('ProjectNotFound'));
+
+      await expect(operations.deleteProject('test-project')).resolves.toBeUndefined();
     });
   });
 
@@ -261,6 +284,22 @@ describe('tlsOperations', () => {
 
       expect(result.topicId).toBe('topic-123');
     });
+
+    it('should tolerate TopicAlreadyExists when the topic is already absent', async () => {
+      mockClient.DescribeProjects.mockResolvedValue({
+        Projects: [{ ProjectId: 'project-123', ProjectName: 'test-project' }],
+      });
+      mockClient.CreateTopic.mockRejectedValueOnce(createError('TopicAlreadyExists'));
+      mockClient.DescribeTopics.mockResolvedValueOnce({ Topics: [] });
+
+      const result = await operations.createTopic({
+        projectName: 'test-project',
+        topicName: 'test-topic',
+      });
+
+      expect(result.topicId).toBeUndefined();
+      expect(result.status).toBe('Active');
+    });
   });
 
   describe('getTopic', () => {
@@ -338,6 +377,13 @@ describe('tlsOperations', () => {
 
       expect(result).toBeNull();
     });
+
+    it('should return null when the project is missing', async () => {
+      mockClient.DescribeProjects.mockResolvedValueOnce({ Projects: [] });
+
+      await expect(operations.getTopic('missing-project', 'test-topic')).resolves.toBeNull();
+      expect(mockClient.DescribeTopics).not.toHaveBeenCalled();
+    });
   });
 
   describe('deleteTopic', () => {
@@ -411,6 +457,18 @@ describe('tlsOperations', () => {
         Total: 1,
       });
       mockClient.DescribeTopics.mockRejectedValueOnce(createError('ResourceNotFound'));
+
+      await expect(operations.deleteTopic('test-project', 'test-topic')).resolves.toBeUndefined();
+    });
+
+    it('should tolerate a not-found response from DeleteTopic', async () => {
+      mockClient.DescribeProjects.mockResolvedValueOnce({
+        Projects: [{ ProjectId: 'project-123', ProjectName: 'test-project' }],
+      });
+      mockClient.DescribeTopics.mockResolvedValueOnce({
+        Topics: [{ TopicId: 'topic-123', TopicName: 'test-topic' }],
+      });
+      mockClient.DeleteTopic.mockRejectedValueOnce(createError('TopicNotFound'));
 
       await expect(operations.deleteTopic('test-project', 'test-topic')).resolves.toBeUndefined();
     });
@@ -538,6 +596,32 @@ describe('tlsOperations', () => {
         }),
       ).resolves.toBeUndefined();
     });
+
+    it('should throw when the topic does not exist', async () => {
+      mockClient.DescribeProjects.mockResolvedValueOnce({
+        Projects: [{ ProjectId: 'project-123', ProjectName: 'test-project' }],
+      });
+      mockClient.DescribeTopics.mockResolvedValueOnce({ Topics: [] });
+
+      await expect(
+        operations.createIndex({ projectName: 'test-project', topicName: 'missing-topic' }),
+      ).rejects.toThrow('TLS_TOPIC_NOT_FOUND');
+    });
+
+    it('should rethrow unexpected createIndex errors', async () => {
+      mockClient.DescribeProjects.mockResolvedValueOnce({
+        Projects: [{ ProjectId: 'project-123', ProjectName: 'test-project' }],
+      });
+      mockClient.DescribeTopics.mockResolvedValueOnce({
+        Topics: [{ TopicId: 'topic-123', TopicName: 'test-topic' }],
+      });
+      const error = createError('AccessDenied');
+      mockClient.CreateIndex.mockRejectedValueOnce(error);
+
+      await expect(
+        operations.createIndex({ projectName: 'test-project', topicName: 'test-topic' }),
+      ).rejects.toBe(error);
+    });
   });
 
   describe('deleteIndex', () => {
@@ -596,6 +680,18 @@ describe('tlsOperations', () => {
       ).resolves.toBeUndefined();
       expect(mockClient.DeleteIndex).not.toHaveBeenCalled();
     });
+
+    it('should tolerate a not-found response from DeleteIndex', async () => {
+      mockClient.DescribeProjects.mockResolvedValueOnce({
+        Projects: [{ ProjectId: 'project-123', ProjectName: 'test-project' }],
+      });
+      mockClient.DescribeTopics.mockResolvedValueOnce({
+        Topics: [{ TopicId: 'topic-123', TopicName: 'test-topic' }],
+      });
+      mockClient.DeleteIndex.mockRejectedValueOnce(createError('IndexNotFound'));
+
+      await expect(operations.deleteIndex('test-project', 'test-topic')).resolves.toBeUndefined();
+    });
   });
 
   describe('waitForProject', () => {
@@ -625,11 +721,12 @@ describe('tlsOperations', () => {
     });
 
     it('should throw when project fails', async () => {
-      mockClient.DescribeProjects.mockRejectedValueOnce(createError('ProjectNotFound'));
+      jest.spyOn(operations, 'getProject').mockResolvedValueOnce({
+        projectName: 'test-project',
+        status: 'Failed',
+      });
 
-      await expect(operations.waitForProject('missing-project')).rejects.toThrow(
-        'TLS_PROJECT_NOT_FOUND',
-      );
+      await expect(operations.waitForProject('test-project')).rejects.toThrow('TLS_PROJECT_FAILED');
     });
   });
 

--- a/tests/unit/common/volcengineClient/tosOperations.test.ts
+++ b/tests/unit/common/volcengineClient/tosOperations.test.ts
@@ -1,6 +1,17 @@
+import * as fs from 'node:fs';
 import { Service } from '@volcengine/openapi';
 import { createTosOperations } from '../../../../src/common/volcengineClient/tosOperations';
 import type { TosBucketConfig } from '../../../../src/common/volcengineClient/types';
+
+jest.mock('node:fs', () => {
+  const actual = jest.requireActual<typeof import('node:fs')>('node:fs');
+  return {
+    ...actual,
+    readdirSync: jest.fn(actual.readdirSync),
+    readFileSync: jest.fn(actual.readFileSync),
+    statSync: jest.fn(actual.statSync),
+  };
+});
 
 jest.mock('../../../../src/common/logger', () => ({
   logger: {
@@ -869,6 +880,30 @@ describe('tosOperations', () => {
         );
       });
 
+      it('should parse a string policy document', async () => {
+        mockClient.fetchOpenAPI.mockResolvedValueOnce({
+          Result: { Policy: JSON.stringify({ Version: '1', Statement: [] }) },
+        });
+
+        await expect(operations.getBucketPolicy('test-bucket')).resolves.toEqual({
+          Version: '1',
+          Statement: [],
+        });
+      });
+
+      it('should return null when the policy result is empty', async () => {
+        mockClient.fetchOpenAPI.mockResolvedValueOnce({ Result: {} });
+
+        await expect(operations.getBucketPolicy('test-bucket')).resolves.toBeNull();
+      });
+
+      it('should rethrow unexpected policy errors', async () => {
+        const error = new Error('Access denied');
+        mockClient.fetchOpenAPI.mockRejectedValueOnce(error);
+
+        await expect(operations.getBucketPolicy('test-bucket')).rejects.toBe(error);
+      });
+
       it('should return null when policy does not exist (NoSuchBucketPolicy)', async () => {
         const error = new Error('Not found') as Error & { code: string };
         error.code = 'NoSuchBucketPolicy';
@@ -917,11 +952,93 @@ describe('tosOperations', () => {
         await expect(operations.deleteBucketPolicy('test-bucket')).resolves.toBeUndefined();
       });
 
+      it('should rethrow unexpected delete policy errors', async () => {
+        const error = new Error('Access denied');
+        mockClient.fetchOpenAPI.mockRejectedValueOnce(error);
+
+        await expect(operations.deleteBucketPolicy('test-bucket')).rejects.toBe(error);
+      });
+
       it('should throw error with null client', async () => {
         const nullClientOperations = createTosOperations(null, 'cn-beijing');
 
         await expect(nullClientOperations.deleteBucketPolicy('test-bucket')).rejects.toThrow(
           'VOLCENGINE_TOS_CLIENT_NOT_INITIALIZED',
+        );
+      });
+    });
+    describe('uploadFiles with a client', () => {
+      it('should upload a single file with its basename and content type', async () => {
+        const statSync = fs.statSync as jest.Mock;
+        statSync.mockReturnValue({
+          isDirectory: () => false,
+        } as fs.Stats);
+        const readFileSync = fs.readFileSync as jest.Mock;
+        readFileSync.mockReturnValue(Buffer.from('data'));
+        mockClient.fetchOpenAPI.mockResolvedValueOnce({});
+
+        await operations.uploadFiles('test-bucket', '/tmp/index.html');
+
+        expect(mockClient.fetchOpenAPI).toHaveBeenCalledWith(
+          expect.objectContaining({
+            Action: 'PutObject',
+            headers: { 'content-type': 'text/html' },
+            query: { Bucket: 'test-bucket', Key: 'index.html' },
+            data: Buffer.from('data'),
+          }),
+        );
+        statSync.mockImplementation(
+          jest.requireActual<typeof import('node:fs')>('node:fs').statSync,
+        );
+        readFileSync.mockImplementation(
+          jest.requireActual<typeof import('node:fs')>('node:fs').readFileSync,
+        );
+      });
+
+      it('should recursively upload files in a directory and ignore unsupported entries', async () => {
+        const directoryEntry = {
+          name: 'nested',
+          isDirectory: () => true,
+          isFile: () => false,
+        };
+        const fileEntry = {
+          name: 'app.js',
+          isDirectory: () => false,
+          isFile: () => true,
+        };
+        const ignoredEntry = {
+          name: 'link',
+          isDirectory: () => false,
+          isFile: () => false,
+        };
+        const readdirSync = fs.readdirSync as jest.Mock;
+        readdirSync.mockImplementation((dirPath: fs.PathLike) =>
+          dirPath === '/tmp/site' ? [directoryEntry, ignoredEntry] : [fileEntry],
+        );
+        const statSync = fs.statSync as jest.Mock;
+        statSync.mockReturnValue({
+          isDirectory: () => true,
+        } as fs.Stats);
+        (fs.readFileSync as jest.Mock).mockReturnValue(Buffer.from('js'));
+        mockClient.fetchOpenAPI.mockResolvedValue({});
+
+        await operations.uploadFiles('test-bucket', '/tmp/site');
+
+        expect(mockClient.fetchOpenAPI).toHaveBeenCalledWith(
+          expect.objectContaining({
+            Action: 'PutObject',
+            query: { Bucket: 'test-bucket', Key: 'nested/app.js' },
+          }),
+        );
+        expect(mockClient.fetchOpenAPI).toHaveBeenCalledTimes(1);
+        readdirSync.mockImplementation(
+          jest.requireActual<typeof import('node:fs')>('node:fs').readdirSync,
+        );
+        statSync.mockImplementation(
+          jest.requireActual<typeof import('node:fs')>('node:fs').statSync,
+        );
+        (fs.readFileSync as jest.Mock).mockImplementation(
+          jest.requireActual<typeof import('node:fs')>('node:fs').readFileSync,
         );
       });
     });

--- a/tests/unit/common/volcengineClient/vefaasOperations.test.ts
+++ b/tests/unit/common/volcengineClient/vefaasOperations.test.ts
@@ -847,6 +847,131 @@ describe('vefaasOperations code size validation', () => {
           }),
         );
       });
+
+      it('should throw when the package exceeds the TOS limit', async () => {
+        const stat = jest.spyOn(fs.promises, 'stat').mockResolvedValue({
+          size: 501 * 1024 * 1024,
+        } as fs.Stats);
+
+        await expect(operations.createFunction(mockConfig, smallZipPath)).rejects.toThrow(
+          'CODE_PACKAGE_TOO_LARGE',
+        );
+        stat.mockRestore();
+      });
+
+      it('should upload packages larger than the ZIP limit to TOS', async () => {
+        const stat = jest.spyOn(fs.promises, 'stat').mockResolvedValue({
+          size: 51 * 1024 * 1024,
+        } as fs.Stats);
+        const readFile = jest
+          .spyOn(fs.promises, 'readFile')
+          .mockResolvedValue(fs.readFileSync(smallZipPath));
+
+        await operations.createFunction(mockConfig, smallZipPath);
+
+        expect(mockService.fetchOpenAPI).toHaveBeenCalledWith(
+          expect.objectContaining({
+            Action: 'CreateFunction',
+            data: expect.objectContaining({
+              SourceType: 'tos',
+              TosBucket: 'vefaas-codes-cn-beijing',
+            }),
+          }),
+        );
+        stat.mockRestore();
+        readFile.mockRestore();
+      });
+
+      it('should throw when CreateFunction does not return an ID', async () => {
+        mockService.fetchOpenAPI.mockImplementation(({ Action }: { Action: string }) =>
+          Promise.resolve(
+            Action === 'CreateFunction'
+              ? { Result: {}, ResponseMetadata: { RequestId: 'request', Service: 'vefaas' } }
+              : Action === 'GetReleaseStatus'
+                ? {
+                    Result: { Status: 'done' },
+                    ResponseMetadata: { RequestId: 'request', Service: 'vefaas' },
+                  }
+                : { Result: {}, ResponseMetadata: { RequestId: 'request', Service: 'vefaas' } },
+          ),
+        );
+
+        await expect(operations.createFunction(mockConfig, smallZipPath)).rejects.toThrow(
+          'did not return a function Id',
+        );
+      });
+
+      it('should return null when no function matches the requested name', async () => {
+        mockService.fetchOpenAPI.mockResolvedValueOnce({
+          Result: { Items: [] },
+          ResponseMetadata: { RequestId: 'request', Service: 'vefaas' },
+        });
+
+        await expect(operations.getFunction('missing-function')).resolves.toBeNull();
+      });
+
+      it('should rethrow unexpected getFunctionById errors', async () => {
+        const error = { code: 'AccessDenied', message: 'denied' };
+        mockService.fetchOpenAPI.mockRejectedValueOnce(error);
+
+        await expect(operations.getFunctionById('func-123')).rejects.toBe(error);
+      });
+
+      it('should throw when a release reports failure', async () => {
+        mockService.fetchOpenAPI
+          .mockResolvedValueOnce({
+            Result: { ReleaseRecordId: 'release-1' },
+            ResponseMetadata: { RequestId: 'request', Service: 'vefaas' },
+          })
+          .mockResolvedValueOnce({
+            Result: { Status: 'failed' },
+            ResponseMetadata: { RequestId: 'request', Service: 'vefaas' },
+          });
+
+        await expect(operations.releaseFunction('func-123')).rejects.toThrow('release failed');
+      });
+
+      it('should translate function deletion polling timeouts', async () => {
+        jest.useFakeTimers();
+        mockService.fetchOpenAPI.mockResolvedValue({
+          Result: { Id: 'func-123', Name: 'test-function', Status: 'Active' },
+          ResponseMetadata: { RequestId: 'request', Service: 'vefaas' },
+        });
+        const promise = operations.waitForFunctionDeleted('func-123');
+        const outcome = promise.catch((error: unknown) => error);
+        await jest.runAllTimersAsync();
+
+        await expect(outcome).resolves.toEqual(
+          expect.objectContaining({
+            message: 'Timed out waiting for veFaaS function func-123 to be deleted',
+          }),
+        );
+        jest.useRealTimers();
+      });
+
+      it('should update function code through TOS for large packages', async () => {
+        const stat = jest.spyOn(fs.promises, 'stat').mockResolvedValue({
+          size: 51 * 1024 * 1024,
+        } as fs.Stats);
+        const readFile = jest
+          .spyOn(fs.promises, 'readFile')
+          .mockResolvedValue(fs.readFileSync(smallZipPath));
+
+        await operations.updateFunctionCode('func-123', smallZipPath);
+
+        expect(mockService.fetchOpenAPI).toHaveBeenCalledWith(
+          expect.objectContaining({
+            Action: 'UpdateFunction',
+            data: expect.objectContaining({
+              Id: 'func-123',
+              SourceType: 'tos',
+              TosBucket: 'vefaas-codes-cn-beijing',
+            }),
+          }),
+        );
+        stat.mockRestore();
+        readFile.mockRestore();
+      });
     });
   });
 });

--- a/tests/unit/stack/aliyunStack/apigwResource.test.ts
+++ b/tests/unit/stack/aliyunStack/apigwResource.test.ts
@@ -3148,4 +3148,129 @@ describe('ApigwResource', () => {
       );
     });
   });
+
+  describe('additional branch coverage', () => {
+    it('should reject an already-existing unowned group after create conflict', async () => {
+      mockedApigwOperations.findApiGroupByName
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce({ groupId: 'group-foreign', groupName: 'test-api-group', tags: [] });
+      mockedApigwOperations.createApiGroup.mockRejectedValue(
+        Object.assign(new Error('already exists'), { code: 'RepeatedCommit' }),
+      );
+      mockedApigwTypes.eventToApigwGroupConfig.mockReturnValue({ groupName: 'test-api-group' });
+      mockedApigwTypes.extractApigwGroupDefinition.mockReturnValue({});
+      mockedApigwTypes.triggerToApigwApiConfig.mockReturnValue({ apiName: 'test-api' });
+      mockedApigwTypes.extractEventDomainDefinition.mockReturnValue(null);
+
+      await expect(
+        createApigwResource(mockContext, testEvent, 'test-service', undefined, initialState),
+      ).rejects.toBeInstanceOf(PartialResourceError);
+      expect(mockedApigwOperations.createApi).not.toHaveBeenCalled();
+    });
+
+    it('should recover an existing state without a group instance from the cloud', async () => {
+      const existingState = {
+        instances: [{ type: 'ALIYUN_APIGW_API', id: 'api-456', apiName: 'test-api' }],
+        definition: {},
+      };
+      mockedStateManager.getResource.mockReturnValue(existingState);
+      mockedApigwOperations.findApiGroupByName.mockResolvedValue({
+        groupId: 'group-cloud',
+        groupName: 'test-api-group',
+        tags: [{ Key: 'si-owned-by', Value: 'test-app-test-service:events.api_gateway' }],
+      });
+      mockedApigwOperations.listApisByGroup.mockResolvedValue([
+        { apiId: 'api-cloud', apiName: 'test-api' },
+      ]);
+      mockedApigwOperations.updateApiGroup.mockResolvedValue(undefined);
+      mockedApigwOperations.getApiGroup.mockResolvedValue({
+        groupId: 'group-cloud',
+        groupName: 'test-api-group',
+      });
+      mockedApigwOperations.getApi.mockResolvedValue({ apiId: 'api-cloud', apiName: 'test-api' });
+      mockedApigwOperations.updateApi.mockResolvedValue(undefined);
+      mockedApigwOperations.deployApi.mockResolvedValue(undefined);
+      mockedApigwTypes.eventToApigwGroupConfig.mockReturnValue({ groupName: 'test-api-group' });
+      mockedApigwTypes.extractApigwGroupDefinition.mockReturnValue({});
+      mockedApigwTypes.triggerToApigwApiConfig.mockReturnValue({ apiName: 'test-api' });
+      mockedApigwTypes.generateApiKey.mockReturnValue('GET_/api/hello');
+      mockedApigwTypes.extractEventDomainDefinition.mockReturnValue(null);
+
+      await updateApigwResource(mockContext, testEvent, 'test-service', undefined, initialState);
+
+      expect(mockedApigwOperations.listApisByGroup).toHaveBeenCalledWith('group-cloud');
+      expect(mockedStateManager.setResource).toHaveBeenCalled();
+    });
+
+    it('should propagate a non-not-found CDN DNS cleanup failure', async () => {
+      const existingState = {
+        instances: [
+          { type: 'ALIYUN_APIGW_GROUP', id: 'group-123' },
+          { type: 'ALIYUN_CDN_DNS_CNAME', id: 'dns-123', dnsRecordId: 'dns-123' },
+        ],
+        definition: { domain: { domainName: 'example.com', cdnEnabled: true } },
+      };
+      mockedStateManager.getResource.mockReturnValue(existingState);
+      mockedCdnOperations.deleteCdnDomain.mockResolvedValue(undefined);
+      mockedDnsOperations.deleteDomainRecord.mockRejectedValue(new Error('DNS access denied'));
+
+      await expect(
+        deleteApigwResource(mockContext, 'events.api_gateway', initialState),
+      ).rejects.toThrow('DNS access denied');
+    });
+
+    it('should tolerate not-found domain and deployment cleanup errors', async () => {
+      const existingState = {
+        instances: [
+          { type: 'ALIYUN_APIGW_GROUP', id: 'group-123' },
+          {
+            type: 'ALIYUN_APIGW_DEPLOYMENT',
+            groupId: 'group-123',
+            apiId: 'api-456',
+            stageName: 'RELEASE',
+          },
+        ],
+        definition: {
+          domain: { domainName: 'example.com', wwwBindApex: true },
+        },
+      };
+      mockedStateManager.getResource.mockReturnValue(existingState);
+      mockedApigwOperations.unbindCustomDomain.mockRejectedValue({ code: 'NotFoundDomain' });
+      mockedApigwOperations.abolishApi.mockRejectedValue({ code: 'NotFoundDeployment' });
+      mockedApigwOperations.deleteApiGroup.mockResolvedValue(undefined);
+
+      await deleteApigwResource(mockContext, 'events.api_gateway', initialState);
+
+      expect(mockedStateManager.removeResource).toHaveBeenCalled();
+    });
+
+    it('should delete additional domain-specific DNS state keys', async () => {
+      const existingState = {
+        instances: [{ type: 'ALIYUN_APIGW_GROUP', id: 'group-123' }],
+        definition: {},
+      };
+      mockedStateManager.getResource
+        .mockReturnValueOnce(existingState)
+        .mockReturnValueOnce(null)
+        .mockReturnValueOnce(null)
+        .mockReturnValueOnce({ instances: [{ id: 'dns-extra' }], definition: {} });
+      mockedDnsOperations.deleteDomainRecord.mockResolvedValue(undefined);
+      mockedApigwOperations.deleteApiGroup.mockResolvedValue(undefined);
+
+      await deleteApigwResource(mockContext, 'events.api_gateway', {
+        ...initialState,
+        resources: {
+          'events.api_gateway.dns_custom.example.com': {
+            mode: 'managed',
+            region: 'cn-hangzhou',
+            definition: {},
+            instances: [{ id: 'dns-extra', sid: 'dns-extra' }],
+            lastUpdated: new Date().toISOString(),
+          },
+        },
+      });
+
+      expect(mockedDnsOperations.deleteDomainRecord).toHaveBeenCalledWith('dns-extra');
+    });
+  });
 });

--- a/tests/unit/stack/aliyunStack/deployer.test.ts
+++ b/tests/unit/stack/aliyunStack/deployer.test.ts
@@ -7,6 +7,7 @@ const mockedLogger = {
   info: jest.fn(),
   error: jest.fn(),
   warn: jest.fn(),
+  debug: jest.fn(),
 };
 
 const createMockStateBackend = (): StateBackend => ({
@@ -42,6 +43,7 @@ jest.mock('../../../../src/common/logger', () => ({
     info: (...args: unknown[]) => mockedLogger.info(...args),
     error: (...args: unknown[]) => mockedLogger.error(...args),
     warn: (...args: unknown[]) => mockedLogger.warn(...args),
+    debug: (...args: unknown[]) => mockedLogger.debug(...args),
   },
 }));
 
@@ -95,7 +97,7 @@ jest.mock('../../../../src/common/context', () => ({
   }),
   setIac: jest.fn(),
   getRoleArnFromState: jest.fn(() => 'arn:aws:iam::123456789012:role/test-role'),
-  getDependencyInfo: jest.fn(() => ({ cycleError: null })),
+  getDependencyInfo: jest.fn(() => ({ cycleError: null, order: [], graph: {} })),
   toDotFormat: jest.fn(() => 'digraph { }'),
 }));
 
@@ -152,6 +154,119 @@ describe('Deployer Integration', () => {
       expect(mockedPlanner.generateDatabasePlan).toHaveBeenCalled();
       expect(mockedPlanner.generateTablePlan).toHaveBeenCalled();
       expect(mockedPlanner.generateApigwPlan).toHaveBeenCalled();
+    });
+
+    it('should report bucket partial failures with prior successful items', async () => {
+      const { deployAliyunStack } = require('../../../../src/stack/aliyunStack/deployer');
+      const iac: ServerlessIac = {
+        version: '1.0',
+        app: 'test-app',
+        service: 'test-service',
+        provider: { name: ProviderEnum.ALIYUN, region: 'cn-hangzhou' },
+      };
+      const failure = {
+        error: new Error('bucket failed'),
+        failedItem: { action: 'create', logicalId: 'buckets.assets', resourceType: 'ALIYUN_OSS' },
+        successfulItems: [],
+      };
+      (mockedStateBackend.withLock as jest.Mock).mockImplementation(
+        async (_name: string, callback: () => Promise<unknown>) => callback(),
+      );
+      mockedExecutor.executeBucketPlan.mockResolvedValue({
+        state: initialState,
+        partialFailure: failure,
+      });
+
+      await expect(deployAliyunStack(iac, mockedStateBackend)).rejects.toMatchObject({
+        message: 'bucket failed',
+        isPartialFailure: true,
+      });
+      expect(mockedLogger.error).toHaveBeenCalled();
+    });
+
+    it('should report database partial failures with prior successful items', async () => {
+      const { deployAliyunStack } = require('../../../../src/stack/aliyunStack/deployer');
+      const iac: ServerlessIac = {
+        version: '1.0',
+        app: 'test-app',
+        service: 'test-service',
+        provider: { name: ProviderEnum.ALIYUN, region: 'cn-hangzhou' },
+      };
+      const failure = {
+        error: new Error('database failed'),
+        failedItem: { action: 'update', logicalId: 'databases.main', resourceType: 'ALIYUN_RDS' },
+        successfulItems: [],
+      };
+      (mockedStateBackend.withLock as jest.Mock).mockImplementation(
+        async (_name: string, callback: () => Promise<unknown>) => callback(),
+      );
+      mockedExecutor.executeDatabasePlan.mockResolvedValue({
+        state: initialState,
+        partialFailure: failure,
+      });
+
+      await expect(deployAliyunStack(iac, mockedStateBackend)).rejects.toMatchObject({
+        message: 'database failed',
+        isPartialFailure: true,
+      });
+    });
+
+    it('should report table partial failures with prior successful items', async () => {
+      const { deployAliyunStack } = require('../../../../src/stack/aliyunStack/deployer');
+      const iac: ServerlessIac = {
+        version: '1.0',
+        app: 'test-app',
+        service: 'test-service',
+        provider: { name: ProviderEnum.ALIYUN, region: 'cn-hangzhou' },
+      };
+      const failure = {
+        error: new Error('table failed'),
+        failedItem: {
+          action: 'delete',
+          logicalId: 'tables.audit',
+          resourceType: 'ALIYUN_TABLESTORE',
+        },
+        successfulItems: [],
+      };
+      (mockedStateBackend.withLock as jest.Mock).mockImplementation(
+        async (_name: string, callback: () => Promise<unknown>) => callback(),
+      );
+      mockedExecutor.executeTablePlan.mockResolvedValue({
+        state: initialState,
+        partialFailure: failure,
+      });
+
+      await expect(deployAliyunStack(iac, mockedStateBackend)).rejects.toMatchObject({
+        message: 'table failed',
+        isPartialFailure: true,
+      });
+    });
+
+    it('should report API Gateway partial failures with prior successful items', async () => {
+      const { deployAliyunStack } = require('../../../../src/stack/aliyunStack/deployer');
+      const iac: ServerlessIac = {
+        version: '1.0',
+        app: 'test-app',
+        service: 'test-service',
+        provider: { name: ProviderEnum.ALIYUN, region: 'cn-hangzhou' },
+      };
+      const failure = {
+        error: new Error('api gateway failed'),
+        failedItem: { action: 'create', logicalId: 'events.api', resourceType: 'ALIYUN_APIGW' },
+        successfulItems: [],
+      };
+      (mockedStateBackend.withLock as jest.Mock).mockImplementation(
+        async (_name: string, callback: () => Promise<unknown>) => callback(),
+      );
+      mockedExecutor.executeApigwPlan.mockResolvedValue({
+        state: initialState,
+        partialFailure: failure,
+      });
+
+      await expect(deployAliyunStack(iac, mockedStateBackend)).rejects.toMatchObject({
+        message: 'api gateway failed',
+        isPartialFailure: true,
+      });
     });
   });
 });

--- a/tests/unit/stack/aliyunStack/fc3Planner.test.ts
+++ b/tests/unit/stack/aliyunStack/fc3Planner.test.ts
@@ -18,9 +18,12 @@ const mockFc3Operations = {
   updateFunctionCode: jest.fn(),
   deleteFunction: jest.fn(),
 };
+const mockEcsOperations = {
+  getSecurityGroupByName: jest.fn(),
+};
 
 jest.mock('../../../../src/common/aliyunClient', () => ({
-  createAliyunClient: () => ({ fc3: mockFc3Operations }),
+  createAliyunClient: () => ({ fc3: mockFc3Operations, ecs: mockEcsOperations }),
 }));
 jest.mock('../../../../src/common/hashUtils', () => ({
   ...jest.requireActual('../../../../src/common/hashUtils'),
@@ -63,6 +66,50 @@ describe('FC3 Planner', () => {
   });
 
   describe('generateFunctionPlan', () => {
+    it('should resolve a named security group before planning', async () => {
+      mockEcsOperations.getSecurityGroupByName.mockResolvedValue({
+        securityGroupId: 'sg-resolved',
+      });
+      mockFc3Operations.getFunction.mockResolvedValue(null);
+
+      const functionWithNamedSecurityGroup: FunctionDomain = {
+        ...testFunction,
+        network: {
+          vpc_id: 'vpc-123',
+          subnet_ids: ['vsw-123'],
+          security_group: { name: 'app-sg', ingress: [], egress: [] },
+        },
+      };
+
+      const plan = await generateFunctionPlan(mockContext, initalState, [
+        functionWithNamedSecurityGroup,
+      ]);
+
+      expect(mockEcsOperations.getSecurityGroupByName).toHaveBeenCalledWith('app-sg', 'vpc-123');
+      expect(plan.items[0]?.changes?.after).toEqual(
+        expect.objectContaining({
+          vpcConfig: expect.objectContaining({ securityGroupId: 'sg-resolved' }),
+        }),
+      );
+    });
+
+    it('should fail when a named security group cannot be resolved', async () => {
+      mockEcsOperations.getSecurityGroupByName.mockResolvedValue(null);
+
+      const functionWithNamedSecurityGroup: FunctionDomain = {
+        ...testFunction,
+        network: {
+          vpc_id: 'vpc-123',
+          subnet_ids: ['vsw-123'],
+          security_group: { name: 'missing-sg', ingress: [], egress: [] },
+        },
+      };
+
+      await expect(
+        generateFunctionPlan(mockContext, initalState, [functionWithNamedSecurityGroup]),
+      ).rejects.toThrow('not found');
+    });
+
     it('should plan to create a new function when state is empty', async () => {
       mockFc3Operations.getFunction.mockResolvedValue(null);
 

--- a/tests/unit/stack/deploy.test.ts
+++ b/tests/unit/stack/deploy.test.ts
@@ -7,6 +7,8 @@ import fs from 'node:fs';
 
 const mockedGetContext = jest.fn();
 const mockedDeployAliyunStack = jest.fn();
+const mockedDeployTencentStack = jest.fn();
+const mockedDeployVolcengineStack = jest.fn();
 
 jest.mock('../../../src/common/context', () => ({
   ...jest.requireActual('../../../src/common/context'),
@@ -21,6 +23,14 @@ jest.mock('../../../src/common', () => ({
 
 jest.mock('../../../src/stack/aliyunStack', () => ({
   deployAliyunStack: (...args: unknown[]) => mockedDeployAliyunStack(...args),
+}));
+
+jest.mock('../../../src/stack/scfStack', () => ({
+  deployTencentStack: (...args: unknown[]) => mockedDeployTencentStack(...args),
+}));
+
+jest.mock('../../../src/stack/volcengineStack', () => ({
+  deployVolcengineStack: (...args: unknown[]) => mockedDeployVolcengineStack(...args),
 }));
 
 const createMockContext = (stage = 'default', additionalFields?: Partial<Context>): Context => ({
@@ -58,6 +68,8 @@ describe('Unit tests for Aliyun stack deployment', () => {
     fs.mkdirSync(testDir, { recursive: true });
 
     mockedDeployAliyunStack.mockResolvedValue(undefined);
+    mockedDeployTencentStack.mockResolvedValue(undefined);
+    mockedDeployVolcengineStack.mockResolvedValue(undefined);
     jest.clearAllMocks();
   });
 
@@ -89,5 +101,27 @@ describe('Unit tests for Aliyun stack deployment', () => {
     await deployStack(oneFcIac, mockBackend);
 
     expect(mockedDeployAliyunStack).toHaveBeenCalledWith(oneFcIac, mockBackend);
+  });
+
+  it('should dispatch Tencent deployments to the Tencent stack', async () => {
+    const tencentIac = {
+      ...minimumIac,
+      provider: { ...minimumIac.provider, name: ProviderEnum.TENCENT },
+    };
+
+    await deployStack(tencentIac, mockBackend);
+
+    expect(mockedDeployTencentStack).toHaveBeenCalledWith(tencentIac, mockBackend);
+  });
+
+  it('should report that Huawei deployment is not implemented', async () => {
+    const huaweiIac = {
+      ...minimumIac,
+      provider: { ...minimumIac.provider, name: ProviderEnum.HUAWEI },
+    };
+
+    await expect(deployStack(huaweiIac, mockBackend)).rejects.toThrow(
+      'Huawei deployment is not yet implemented',
+    );
   });
 });

--- a/tests/unit/stack/localStack/functionRunner.test.ts
+++ b/tests/unit/stack/localStack/functionRunner.test.ts
@@ -1,0 +1,235 @@
+import { EventEmitter } from 'node:events';
+
+type WorkerMock = EventEmitter & {
+  postMessage: jest.Mock;
+  terminate: jest.Mock;
+  once: (event: string, listener: (...args: never[]) => void) => WorkerMock;
+  off: (event: string, listener: (...args: never[]) => void) => WorkerMock;
+};
+
+const createWorkerMock = (): WorkerMock => {
+  const worker = new EventEmitter() as WorkerMock;
+  worker.postMessage = jest.fn();
+  worker.terminate = jest.fn().mockResolvedValue(0);
+  return worker;
+};
+
+const workers: WorkerMock[] = [];
+
+jest.mock('node:fs', () => ({ existsSync: jest.fn().mockReturnValue(true) }));
+jest.mock('node:worker_threads', () => {
+  class MockMessagePort extends EventEmitter {
+    close = jest.fn();
+  }
+
+  return {
+    MessageChannel: class {
+      port1 = new MockMessagePort();
+      port2 = new MockMessagePort();
+
+      constructor() {
+        this.port2.on('message', (value) => this.port1.emit('message', value));
+        this.port2.on('error', (error) => this.port1.emit('error', error));
+        this.port2.on('close', () => this.port1.emit('close'));
+      }
+    },
+    Worker: jest.fn(() => {
+      const worker = createWorkerMock();
+      workers.push(worker);
+      return worker;
+    }),
+    isMainThread: true,
+    parentPort: undefined,
+    workerData: undefined,
+  };
+});
+
+import { invokeFunction, runFunction } from '../../../../src/stack/localStack/functionRunner';
+
+const options = {
+  codeDir: '/tmp/functions',
+  functionKey: 'hello',
+  handler: 'index.handler',
+  servicePath: '',
+  timeout: 1000,
+};
+
+describe('functionRunner main-thread API', () => {
+  beforeEach(() => {
+    workers.length = 0;
+    jest.clearAllMocks();
+  });
+
+  it('sends an event and resolves a normal worker response', async () => {
+    const runner = runFunction(options, { NODE_ENV: 'test' });
+    const execution = runner.execute({ value: 1 }, { requestId: 'req-1' });
+
+    expect(workers[0]?.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ event: { value: 1 }, context: { requestId: 'req-1' } }),
+      expect.any(Array),
+    );
+
+    const worker = workers[0];
+    expect(worker).toBeDefined();
+    const postedPort = worker?.postMessage.mock.calls[0]?.[0].port;
+    postedPort.emit('message', { result: 'ok' });
+
+    await expect(execution).resolves.toEqual({ result: 'ok' });
+    await expect(runner.terminate()).resolves.toBe(0);
+  });
+
+  it('rejects when the worker sends an Error object', async () => {
+    const runner = runFunction(options, {});
+    const execution = runner.execute({}, {});
+    const postedPort = workers[0]?.postMessage.mock.calls[0]?.[0].port;
+    const error = new Error('handler failed');
+    postedPort.emit('message', error);
+
+    await expect(execution).rejects.toBe(error);
+  });
+
+  it('rejects on worker errors and ignores later messages', async () => {
+    const runner = runFunction(options, {});
+    const execution = runner.execute({}, {});
+    const worker = workers[0];
+    const postedPort = worker?.postMessage.mock.calls[0]?.[0].port;
+    const error = new Error('worker failed');
+
+    worker.emit('error', error);
+    postedPort.emit('message', 'late response');
+
+    await expect(execution).rejects.toBe(error);
+  });
+
+  it('rejects when the worker exits with a non-zero code', async () => {
+    const runner = runFunction(options, {});
+    const execution = runner.execute({}, {});
+    workers[0]?.emit('exit', 7);
+
+    await expect(execution).rejects.toThrow('Worker stopped with exit code 7');
+  });
+
+  it('rejects when the worker exits successfully before responding', async () => {
+    const runner = runFunction(options, {});
+    const execution = runner.execute({}, {});
+    const postedPort = workers[0]?.postMessage.mock.calls[0]?.[0].port;
+    workers[0]?.emit('exit', 0);
+    postedPort.emit('close');
+
+    await expect(execution).rejects.toThrow('Port closed before receiving response');
+  });
+
+  it('converts non-Error postMessage failures to Error objects', async () => {
+    const runner = runFunction(options, {});
+    const worker = workers[0];
+    worker.postMessage.mockImplementation(() => {
+      throw 'not an error';
+    });
+
+    await expect(runner.execute({}, {})).rejects.toThrow('not an error');
+  });
+
+  it('terminates the worker after invokeFunction resolves', async () => {
+    const execution = invokeFunction(options, {}, 'event', 'context');
+    const worker = workers[0];
+    const postedPort = worker?.postMessage.mock.calls[0]?.[0].port;
+    postedPort.emit('message', 'result');
+
+    await expect(execution).resolves.toBe('result');
+    expect(worker?.terminate).toHaveBeenCalledTimes(1);
+  });
+
+  it('terminates the worker after invokeFunction rejects', async () => {
+    const execution = invokeFunction(options, {}, 'event', 'context');
+    const worker = workers[0];
+    worker?.emit('error', new Error('execution failed'));
+
+    await expect(execution).rejects.toThrow('execution failed');
+    expect(worker?.terminate).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('functionRunner worker-thread handler', () => {
+  it('loads a callback handler, reconstructs its context, and converts Uint8Array events', async () => {
+    jest.resetModules();
+    const parentPort = new EventEmitter();
+    const workerData = {
+      codeDir: 'tests/fixtures/aliyun-fc-handler',
+      functionKey: 'hello',
+      handler: 'index.handler',
+      servicePath: '',
+      timeout: 1000,
+    };
+    jest.doMock('node:worker_threads', () => ({
+      MessageChannel: jest.fn(),
+      Worker: jest.fn(),
+      isMainThread: false,
+      parentPort,
+      workerData,
+    }));
+
+    jest.isolateModules(() => {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      require('../../../../src/stack/localStack/functionRunner');
+    });
+
+    const port = new EventEmitter() as EventEmitter & {
+      postMessage: jest.Mock;
+      close: jest.Mock;
+    };
+    port.postMessage = jest.fn();
+    port.close = jest.fn();
+    const context = {
+      requestId: 'request-1',
+      function: { name: 'hello' },
+      service: { name: 'service' },
+      tracing: {},
+    };
+    const event = new Uint8Array(Buffer.from(JSON.stringify({ path: '/hello' })));
+
+    parentPort.emit('message', { event, context, port });
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(port.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ statusCode: '200', isBase64Encoded: false }),
+    );
+    expect(port.close).toHaveBeenCalled();
+  });
+
+  it('returns an error response when the handler method is missing', async () => {
+    jest.resetModules();
+    const parentPort = new EventEmitter();
+    jest.doMock('node:worker_threads', () => ({
+      MessageChannel: jest.fn(),
+      Worker: jest.fn(),
+      isMainThread: false,
+      parentPort,
+      workerData: {
+        codeDir: 'tests/fixtures/aliyun-fc-handler',
+        functionKey: 'hello',
+        handler: 'index.missing',
+        servicePath: '',
+        timeout: 1000,
+      },
+    }));
+
+    jest.isolateModules(() => {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      require('../../../../src/stack/localStack/functionRunner');
+    });
+
+    const port = new EventEmitter() as EventEmitter & {
+      postMessage: jest.Mock;
+      close: jest.Mock;
+    };
+    port.postMessage = jest.fn();
+    port.close = jest.fn();
+    parentPort.emit('message', { event: {}, context: {}, port });
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(port.postMessage.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({ message: expect.stringContaining('Handler "missing" not found') }),
+    );
+    expect(port.close).toHaveBeenCalled();
+  });
+});

--- a/tests/unit/stack/localStack/localServer.test.ts
+++ b/tests/unit/stack/localStack/localServer.test.ts
@@ -52,6 +52,48 @@ describe('localServer routing', () => {
 
       expect(res.statusCode).toBe(404);
     });
+
+    it('returns 404 when a recognized route has no registered handler', async () => {
+      const res = await makeRequest(
+        `http://localhost:${SI_LOCALSTACK_SERVER_PORT}/si_events/missing`,
+      );
+
+      expect(res.statusCode).toBe(404);
+      expect(res.data).toContain('Handler for SI_EVENTS not registered');
+    });
+
+    it('returns 404 when the request has no route segment', async () => {
+      const res = await makeRequest(`http://localhost:${SI_LOCALSTACK_SERVER_PORT}/`);
+
+      expect(res.statusCode).toBe(404);
+      expect(res.data).toContain('Route not found');
+    });
+
+    it('returns 204 when a handler has no response', async () => {
+      handlers.push({ kind: RouteKind.SI_EVENTS, handler: async () => undefined });
+      const res = await makeRequest(`http://localhost:${SI_LOCALSTACK_SERVER_PORT}/si_events/`);
+
+      expect(res.statusCode).toBe(204);
+    });
+
+    it('returns 500 when a handler throws', async () => {
+      handlers.push({
+        kind: RouteKind.SI_WEBSITE_BUCKETS,
+        handler: async () => {
+          throw new Error('boom');
+        },
+      });
+      const res = await makeRequest(
+        `http://localhost:${SI_LOCALSTACK_SERVER_PORT}/si_website_buckets/`,
+      );
+
+      expect(res.statusCode).toBe(500);
+      expect(res.data).toContain('Local gateway failure');
+    });
+
+    it('does not start a second server when one is already running', async () => {
+      await expect(servLocal(handlers, iac)).resolves.toBeUndefined();
+    });
   });
 
   describe('Raw HTML responses', () => {

--- a/tests/unit/stack/rfsStack/function.test.ts
+++ b/tests/unit/stack/rfsStack/function.test.ts
@@ -1,0 +1,71 @@
+import { resolveCode } from '../../../../src/common';
+import { resolveFunction } from '../../../../src/stack/rfsStack/function';
+import type { RfsStack } from '../../../../src/stack/rfsStack';
+import type { Context, FunctionDomain } from '../../../../src/types';
+
+jest.mock('../../../../src/common/iacHelper', () => ({
+  resolveCode: jest.fn(),
+}));
+
+const appendHcl = jest.fn();
+const stack = { appendHcl } as unknown as RfsStack;
+const context = {
+  stage: 'dev',
+  app: 'app',
+  service: 'service',
+  provider: 'huaweicloud',
+  region: 'cn-north-4',
+  accessKeyId: 'access-key',
+  accessKeySecret: 'secret-key',
+  iacLocation: 'serverless.yml',
+} as unknown as Context;
+
+const functionDefinition = {
+  key: 'hello',
+  name: 'hello-function',
+  memory: 256,
+  timeout: 30,
+  environment: { MODE: 'test' },
+  code: { path: 'functions/hello.zip', handler: 'index.handler', runtime: 'Node.js18' },
+} as unknown as FunctionDomain;
+
+describe('resolveFunction', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (resolveCode as jest.Mock).mockReturnValue('base64-code');
+  });
+
+  it('does nothing when functions are undefined', () => {
+    expect(resolveFunction(stack, undefined, context, 'app-service')).toBeUndefined();
+    expect(appendHcl).not.toHaveBeenCalled();
+  });
+
+  it('appends an application and function resource for each function', () => {
+    const secondFunction = {
+      ...functionDefinition,
+      key: 'goodbye',
+      name: 'goodbye-function',
+      code: { ...functionDefinition.code, path: 'functions/goodbye.zip' },
+    } as FunctionDomain;
+
+    resolveFunction(stack, [functionDefinition, secondFunction], context, 'app-service');
+
+    expect(resolveCode).toHaveBeenCalledTimes(2);
+    expect(resolveCode).toHaveBeenNthCalledWith(1, 'functions/hello.zip');
+    expect(resolveCode).toHaveBeenNthCalledWith(2, 'functions/goodbye.zip');
+    expect(appendHcl).toHaveBeenCalledTimes(1);
+    expect(appendHcl.mock.calls[0][0]).toContain('resource "huaweicloud_fgs_application"');
+    expect(appendHcl.mock.calls[0][0]).toContain('resource "huaweicloud_fgs_function" "hello"');
+    expect(appendHcl.mock.calls[0][0]).toContain('resource "huaweicloud_fgs_function" "goodbye"');
+    expect(appendHcl.mock.calls[0][0]).toContain('environment = {"MODE":"test"}');
+    expect(appendHcl.mock.calls[0][0]).toContain('func_code = "base64-code"');
+  });
+
+  it('appends only the application resource for an empty function list', () => {
+    resolveFunction(stack, [], context, 'app-service');
+
+    expect(resolveCode).not.toHaveBeenCalled();
+    expect(appendHcl.mock.calls[0][0]).toContain('name = "app-service-app"');
+    expect(appendHcl.mock.calls[0][0]).not.toContain('huaweicloud_fgs_function');
+  });
+});

--- a/tests/unit/stack/scfStack/scfTypes.test.ts
+++ b/tests/unit/stack/scfStack/scfTypes.test.ts
@@ -1,5 +1,9 @@
-import { functionToScfConfig, extractScfDefinition } from '../../../../src/stack/scfStack/scfTypes';
-import { FunctionDomain } from '../../../../src/types';
+import {
+  functionToScfConfig,
+  extractFunctionDomainDefinition,
+  extractScfDefinition,
+} from '../../../../src/stack/scfStack/scfTypes';
+import { FunctionDomain, FunctionGpuEnum, NasStorageClassEnum } from '../../../../src/types';
 
 describe('SCF Types', () => {
   describe('functionToScfConfig', () => {
@@ -88,6 +92,36 @@ describe('SCF Types', () => {
         Timeout: 5,
       });
     });
+
+    it('should map network, storage, GPU, container, and role options', () => {
+      const fn: FunctionDomain = {
+        key: 'full_fn',
+        name: 'full-function',
+        code: { runtime: 'nodejs18', handler: 'index.handler', path: 'test.zip' },
+        network: {
+          vpc_id: 'vpc-123',
+          subnet_ids: ['subnet-456'],
+          security_group: { name: 'sg-123', ingress: [], egress: [] },
+        },
+        storage: {
+          disk: 512,
+          nas: [{ mount_path: '/mnt/data', storage_class: NasStorageClassEnum.STANDARD_CAPACITY }],
+        },
+        gpu: FunctionGpuEnum.TESLA_8,
+        container: { image: 'registry.example.com/image:latest', port: 8080 },
+      };
+
+      const config = functionToScfConfig(fn, 'role-123');
+
+      expect(config).toMatchObject({
+        Role: 'role-123',
+        VpcConfig: { VpcId: 'vpc-123', SubnetId: 'subnet-456' },
+        DiskSize: 512,
+        CfsConfig: { CfsInsList: [{ LocalMountDir: '/mnt/data', RemoteMountDir: '/' }] },
+        UseGpu: 'TRUE',
+        ImageConfig: { ImageUri: 'registry.example.com/image:latest' },
+      });
+    });
   });
 
   describe('extractScfDefinition', () => {
@@ -169,6 +203,26 @@ describe('SCF Types', () => {
         NODE_ENV: 'production',
         API_KEY: 'test123',
       });
+    });
+
+    it('should include IAM when extracting a function domain definition', () => {
+      const fn: FunctionDomain = {
+        key: 'iam_fn',
+        name: 'iam-function',
+        code: { runtime: 'nodejs18', handler: 'index.handler', path: 'test.zip' },
+        iam: { role: 'role-123' },
+        storage: {},
+      };
+
+      const definition = extractFunctionDomainDefinition(fn, 'hash-123');
+
+      expect(definition).toEqual(
+        expect.objectContaining({
+          functionName: 'iam-function',
+          codeHash: 'hash-123',
+          iam: { role: 'role-123' },
+        }),
+      );
     });
   });
 });

--- a/tests/unit/stack/scfStack/tdsqlcPlanner.test.ts
+++ b/tests/unit/stack/scfStack/tdsqlcPlanner.test.ts
@@ -300,6 +300,45 @@ describe('TdsqlcPlanner', () => {
       });
     });
 
+    it('should generate a drifted create plan when the stored cluster is missing remotely', async () => {
+      const existingState: ResourceState = {
+        mode: 'managed',
+        region: 'ap-guangzhou',
+        definition: expectedDefinition,
+        instances: [{ sid: 'sid', id: 'cynosdbmysql-test123', clusterName: 'test-tdsqlc' }],
+        lastUpdated: '2024-01-01T00:00:00Z',
+        metadata: { clusterId: 'cynosdbmysql-test123' },
+      };
+      jest.spyOn(stateManager, 'getResource').mockReturnValue(existingState);
+      jest.spyOn(stateManager, 'getAllResources').mockReturnValue({});
+      mockTdsqlcOperations.getCluster.mockResolvedValue(null);
+
+      const result = await generateDatabasePlan(mockContext, mockState, [mockDatabase]);
+
+      expect(result.items[0]).toMatchObject({ action: 'create', drifted: true });
+      expect(result.items[0].changes?.before).toEqual(expectedDefinition);
+    });
+
+    it('should fall back to create when the remote cluster probe fails', async () => {
+      const existingState: ResourceState = {
+        mode: 'managed',
+        region: 'ap-guangzhou',
+        definition: expectedDefinition,
+        instances: [{ sid: 'sid', id: 'cynosdbmysql-test123', clusterName: 'test-tdsqlc' }],
+        lastUpdated: '2024-01-01T00:00:00Z',
+        metadata: { clusterId: 'cynosdbmysql-test123' },
+      };
+      jest.spyOn(stateManager, 'getResource').mockReturnValue(existingState);
+      jest.spyOn(stateManager, 'getAllResources').mockReturnValue({});
+      mockTdsqlcOperations.getCluster.mockRejectedValue(new Error('probe failed'));
+
+      const result = await generateDatabasePlan(mockContext, mockState, [mockDatabase]);
+
+      expect(result.items[0]).toMatchObject({ action: 'create' });
+      expect(result.items[0]).not.toHaveProperty('drifted');
+      expect(result.items[0].changes?.before).toEqual(expectedDefinition);
+    });
+
     it('should generate delete plan for removed databases', async () => {
       const existingResources: Record<string, ResourceState> = {
         'databases.test_db': {
@@ -328,6 +367,51 @@ describe('TdsqlcPlanner', () => {
         action: 'delete',
         resourceType: 'TDSQL_C_SERVERLESS',
       });
+    });
+
+    it('should delete legacy and typed stale database states while ignoring unrelated states', async () => {
+      const existingResources: Record<string, ResourceState> = {
+        'databases.legacy': {
+          mode: 'managed',
+          region: 'ap-guangzhou',
+          definition: expectedDefinition,
+          instances: [],
+          lastUpdated: '2024-01-01T00:00:00Z',
+          metadata: {},
+        },
+        'databases.typed': {
+          mode: 'managed',
+          region: 'ap-guangzhou',
+          definition: expectedDefinition,
+          instances: [],
+          lastUpdated: '2024-01-01T00:00:00Z',
+          metadata: { resourceType: 'TDSQL_C_SERVERLESS' },
+        },
+        'databases.other': {
+          mode: 'managed',
+          region: 'ap-guangzhou',
+          definition: expectedDefinition,
+          instances: [],
+          lastUpdated: '2024-01-01T00:00:00Z',
+          metadata: { resourceType: 'OTHER' },
+        },
+        'functions.keep': {
+          mode: 'managed',
+          region: 'ap-guangzhou',
+          definition: expectedDefinition,
+          instances: [],
+          lastUpdated: '2024-01-01T00:00:00Z',
+          metadata: {},
+        },
+      };
+      jest.spyOn(stateManager, 'getAllResources').mockReturnValue(existingResources);
+
+      const result = await generateDatabasePlan(mockContext, mockState, [mockDatabase]);
+
+      expect(result.items.map((item) => item.logicalId)).toEqual(
+        expect.arrayContaining(['databases.legacy', 'databases.typed']),
+      );
+      expect(result.items).toHaveLength(3);
     });
 
     it('should handle undefined databases', async () => {

--- a/tests/unit/stack/volcengineStack/apigwPlanner.test.ts
+++ b/tests/unit/stack/volcengineStack/apigwPlanner.test.ts
@@ -166,4 +166,120 @@ describe('apigwPlanner', () => {
       action: 'delete',
     });
   });
+
+  it('plans a drifted create when the recorded service is missing remotely', async () => {
+    const stateWithEvent: StateFile = {
+      ...emptyState,
+      resources: {
+        'events.api_gateway': {
+          mode: 'managed',
+          region: 'cn-beijing',
+          definition: { gatewayName: 'test-gw' },
+          instances: [
+            {
+              type: 'VOLCENGINE_APIGW_SERVICE',
+              sid: 's',
+              id: 'svc-missing',
+              serviceId: 'svc-missing',
+              gatewayId: 'gw-1',
+            },
+          ],
+          lastUpdated: '2024-01-01T00:00:00Z',
+          status: 'ready',
+        },
+      },
+    };
+    mockClient.apigw.getService.mockResolvedValue(null);
+
+    const plan = await generateApigwPlan(mockContext, stateWithEvent, [mockEvent], 'test-service');
+
+    expect(plan.items[0]).toMatchObject({
+      logicalId: 'events.api_gateway',
+      action: 'create',
+      drifted: true,
+      changes: { before: { gatewayName: 'test-gw' } },
+    });
+  });
+
+  it('plans update when the desired event definition changed', async () => {
+    const stateWithEvent: StateFile = {
+      ...emptyState,
+      resources: {
+        'events.api_gateway': {
+          mode: 'managed',
+          region: 'cn-beijing',
+          definition: { gatewayName: 'old-gateway' },
+          instances: [],
+          lastUpdated: '2024-01-01T00:00:00Z',
+          status: 'ready',
+        },
+      },
+    };
+    const { attributesEqual } = jest.requireMock('../../../../src/common/hashUtils');
+    (attributesEqual as jest.Mock).mockReturnValue(false);
+
+    const plan = await generateApigwPlan(mockContext, stateWithEvent, [mockEvent], 'test-service');
+
+    expect(plan.items[0]).toMatchObject({
+      logicalId: 'events.api_gateway',
+      action: 'update',
+      changes: {
+        before: { gatewayName: 'old-gateway' },
+        after: { gatewayName: 'test-gw' },
+      },
+    });
+  });
+
+  it('deletes stale events while excluding non-event resources', async () => {
+    const stateWithMixedResources: StateFile = {
+      ...emptyState,
+      resources: {
+        'events.api_gateway': {
+          mode: 'managed',
+          region: 'cn-beijing',
+          definition: { gatewayName: 'test-gw' },
+          instances: [],
+          lastUpdated: '2024-01-01T00:00:00Z',
+          status: 'ready',
+        },
+        'events.old_event': {
+          mode: 'managed',
+          region: 'cn-beijing',
+          definition: { gatewayName: 'old-gw' },
+          instances: [],
+          lastUpdated: '2024-01-01T00:00:00Z',
+          status: 'ready',
+        },
+        'functions.api_function': {
+          mode: 'managed',
+          region: 'cn-beijing',
+          definition: { functionName: 'test-fn' },
+          instances: [],
+          lastUpdated: '2024-01-01T00:00:00Z',
+          status: 'ready',
+        },
+      },
+    };
+    const { attributesEqual } = jest.requireMock('../../../../src/common/hashUtils');
+    (attributesEqual as jest.Mock).mockReturnValue(true);
+
+    const plan = await generateApigwPlan(
+      mockContext,
+      stateWithMixedResources,
+      [mockEvent],
+      'test-service',
+    );
+
+    expect(plan.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ logicalId: 'events.api_gateway', action: 'noop' }),
+        expect.objectContaining({
+          logicalId: 'events.old_event',
+          action: 'delete',
+          changes: { before: { gatewayName: 'old-gw' } },
+        }),
+      ]),
+    );
+    expect(plan.items).toHaveLength(2);
+  });
 });

--- a/tests/unit/stack/volcengineStack/apigwResource.test.ts
+++ b/tests/unit/stack/volcengineStack/apigwResource.test.ts
@@ -385,6 +385,53 @@ describe('apigwResource', () => {
       expect(mockClient.tls.createProject).not.toHaveBeenCalled();
       expect(mockClient.apigw.updateGatewayLog).not.toHaveBeenCalled();
     });
+
+    it('adopts an owned gateway after an already-exists create conflict', async () => {
+      mockClient.apigw.createGateway.mockRejectedValue(new Error('gateway already exists'));
+      mockClient.apigw.findGatewayByName.mockResolvedValueOnce(null).mockResolvedValueOnce({
+        gatewayId: 'gw-owned',
+        gatewayName: 'test-service-dev-apigw',
+        type: 'serverless',
+        tags: [{ Key: 'si-owned-by', Value: 'test-app-test-service:events.api_gateway' }],
+      });
+
+      const result = await createApigwResource(
+        mockContext,
+        mockEvent,
+        'test-service',
+        stateWithFunction,
+      );
+
+      expect(mockClient.apigw.waitForGatewayRunning).toHaveBeenCalledWith('gw-owned');
+      expect(mockClient.apigw.createService).toHaveBeenCalledWith(
+        expect.objectContaining({ gatewayId: 'gw-owned' }),
+      );
+      expect(result.resources['events.api_gateway'].status).toBe('ready');
+    });
+
+    it('refuses to adopt a foreign gateway after an already-exists create conflict', async () => {
+      mockClient.apigw.createGateway.mockRejectedValue(new Error('gateway already exists'));
+      mockClient.apigw.findGatewayByName.mockResolvedValueOnce(null).mockResolvedValueOnce({
+        gatewayId: 'gw-foreign',
+        gatewayName: 'test-service-dev-apigw',
+        type: 'serverless',
+        tags: [],
+      });
+
+      await expect(
+        createApigwResource(mockContext, mockEvent, 'test-service', stateWithFunction),
+      ).rejects.toThrow('not owned by this stack');
+      expect(mockClient.apigw.waitForGatewayRunning).not.toHaveBeenCalled();
+    });
+
+    it('propagates non-conflict gateway creation failures', async () => {
+      mockClient.apigw.createGateway.mockRejectedValue(new Error('network unavailable'));
+
+      await expect(
+        createApigwResource(mockContext, mockEvent, 'test-service', stateWithFunction),
+      ).rejects.toThrow('network unavailable');
+      expect(mockClient.apigw.findGatewayByName).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('updateApigwResource', () => {
@@ -468,6 +515,186 @@ describe('apigwResource', () => {
       expect(mockClient.apigw.createRoute).not.toHaveBeenCalled();
       expect(mockClient.apigw.findRouteByName).toHaveBeenCalled();
       expect(result.resources['events.api_gateway'].instances).toHaveLength(5);
+    });
+
+    it('creates the resource when local event state is missing', async () => {
+      (getResource as jest.Mock).mockImplementation((state: StateFile, logicalId: string) =>
+        logicalId === 'events.api_gateway' ? null : state.resources?.[logicalId] || null,
+      );
+
+      const result = await updateApigwResource(
+        mockContext,
+        mockEvent,
+        'test-service',
+        stateWithFunction,
+      );
+
+      expect(mockClient.apigw.createGateway).toHaveBeenCalled();
+      expect(result.resources['events.api_gateway'].status).toBe('ready');
+    });
+
+    it('creates the resource when local event state has no service instance', async () => {
+      const stateWithoutService: StateFile = {
+        ...stateWithEvent,
+        resources: {
+          ...stateWithEvent.resources,
+          'events.api_gateway': {
+            ...stateWithEvent.resources['events.api_gateway'],
+            instances: [
+              { type: 'VOLCENGINE_APIGW_GATEWAY', sid: 's', id: 'gw-1', gatewayId: 'gw-1' },
+            ],
+          },
+        },
+      };
+      (getResource as jest.Mock).mockImplementation(
+        (state: StateFile, logicalId: string) => state.resources?.[logicalId] || null,
+      );
+
+      const result = await updateApigwResource(
+        mockContext,
+        mockEvent,
+        'test-service',
+        stateWithoutService,
+      );
+
+      expect(mockClient.apigw.createGateway).toHaveBeenCalled();
+      expect(result.resources['events.api_gateway'].status).toBe('ready');
+    });
+
+    it('reuses existing TLS resources when logs remain enabled', async () => {
+      const eventWithLog: EventDomain = { ...mockEvent, log: true };
+      const stateWithLogs: StateFile = {
+        ...stateWithEvent,
+        resources: {
+          ...stateWithEvent.resources,
+          'events.api_gateway': {
+            ...stateWithEvent.resources['events.api_gateway'],
+            instances: [
+              ...stateWithEvent.resources['events.api_gateway'].instances,
+              {
+                type: 'VOLCENGINE_TLS_PROJECT',
+                sid: 's',
+                id: 'test-service-dev-apigw-tls',
+                projectId: 'proj-existing',
+              },
+              {
+                type: 'VOLCENGINE_TLS_TOPIC',
+                sid: 's',
+                id: 'test-service-dev-apigw-tls/test-service-dev-apigw-logs',
+                topicId: 'topic-existing',
+              },
+            ],
+          },
+        },
+      };
+      (getResource as jest.Mock).mockImplementation(
+        (state: StateFile, logicalId: string) => state.resources?.[logicalId] || null,
+      );
+      mockClient.apigw.findUpstreamByName.mockResolvedValue({
+        upstreamId: 'up-1',
+        upstreamName: 'u',
+      });
+      mockClient.apigw.findRouteByName.mockResolvedValue({ routeId: 'route-1', routeName: 'r' });
+
+      const result = await updateApigwResource(
+        mockContext,
+        eventWithLog,
+        'test-service',
+        stateWithLogs,
+      );
+
+      expect(mockClient.tls.createProject).not.toHaveBeenCalled();
+      expect(mockClient.apigw.updateGatewayLog).toHaveBeenCalledWith('gw-1', {
+        enable: true,
+        projectId: 'proj-existing',
+        topicId: 'topic-existing',
+      });
+      expect(result.resources['events.api_gateway'].instances).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ type: 'VOLCENGINE_TLS_PROJECT', projectId: 'proj-existing' }),
+          expect.objectContaining({ type: 'VOLCENGINE_TLS_TOPIC', topicId: 'topic-existing' }),
+        ]),
+      );
+    });
+
+    it('disables gateway logging when TLS resources remain in state but log is removed', async () => {
+      const stateWithLogs: StateFile = {
+        ...stateWithEvent,
+        resources: {
+          ...stateWithEvent.resources,
+          'events.api_gateway': {
+            ...stateWithEvent.resources['events.api_gateway'],
+            instances: [
+              ...stateWithEvent.resources['events.api_gateway'].instances,
+              {
+                type: 'VOLCENGINE_TLS_PROJECT',
+                sid: 's',
+                id: 'test-service-dev-apigw-tls',
+                projectId: 'proj-existing',
+              },
+            ],
+          },
+        },
+      };
+      (getResource as jest.Mock).mockImplementation(
+        (state: StateFile, logicalId: string) => state.resources?.[logicalId] || null,
+      );
+      mockClient.apigw.findUpstreamByName.mockResolvedValue({
+        upstreamId: 'up-1',
+        upstreamName: 'u',
+      });
+      mockClient.apigw.findRouteByName.mockResolvedValue({ routeId: 'route-1', routeName: 'r' });
+
+      await updateApigwResource(mockContext, mockEvent, 'test-service', stateWithLogs);
+
+      expect(mockClient.apigw.updateGatewayLog).toHaveBeenCalledWith('gw-1', {
+        enable: false,
+        projectId: '',
+        topicId: '',
+      });
+    });
+
+    it('adopts a remote upstream and creates routes for it', async () => {
+      const stateWithoutUpstream: StateFile = {
+        ...stateWithEvent,
+        resources: {
+          ...stateWithEvent.resources,
+          'events.api_gateway': {
+            ...stateWithEvent.resources['events.api_gateway'],
+            instances: stateWithEvent.resources['events.api_gateway'].instances.filter(
+              (instance) => instance.type !== 'VOLCENGINE_APIGW_UPSTREAM',
+            ),
+          },
+        },
+      };
+      (getResource as jest.Mock).mockImplementation(
+        (state: StateFile, logicalId: string) => state.resources?.[logicalId] || null,
+      );
+      mockClient.apigw.findUpstreamByName.mockResolvedValue({
+        upstreamId: 'up-adopted',
+        upstreamName: 'test-gw-dev-upstream-api-function',
+      });
+      mockClient.apigw.findRouteByName.mockResolvedValue(null);
+      mockClient.apigw.createRoute
+        .mockResolvedValueOnce('route-2')
+        .mockResolvedValueOnce('route-3');
+
+      const result = await updateApigwResource(
+        mockContext,
+        mockEvent,
+        'test-service',
+        stateWithoutUpstream,
+      );
+
+      expect(mockClient.apigw.createUpstream).not.toHaveBeenCalled();
+      expect(mockClient.apigw.createRoute).toHaveBeenCalledWith(
+        expect.objectContaining({ upstreamId: 'up-adopted' }),
+      );
+      expect(result.resources['events.api_gateway'].instances).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ type: 'VOLCENGINE_APIGW_ROUTE', routeId: 'route-2' }),
+        ]),
+      );
     });
   });
 
@@ -562,6 +789,89 @@ describe('apigwResource', () => {
       );
       expect(mockClient.tls.deleteProject).toHaveBeenCalledWith('test-service-dev-apigw-tls');
       expect(removeResource).toHaveBeenCalled();
+    });
+
+    it('returns unchanged state when the event resource is already absent', async () => {
+      (getResource as jest.Mock).mockReturnValue(null);
+
+      const result = await deleteApigwResource(mockContext, 'events.missing', stateWithFunction);
+
+      expect(result).toBe(stateWithFunction);
+      expect(removeResource).not.toHaveBeenCalled();
+    });
+
+    it('ignores provider not-found errors while deleting all dependent resources', async () => {
+      const stateWithDependents: StateFile = {
+        ...stateWithFunction,
+        resources: {
+          ...stateWithFunction.resources,
+          'events.api_gateway': {
+            mode: 'managed',
+            region: 'cn-beijing',
+            definition: {},
+            instances: [
+              {
+                type: 'VOLCENGINE_APIGW_SERVICE',
+                sid: 's',
+                id: 'svc-1',
+                serviceId: 'svc-1',
+                gatewayId: 'gw-1',
+              },
+              { type: 'VOLCENGINE_APIGW_ROUTE', sid: 's', id: 'route-1', routeId: 'route-1' },
+              { type: 'VOLCENGINE_APIGW_UPSTREAM', sid: 's', id: 'up-1', upstreamId: 'up-1' },
+              { type: 'VOLCENGINE_APIGW_DOMAIN', sid: 's', id: 'domain-1' },
+            ],
+            lastUpdated: '2024-01-01T00:00:00Z',
+          },
+        },
+      };
+      (getResource as jest.Mock).mockImplementation(
+        (state: StateFile, logicalId: string) => state.resources?.[logicalId] || null,
+      );
+      mockClient.apigw.deleteRoute.mockRejectedValue({ code: 'RouteNotFound' });
+      mockClient.apigw.deleteUpstream.mockRejectedValue({ code: 'UpstreamNotFound' });
+      mockClient.apigw.deleteService.mockRejectedValue({ code: 'ServiceNotFound' });
+      mockClient.apigw.deleteCustomDomain.mockRejectedValue({ code: 'DomainNotFound' });
+
+      await expect(
+        deleteApigwResource(mockContext, 'events.api_gateway', stateWithDependents),
+      ).resolves.toEqual(expect.not.objectContaining({ events: expect.anything() }));
+
+      expect(mockClient.apigw.deleteCustomDomain).toHaveBeenCalledWith('domain-1');
+      expect(removeResource).toHaveBeenCalled();
+    });
+
+    it('propagates unexpected route deletion errors without removing state', async () => {
+      const stateWithRoute: StateFile = {
+        ...stateWithFunction,
+        resources: {
+          ...stateWithFunction.resources,
+          'events.api_gateway': {
+            mode: 'managed',
+            region: 'cn-beijing',
+            definition: {},
+            instances: [
+              {
+                type: 'VOLCENGINE_APIGW_SERVICE',
+                sid: 's',
+                id: 'svc-1',
+                gatewayId: 'gw-1',
+              },
+              { type: 'VOLCENGINE_APIGW_ROUTE', sid: 's', id: 'route-1' },
+            ],
+            lastUpdated: '2024-01-01T00:00:00Z',
+          },
+        },
+      };
+      (getResource as jest.Mock).mockImplementation(
+        (state: StateFile, logicalId: string) => state.resources?.[logicalId] || null,
+      );
+      mockClient.apigw.deleteRoute.mockRejectedValue({ code: 'PermissionDenied' });
+
+      await expect(
+        deleteApigwResource(mockContext, 'events.api_gateway', stateWithRoute),
+      ).rejects.toEqual({ code: 'PermissionDenied' });
+      expect(removeResource).not.toHaveBeenCalled();
     });
   });
 });

--- a/tests/unit/stack/volcengineStack/apigwTypes.test.ts
+++ b/tests/unit/stack/volcengineStack/apigwTypes.test.ts
@@ -9,8 +9,21 @@ import {
   triggerToApigwUpstreamConfig,
   triggerToApigwRouteConfig,
   extractEventDomainDefinition,
+  resolveFunctionReference,
 } from '../../../../src/stack/volcengineStack/apigwTypes';
 import type { EventDomain } from '../../../../src/types';
+import { getContext, getIacDefinition, isFunctionDomain, logger } from '../../../../src/common';
+
+jest.mock('../../../../src/common', () => ({
+  getContext: jest.fn(),
+  getIacDefinition: jest.fn(),
+  isFunctionDomain: jest.fn(),
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+}));
+
+jest.mock('../../../../src/lang', () => ({
+  lang: { __: (key: string) => key },
+}));
 
 const mockEvent: EventDomain = {
   key: 'api_gateway',
@@ -24,6 +37,10 @@ const mockEvent: EventDomain = {
 };
 
 describe('apigwTypes', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('should build gateway name from service + stage', () => {
     expect(buildGatewayName('rest-api-volcengine', 'dev')).toBe('rest-api-volcengine-dev-apigw');
   });
@@ -96,5 +113,41 @@ describe('apigwTypes', () => {
       path: '/graphql',
       backend: '${functions.api_function}',
     });
+  });
+
+  it('should retain the backend reference when IaC context is unavailable', () => {
+    (getContext as jest.Mock).mockReturnValue({ iac: undefined });
+
+    const result = resolveFunctionReference('${functions.api_function}');
+
+    expect(result).toBe('${functions.api_function}');
+    expect(logger.warn).toHaveBeenCalledWith('CANNOT_RESOLVE_FUNCTION_REF');
+    expect(getIacDefinition).not.toHaveBeenCalled();
+  });
+
+  it('should retain the backend reference when the definition is not a function', () => {
+    const iac = { functions: {} };
+    (getContext as jest.Mock).mockReturnValue({ iac });
+    (getIacDefinition as jest.Mock).mockReturnValue({ type: 'API_GATEWAY' });
+    (isFunctionDomain as unknown as jest.Mock).mockReturnValue(false);
+
+    const result = resolveFunctionReference('${functions.api_function}');
+
+    expect(result).toBe('${functions.api_function}');
+    expect(getIacDefinition).toHaveBeenCalledWith(iac, '${functions.api_function}');
+    expect(logger.warn).toHaveBeenCalledWith('FUNCTION_REF_NOT_RESOLVED');
+  });
+
+  it('should return the resolved function name for a valid function definition', () => {
+    const iac = { functions: {} };
+    const functionDefinition = { name: 'resolved-function' };
+    (getContext as jest.Mock).mockReturnValue({ iac });
+    (getIacDefinition as jest.Mock).mockReturnValue(functionDefinition);
+    (isFunctionDomain as unknown as jest.Mock).mockReturnValue(true);
+
+    const result = resolveFunctionReference('${functions.api_function}');
+
+    expect(result).toBe('resolved-function');
+    expect(logger.warn).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/stack/volcengineStack/destroyer.test.ts
+++ b/tests/unit/stack/volcengineStack/destroyer.test.ts
@@ -186,6 +186,52 @@ describe('volcengineStack destroyer', () => {
       );
     });
 
+    it('should delete API Gateway resources before functions', async () => {
+      const stateWithGatewayAndFunction: StateFile = {
+        ...mockState,
+        resources: {
+          'events.api_gateway': {
+            mode: 'managed',
+            region: 'cn-beijing',
+            definition: {},
+            instances: [{ sid: 'gateway-sid', id: 'gateway-id', type: 'VOLCENGINE_APIGW_GATEWAY' }],
+            lastUpdated: '2024-01-01T00:00:00Z',
+          },
+          'functions.test_fn': {
+            mode: 'managed',
+            region: 'cn-beijing',
+            definition: { functionName: 'test-function' },
+            instances: [
+              { sid: 'function-sid', id: 'test-function', type: 'VOLCENGINE_VEFAAS_FUNCTION' },
+            ],
+            lastUpdated: '2024-01-01T00:00:00Z',
+          },
+        },
+      };
+      mockBackend.loadState = jest.fn().mockResolvedValue(stateWithGatewayAndFunction);
+      const { getAllResources } = jest.requireMock('../../../../src/common/stateManager');
+      const { deleteApigwResource } = jest.requireMock(
+        '../../../../src/stack/volcengineStack/apigwResource',
+      );
+      const { deleteResource } = jest.requireMock(
+        '../../../../src/stack/volcengineStack/vefaasResource',
+      );
+      const calls: Array<string> = [];
+      getAllResources.mockReturnValue(stateWithGatewayAndFunction.resources);
+      deleteApigwResource.mockImplementation(async () => {
+        calls.push('gateway');
+        return stateWithGatewayAndFunction;
+      });
+      deleteResource.mockImplementation(async () => {
+        calls.push('function');
+        return stateWithGatewayAndFunction;
+      });
+
+      await destroyVolcengineStack(mockBackend);
+
+      expect(calls).toEqual(['gateway', 'function']);
+    });
+
     it('should handle bucket deletion error', async () => {
       const stateWithBucket: StateFile = {
         ...mockState,

--- a/tests/unit/stack/volcengineStack/vefaasPlanner.test.ts
+++ b/tests/unit/stack/volcengineStack/vefaasPlanner.test.ts
@@ -520,5 +520,64 @@ describe('vefaasPlanner', () => {
       expect(result.items).toHaveLength(1);
       expect(result.items[0].action).toBe('create');
     });
+
+    it('should reuse TLS topic names from state when function logging is enabled', async () => {
+      const functionWithLog: FunctionDomain = { ...mockFunction, log: true };
+      const stateWithTlsTopic: StateFile = {
+        ...mockState,
+        resources: {
+          'functions.test_fn': {
+            mode: 'managed',
+            region: 'cn-beijing',
+            definition: { functionName: 'test-function' },
+            instances: [
+              { sid: 'test-sid', id: 'test-function', type: 'VOLCENGINE_VEFAAS_FUNCTION' },
+              {
+                sid: 'topic-sid',
+                id: 'existing-project/existing-topic',
+                type: 'VOLCENGINE_TLS_TOPIC',
+              },
+            ],
+            status: 'tainted',
+            lastUpdated: '2024-01-01T00:00:00Z',
+          },
+        },
+      };
+      jest
+        .spyOn(stateManager, 'getResource')
+        .mockReturnValue(stateWithTlsTopic.resources['functions.test_fn']);
+      mockVefaasClient.vefaas.getFunction.mockResolvedValueOnce({
+        functionName: 'test-function',
+        Tags: [{ Key: 'si-owned-by', Value: 'test-app-test-service:functions.test_fn' }],
+      });
+
+      const result = await generateFunctionPlan(mockContext, stateWithTlsTopic, [functionWithLog]);
+
+      expect(result.items[0]).toMatchObject({
+        action: 'create',
+        changes: {
+          after: { logConfig: { project: 'existing-project', topic: 'existing-topic' } },
+        },
+      });
+    });
+
+    it('should derive deterministic TLS names when logging is enabled without TLS state', async () => {
+      const functionWithLog: FunctionDomain = { ...mockFunction, log: true };
+      mockVefaasClient.vefaas.getFunction.mockResolvedValueOnce(null);
+
+      const result = await generateFunctionPlan(mockContext, mockState, [functionWithLog]);
+
+      expect(result.items[0]).toMatchObject({
+        action: 'create',
+        changes: {
+          after: {
+            logConfig: {
+              project: 'test-app-test-service-dev-tls',
+              topic: 'test-app-test-service-dev-logs',
+            },
+          },
+        },
+      });
+    });
   });
 });


### PR DESCRIPTION
## Summary
- initialize the SaaS state backend before acquiring the destroy lock
- recognize current Volcengine API Gateway state types during destroy
- delete API Gateway resources before deleting veFaaS functions

## Verification
- `npx tsc --noEmit`
- `npx jest tests/unit/commands/destroy.test.ts tests/unit/stack/volcengineStack/destroyer.test.ts tests/unit/common/stateBackend/saasStateBackend.test.ts --runInBand --forceExit --silent`
- `npm run lint:check`

The unrelated working-tree change in `src/stack/volcengineStack/vefaasPlanner.ts` is intentionally excluded.