### PR TITLE
fix(ims): use global endpoint ims.aliyuncs.com for IAM info lookup

### DIFF
--- a/src/common/imsClient.ts
+++ b/src/common/imsClient.ts
@@ -13,6 +13,7 @@ export const getIamInfo = async (context: Context) => {
     accessKeyId: context.accessKeyId,
     accessKeySecret: context.accessKeySecret,
     regionId: context.region,
+    endpoint: 'ims.aliyuncs.com',
   });
   imsConfig.connectTimeout = ALIYUN_FC3_CONNECT_TIMEOUT_MS;
   imsConfig.readTimeout = ALIYUN_FC3_READ_TIMEOUT_MS;

--- a/tests/unit/common/imsClient.test.ts
+++ b/tests/unit/common/imsClient.test.ts
@@ -122,5 +122,27 @@ describe('imsClient', () => {
         }),
       );
     });
+
+    it('should use global IMS endpoint instead of regionalized host', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const mockConfig = require('@alicloud/openapi-client').Config;
+      mockGetUser.mockResolvedValue({
+        body: {
+          user: {
+            userPrincipalName: 'test@123456.onaliyun.com',
+          },
+        },
+      });
+
+      const context = mockContext(ProviderEnum.ALIYUN);
+      await getIamInfo(context);
+
+      expect(mockConfig).toHaveBeenCalledWith(
+        expect.objectContaining({
+          regionId: 'cn-hangzhou',
+          endpoint: 'ims.aliyuncs.com',
+        }),
+      );
+    });
   });
 });


### PR DESCRIPTION
## Summary
Fixes #217

`getIamInfo` built the IMS client config without an explicit endpoint, so the SDK regionalized the host to `ims.<region>.aliyuncs.com`. That host only exists for `cn-hangzhou` — for every other region (e.g. `ap-southeast-1`) DNS resolution fails (`getaddrinfo ENOTFOUND`) and aborts every command that initializes context: `si deploy`, `si plan`, `si destroy`.

## Root cause
The official `@alicloud/ims20190815` endpoint map contains only `cn-hangzhou → ims.aliyuncs.com`. Unmapped regions fall through to the generic `ims.<region>.aliyuncs.com` rule. IMS is served exclusively from the global endpoint.

## Fix
Pin the explicit global endpoint in `src/common/imsClient.ts`, which takes precedence over regionalization per official SDK docs. `regionId` is retained alongside it (officially supported; no auth/signing impact).

```diff
   const imsConfig = new openApi.Config({
     accessKeyId: context.accessKeyId,
     accessKeySecret: context.accessKeySecret,
     regionId: context.region,
+    endpoint: 'ims.aliyuncs.com',
   });
```

## Test plan
- [x] New unit test `should use global IMS endpoint instead of regionalized host` written test-first: failed against unfixed code (Config had no \`endpoint\`), passes after fix (RED→GREEN captured)
- [x] Focused imsClient suite: 8/8 passed
- [x] Full unit suite: 140 suites / 2963 tests passed, 85% coverage gate satisfied
- [x] \`npm run lint:check\` and \`npm run build\` pass

Fixes #217