### PR TITLE
fix(#221): collision-safe generated resource names + pre-deploy validation hardening (#222)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,61 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### ⚠️ Breaking change
+
+- **Generated API Gateway resource names are now collision-safe.** Aliyun apiNames
+  (`agw_api` events), Volcengine route names, and Aliyun group names are produced by a
+  deterministic constrained-name builder ([#221](https://github.com/geek-fun/serverlessinsight/issues/221),
+  [#222](https://github.com/geek-fun/serverlessinsight/issues/222)): when a composed name exceeds the provider
+  limit, the leading human-readable segments are truncated while the method/path
+  discriminator is preserved, and a deterministic hash suffix guarantees distinctness.
+  - Configurations whose previous names already fit their provider limit keep the
+    exact same generated names.
+  - Deployments affected by the historical truncation will regenerate names. Existing
+    cloud APIs/routes created under old truncated names are no longer matched by
+    `expectedApiNames` during updates: they become orphaned instead of adopted, so
+    plans may show create operations for new names. Manually delete superseded
+    gateway resources after upgrading.
+- **Aliyun API Gateway groups are now per-event.** The group name includes the event
+  key (`<service>-<stage>-<eventKey>-agw-group`), so multiple `API_GATEWAY` events
+  under one service+stage each own their group instead of fighting over one shared
+  group's ownership tag. Groups created before this change are orphaned on the next
+  plan (same regeneration story as above); delete them manually after upgrading.
+- **Volcengine `python3.8/v1` runtime removed.** Volcengine has retired Python 3.8
+  for veFaaS (product notice). The two newer native runtime ids from
+  Volcengine-maintained tooling were added: `native-python3.12/v1`,
+  `native-node20/v1`.
+
+### Added
+
+- Huawei Cloud FunctionGraph is now first-class in runtime compatibility checks:
+  standard runtime ids map to the officially supported FunctionGraph runtimes
+  (Node.js 10–20, Python 3.6/3.9/3.10/3.12, Java 8/11/17/21, Go 1.x, .NET Core 3.1),
+  so literal `runtime` values validate for provider `huawei` instead of always
+  failing.
+- Pre-deploy semantic validation runs alongside schema validation and reports, in a
+  single aggregated error set: duplicate `method+path` triggers per event,
+  duplicate generated apiName/routeName within the deploy scope, dangling
+  `${functions.x}` trigger backends, plus provider-conditional function-name length
+  limits (Aliyun ≤ 64, Tencent ≤ 60) enforced through JSON Schema `if/then`, and
+  literal-format rules for trigger paths (`^/…`), bucket names and domain hostnames.
+  Template references (`${vars.x}`, …) bypass literal format rules by design.
+- Samples-as-canaries: a unit test validates every `samples/*.yml` through the full
+  schema + semantic validation, so sample drift fails CI instead of users.
+- Fixed trigger definitions being silently unvalidated inside `events.*.triggers`
+  items (the subschema lacked its object envelope), which also hid HTTP-method enums.
+
+### Fixed
+
+- Table schema now accepts `network.vpc_id` (the resource layer always passed it
+  through) and rejects unknown keys inside `network` via `additionalProperties`.
+- Schema error formatter no longer prints an empty `Allowed values:` line when the
+  violating rule has no allowed values.
+- Localized the BUCKET_STORE backend error message to the i18n system
+  ([#222](https://github.com/geek-fun/serverlessinsight/issues/222)).
+
 ## [0.7.2] - 2026-06-26
 
 ### Fixed

--- a/samples/aliyun-poc-fc-gpu.yml
+++ b/samples/aliyun-poc-fc-gpu.yml
@@ -52,5 +52,5 @@ functions:
       OLLAMA_NOHISTORY: false
       OLLAMA_NOPRUNE: false
       OLLAMA_NUM_PARALLEL: 1
-      OLLAMA_ORIGINS: [ * http://localhost https://localhost http://localhost:* https://localhost:* http://127.0.0.1 https://127.0.0.1 http://127.0.0.1:* https://127.0.0.1:* http://0.0.0.0 https://0.0.0.0 http://0.0.0.0:* https://0.0.0.0:* app://* file://* tauri://* vscode-webview://* ]
-      OLLAMA_SCHED_SPREAD: fals
+      OLLAMA_ORIGINS: 'http://localhost,https://localhost,http://localhost:*,https://localhost:*,http://127.0.0.1,https://127.0.0.1,http://127.0.0.1:*,https://127.0.0.1:*,http://0.0.0.0,https://0.0.0.0,http://0.0.0.0:*,https://0.0.0.0:*,app://*,file://*,tauri://*,vscode-webview://*'
+      OLLAMA_SCHED_SPREAD: false

--- a/samples/aliyun-poc-table.yml
+++ b/samples/aliyun-poc-table.yml
@@ -13,7 +13,7 @@ tags:
 tables:
   insight_poc_table:
     collection: insight-poc-collection
-    description: Insight POC Table for testing purposes
+    desc: Insight POC Table for testing purposes
     name: insightPocTable
     type: TABLE_STORE_H
     network:

--- a/samples/volcengine-poc-advanced.yml
+++ b/samples/volcengine-poc-advanced.yml
@@ -10,7 +10,7 @@ functions:
   vpc_function:
     name: insight-poc-vpc-fn
     code:
-      runtime: nodejs/v18
+      runtime: node20/v1
       handler: index.handler
       path: ./artifacts/function.zip
     memory: 512
@@ -23,13 +23,9 @@ functions:
       security_group:
         name: fn-security-group
         ingress:
-          - protocol: TCP
-            port: 443
-            source: 0.0.0.0/0
+          - 'TCP:0.0.0.0/0:443'
         egress:
-          - protocol: TCP
-            port: 0
-            destination: 0.0.0.0/0
+          - 'TCP:0.0.0.0/0:ALL'
     environment:
       DATABASE_URL: mysql://...
       REDIS_URL: redis://...
@@ -37,7 +33,7 @@ functions:
   basic_function:
     name: insight-poc-basic-fn
     code:
-      runtime: python/v3.10
+      runtime: python3.12/v1
       handler: main.handler
       path: ./artifacts/processor.zip
     memory: 256

--- a/samples/volcengine-poc-api.yml
+++ b/samples/volcengine-poc-api.yml
@@ -10,7 +10,7 @@ functions:
   api_function:
     name: insight-poc-api-fn
     code:
-      runtime: nodejs/v18
+      runtime: node20/v1
       handler: index.handler
       path: ./artifacts/function.zip
     memory: 256

--- a/samples/volcengine-poc-function.yml
+++ b/samples/volcengine-poc-function.yml
@@ -10,7 +10,7 @@ functions:
   hello_function:
     name: insight-poc-hello-fn
     code:
-      runtime: nodejs/v18
+      runtime: node20/v1
       handler: index.handler
       path: ./artifacts/function.zip
     memory: 128

--- a/samples/volcengine-poc-vpc.yml
+++ b/samples/volcengine-poc-vpc.yml
@@ -10,7 +10,7 @@ functions:
   vpc_function:
     name: insight-poc-vpc-fn
     code:
-      runtime: nodejs/v18
+      runtime: node20/v1
       handler: index.handler
       path: ./artifacts/function.zip
     memory: 512
@@ -22,13 +22,9 @@ functions:
       security_group:
         name: fn-security-group
         ingress:
-          - protocol: TCP
-            port: 443
-            source: 0.0.0.0/0
+          - 'TCP:0.0.0.0/0:443'
         egress:
-          - protocol: TCP
-            port: 0
-            destination: 0.0.0.0/0
+          - 'TCP:0.0.0.0/0:ALL'
     environment:
       DATABASE_URL: mysql://rds-host:3306/mydb
       REDIS_URL: redis://redis-host:6379

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -20,3 +20,5 @@ export * from './planFormatter';
 export * from './credentialStore';
 export * from './apiClient';
 export * from './triggerMapper';
+export * from './nameBuilder';
+export * from './providerNames';

--- a/src/common/nameBuilder.ts
+++ b/src/common/nameBuilder.ts
@@ -1,0 +1,104 @@
+/**
+ * Deterministic constrained-name builder.
+ *
+ * Contract (see GitHub issue #222):
+ * - Identifiers are derived from user config and must respect a provider
+ *   maximum length. Silent truncation used to discard the distinguishing
+ *   discriminator (issue #221: RepeatedApiName collisions).
+ * - When the composed name fits the maximum length, it is returned verbatim
+ *   (minus charset sanitisation) so existing well-fitting configurations keep
+ *   their deployed names and do not churn.
+ * - When it does not fit, the human-readable prefix is truncated FIRST while
+ *   the discriminator (later parts) is preserved whenever possible, and a
+ *   deterministic hash of the raw parts is always appended so distinct inputs
+ *   never collapse to the same name. Theoretical digest collisions within a
+ *   deploy set are additionally rejected up-front by semantic validation.
+ */
+
+const FNV_OFFSET_BASIS = 0x811c9dc5;
+const FNV_PRIME = 0x01000193;
+
+type CharsetMode = 'underscore' | 'hyphen';
+
+const SANITISERS: Record<CharsetMode, { invalidChars: RegExp; separator: string }> = {
+  // Aliyun identifiers (CreateApi apiName: [A-Za-z0-9_], hyphens forbidden)
+  underscore: { invalidChars: /[^A-Za-z0-9_]/g, separator: '_' },
+  // Volcengine identifiers (letters/digits/hyphens, underscores folded to hyphens)
+  hyphen: { invalidChars: /[^A-Za-z0-9-]/g, separator: '-' },
+};
+
+export const DEFAULT_HASH_LENGTH = 7;
+
+const toUtf8Bytes = (input: string): Array<number> => Array.from(Buffer.from(input, 'utf8'));
+
+/** Deterministic 32-bit FNV-1a rendered as fixed-width base36. */
+export const stableHash = (raw: string, length: number = DEFAULT_HASH_LENGTH): string =>
+  toUtf8Bytes(raw)
+    .reduce((hash, byte) => ((hash ^ byte) * FNV_PRIME) >>> 0, FNV_OFFSET_BASIS)
+    .toString(36)
+    .padStart(length, '0')
+    .slice(0, length);
+
+const sanitizePart = (part: string, mode: CharsetMode): string =>
+  part.replace(SANITISERS[mode].invalidChars, SANITISERS[mode].separator);
+
+export type ConstrainedNameOptions = {
+  parts: Array<string>;
+  maxLength: number;
+  charset: CharsetMode;
+};
+
+/**
+ * Build a provider-constrained identifier from ordered user-derived segments,
+ * joined by the charset separator. Over-long compositions truncate the leading
+ * (human-readable) segments first and append a hash of the raw segments so
+ * distinct inputs never collapse into one name.
+ */
+export const buildConstrainedName = ({
+  parts,
+  maxLength,
+  charset,
+}: ConstrainedNameOptions): string => {
+  const { separator } = SANITISERS[charset];
+  const joinSegments = (segments: Array<string>): string =>
+    segments
+      .map((part) => sanitizePart(part, charset))
+      .filter((part) => part.length > 0)
+      .join(separator);
+
+  const readable = joinSegments(parts);
+  if (readable.length <= maxLength) {
+    return readable;
+  }
+
+  const hashLength = Math.max(1, Math.min(DEFAULT_HASH_LENGTH, maxLength - 1));
+  // Hash over the RAW segments so inputs sanitising identically stay distinct.
+  const hash = stableHash(parts.join('\u0000'), hashLength);
+
+  const clampPrefix = (cap: number): string => {
+    const prefix = joinSegments(parts.slice(0, -1)).slice(0, Math.max(cap, 0));
+    return prefix.replace(new RegExp(`\\${separator}+$`), '');
+  };
+
+  const separatorAllowance = separator.length * 2;
+  const discriminatorRoom = maxLength - hashLength - separatorAllowance;
+  const discriminatorSanitized = sanitizePart(parts[parts.length - 1], charset);
+
+  if (parts.length > 1 && discriminatorSanitized.length <= discriminatorRoom) {
+    const headSegments = [
+      clampPrefix(discriminatorRoom - discriminatorSanitized.length),
+      discriminatorSanitized,
+    ].filter((segment) => segment.length > 0);
+    return `${headSegments.join(separator)}${separator}${hash}`;
+  }
+
+  const headOnly = clampPrefix(maxLength - hashLength - separator.length);
+  return [headOnly, hash].filter((segment) => segment.length > 0).join(separator);
+};
+
+/** Per-provider maximum lengths for names generated through this module. */
+export const CONSTRAINT_NAME_LIMITS = {
+  ALIYUN_CREATE_API_NAME: 50,
+  ALIYUN_API_GROUP_NAME: 50,
+  VOLCENGINE_ROUTE_NAME: 63,
+} as const;

--- a/src/common/providerNames.ts
+++ b/src/common/providerNames.ts
@@ -1,0 +1,56 @@
+/**
+ * Leaf module for generated provider resource names.
+ *
+ * Lives in src/common (not in the stack modules) so that both the deployment
+ * stacks and the pre-deploy semantic validator share ONE source of truth for
+ * generated names without introducing import cycles. See issue #222.
+ */
+import { buildConstrainedName, CONSTRAINT_NAME_LIMITS } from './nameBuilder';
+
+/**
+ * Generate a unique API key from an HTTP method and path.
+ * Uses URL encoding to preserve path structure and avoid collisions.
+ */
+export const generateApiKey = (method: string, path: string): string => {
+  // Replace slashes with double underscores to preserve path structure
+  // Replace other non-alphanumeric chars with single underscore
+  const sanitizedPath = path
+    .replace(/\//g, '__')
+    .replace(/[^a-zA-Z0-9_]/g, '_')
+    .replace(/^__/, '') // Remove leading double underscore
+    .replace(/__$/, ''); // Remove trailing double underscore
+  return `${method}_${sanitizedPath}`;
+};
+
+/**
+ * Aliyun API Gateway apiName. Aliyun CreateApi requires 4-50 chars of
+ * [A-Za-z0-9_] — no hyphens.
+ *
+ * Resolves issue #221: long event names no longer truncate the trailing
+ * method/path discriminator out of existence.
+ */
+export const buildAliyunApigwApiName = (eventName: string, stage: string, apiKey: string): string =>
+  buildConstrainedName({
+    parts: [eventName, stage, 'agw_api', apiKey],
+    maxLength: CONSTRAINT_NAME_LIMITS.ALIYUN_CREATE_API_NAME,
+    charset: 'underscore',
+  });
+
+/**
+ * Volcengine API Gateway route name (max 63 chars, letters/digits/hyphens).
+ */
+export const buildVolcengineRouteName = (
+  eventName: string,
+  method: string,
+  path: string,
+): string => {
+  const sanitizedPath = path
+    .replace(/\//g, '_')
+    .replace(/[^a-zA-Z0-9_]/g, '_')
+    .replace(/^_+|_+$/g, '');
+  return buildConstrainedName({
+    parts: [eventName, `${method}_${sanitizedPath}`],
+    maxLength: CONSTRAINT_NAME_LIMITS.VOLCENGINE_ROUTE_NAME,
+    charset: 'hyphen',
+  });
+};

--- a/src/common/runtimeMapper.ts
+++ b/src/common/runtimeMapper.ts
@@ -44,26 +44,32 @@ const runtimeMappings: Record<StandardRuntime, RuntimeMapping> = {
   [StandardRuntime.NODEJS20]: {
     [ProviderEnum.ALIYUN]: 'nodejs20',
     [ProviderEnum.AWS]: 'nodejs20.x',
+    [ProviderEnum.HUAWEI]: 'nodejs20.15',
   },
   [StandardRuntime.NODEJS18]: {
     [ProviderEnum.ALIYUN]: 'nodejs18',
     [ProviderEnum.TENCENT]: 'Nodejs18.15',
+    [ProviderEnum.HUAWEI]: 'nodejs18.15',
   },
   [StandardRuntime.NODEJS16]: {
     [ProviderEnum.ALIYUN]: 'nodejs16',
     [ProviderEnum.TENCENT]: 'Nodejs16.13',
+    [ProviderEnum.HUAWEI]: 'nodejs16.17',
   },
   [StandardRuntime.NODEJS14]: {
     [ProviderEnum.ALIYUN]: 'nodejs14',
     [ProviderEnum.TENCENT]: 'Nodejs14.18',
+    [ProviderEnum.HUAWEI]: 'nodejs14.18',
   },
   [StandardRuntime.NODEJS12]: {
     [ProviderEnum.ALIYUN]: 'nodejs12',
     [ProviderEnum.TENCENT]: 'Nodejs12.16',
+    [ProviderEnum.HUAWEI]: 'nodejs12.13',
   },
   [StandardRuntime.NODEJS10]: {
     [ProviderEnum.ALIYUN]: 'nodejs10',
     [ProviderEnum.TENCENT]: 'Nodejs10.15',
+    [ProviderEnum.HUAWEI]: 'nodejs10.16',
   },
   [StandardRuntime.PYTHON3_14]: {
     [ProviderEnum.AWS]: 'python3.14',
@@ -74,6 +80,7 @@ const runtimeMappings: Record<StandardRuntime, RuntimeMapping> = {
   [StandardRuntime.PYTHON3_12]: {
     [ProviderEnum.ALIYUN]: 'python3.12',
     [ProviderEnum.AWS]: 'python3.12',
+    [ProviderEnum.HUAWEI]: 'python3.12',
   },
   [StandardRuntime.PYTHON3_11]: {
     [ProviderEnum.AWS]: 'python3.11',
@@ -82,10 +89,12 @@ const runtimeMappings: Record<StandardRuntime, RuntimeMapping> = {
     [ProviderEnum.ALIYUN]: 'python3.10',
     [ProviderEnum.TENCENT]: 'Python3.10',
     [ProviderEnum.AWS]: 'python3.10',
+    [ProviderEnum.HUAWEI]: 'python3.10',
   },
   [StandardRuntime.PYTHON3_9]: {
     [ProviderEnum.ALIYUN]: 'python3.9',
     [ProviderEnum.TENCENT]: 'Python3.9',
+    [ProviderEnum.HUAWEI]: 'python3.9',
   },
   [StandardRuntime.PYTHON3_7]: {
     [ProviderEnum.TENCENT]: 'Python3.7',
@@ -93,24 +102,30 @@ const runtimeMappings: Record<StandardRuntime, RuntimeMapping> = {
   [StandardRuntime.PYTHON3_6]: {
     [ProviderEnum.ALIYUN]: 'python3.6',
     [ProviderEnum.TENCENT]: 'Python3.6',
+    [ProviderEnum.HUAWEI]: 'python3.6',
   },
   [StandardRuntime.JAVA25]: {
     [ProviderEnum.AWS]: 'java25',
   },
   [StandardRuntime.JAVA21]: {
     [ProviderEnum.AWS]: 'java21',
+    // Huawei java21 is regional (ME-Riyadh, TR-Istanbul) per FunctionGraph docs.
+    [ProviderEnum.HUAWEI]: 'java21',
   },
   [StandardRuntime.JAVA17]: {
     [ProviderEnum.AWS]: 'java17',
+    [ProviderEnum.HUAWEI]: 'java17',
   },
   [StandardRuntime.JAVA11]: {
     [ProviderEnum.ALIYUN]: 'java11',
     [ProviderEnum.AWS]: 'java11',
+    [ProviderEnum.HUAWEI]: 'java11',
   },
   [StandardRuntime.JAVA8]: {
     [ProviderEnum.ALIYUN]: 'java8',
     [ProviderEnum.TENCENT]: 'Java8',
     [ProviderEnum.AWS]: 'java8.al2',
+    [ProviderEnum.HUAWEI]: 'java8',
   },
   [StandardRuntime.PHP8_0]: {
     [ProviderEnum.TENCENT]: 'Php8.0',
@@ -128,9 +143,11 @@ const runtimeMappings: Record<StandardRuntime, RuntimeMapping> = {
   [StandardRuntime.GO1]: {
     [ProviderEnum.ALIYUN]: 'go 1.x',
     [ProviderEnum.TENCENT]: 'Go1',
+    [ProviderEnum.HUAWEI]: 'go1.x',
   },
   [StandardRuntime.DOTNET_CORE3_1]: {
     [ProviderEnum.ALIYUN]: '.NET Core 3.1',
+    [ProviderEnum.HUAWEI]: 'dotnetcore3.1',
   },
 };
 
@@ -153,9 +170,12 @@ export const mapRuntime = (standardRuntime: string, provider: ProviderEnum): str
   return providerRuntime;
 };
 
-// Valid veFaaS runtimes per the official CreateFunction API reference:
-// golang/v1, native/v1, nativejava8/v1, node14/v1, node20/v1, nodeprime14/v1,
-// python3.12/v1, python3.8/v1, python3.9/v1
+// Valid veFaaS runtimes per the official CreateFunction API reference, adjusted
+// for product notices: python3.8/v1 retired (volcengine notice 2121844) and the
+// native-family ids added from Volcengine-maintained tooling (mcp-server / veadk).
+// Verified 2026-08: golang/v1, native/v1, nativejava8/v1, node14/v1, node20/v1,
+// nodeprime14/v1, python3.12/v1, python3.9/v1, native-python3.12/v1,
+// native-node20/v1
 const VOLCENGINE_NATIVE_RUNTIMES = [
   'golang/v1',
   'native/v1',
@@ -164,8 +184,9 @@ const VOLCENGINE_NATIVE_RUNTIMES = [
   'node20/v1',
   'nodeprime14/v1',
   'python3.12/v1',
-  'python3.8/v1',
   'python3.9/v1',
+  'native-python3.12/v1',
+  'native-node20/v1',
 ];
 
 export const isRuntimeSupported = (runtime: string, provider: ProviderEnum): boolean => {

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -505,6 +505,18 @@ export const en = {
   RESOLVED_FUNCTION_REF:
     'Resolved function reference {{backendRef}} to function name: {{functionName}}',
 
+  // Pre-deploy semantic validation (issue #222)
+  PARSE_BACKEND_BUCKET_STORE_FIELDS_REQUIRED:
+    'Backend type BUCKET_STORE requires both "bucket" and "key" fields',
+  SEMANTIC_DUPLICATE_TRIGGER:
+    'Duplicate trigger in event "{{eventKey}}": {{method}} {{path}} is defined more than once',
+  SEMANTIC_DUPLICATE_GENERATED_API_NAME:
+    'Generated API Gateway apiName "{{apiName}}" collides between "{{firstPath}}" and "{{secondPath}}" in this deployment; shorten the event name or differentiate trigger method/path',
+  SEMANTIC_DUPLICATE_ROUTE_NAME:
+    'Generated API Gateway route name "{{routeName}}" collides between "{{firstPath}}" and "{{secondPath}}" in this deployment; shorten the event name or differentiate trigger method/path',
+  SEMANTIC_UNRESOLVED_FUNCTION_BACKEND:
+    'Trigger backend "{{reference}}" in event "{{eventKey}}" does not match any function definition in the configuration',
+
   // Show command messages
   LOADING_STATE_FOR: 'Loading state for app: {{app}}, service: {{service}}, stage: {{stage}}...',
   NO_RESOURCES_FOUND: 'No resources found in state.',

--- a/src/lang/zh-CN.ts
+++ b/src/lang/zh-CN.ts
@@ -451,6 +451,18 @@ export const zhCN = {
   FUNCTION_REF_NOT_RESOLVED: '无法从 IAC 解析函数引用 {{backendRef}}',
   RESOLVED_FUNCTION_REF: '已将函数引用 {{backendRef}} 解析为函数名: {{functionName}}',
 
+  // Pre-deploy semantic validation (issue #222)
+  PARSE_BACKEND_BUCKET_STORE_FIELDS_REQUIRED:
+    '后端类型 BUCKET_STORE 需要同时提供 "bucket" 和 "key" 字段',
+  SEMANTIC_DUPLICATE_TRIGGER:
+    '事件 "{{eventKey}}" 中存在重复触发器: {{method}} {{path}} 定义了不止一次',
+  SEMANTIC_DUPLICATE_GENERATED_API_NAME:
+    '生成的 API Gateway apiName "{{apiName}}" 在 "{{firstPath}}" 与 "{{secondPath}}" 之间发生冲突；请缩短事件名称或区分触发器的 method/path',
+  SEMANTIC_DUPLICATE_ROUTE_NAME:
+    '生成的 API Gateway route name "{{routeName}}" 在 "{{firstPath}}" 与 "{{secondPath}}" 之间发生冲突；请缩短事件名称或区分触发器的 method/path',
+  SEMANTIC_UNRESOLVED_FUNCTION_BACKEND:
+    '事件 "{{eventKey}}" 的触发器后端 "{{reference}}" 未匹配到配置中的任何函数定义',
+
   // Show command messages
   LOADING_STATE_FOR: '正在加载应用 {{app}}、服务 {{service}}、阶段 {{stage}} 的状态...',
   NO_RESOURCES_FOUND: '状态中未找到资源。',

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -16,6 +16,7 @@ import { validateYaml } from '../validator';
 import { parseBucket } from './bucketParser';
 import { parseTable } from './tableParser';
 import { calcValue } from '../common';
+import { lang } from '../lang';
 
 const validateExistence = (path: string) => {
   if (!existsSync(path)) {
@@ -34,7 +35,7 @@ const parseBackend = (raw: BackendConfigRaw | undefined): BackendConfig | undefi
 
   if (type === StateBackendType.BUCKET_STORE) {
     if (!stateManager.bucket || !stateManager.key) {
-      throw new Error('Backend type BUCKET_STORE requires both "bucket" and "key" fields');
+      throw new Error(lang.__('PARSE_BACKEND_BUCKET_STORE_FIELDS_REQUIRED'));
     }
     return {
       type: StateBackendType.BUCKET_STORE,

--- a/src/stack/aliyunStack/apigwTypes.ts
+++ b/src/stack/aliyunStack/apigwTypes.ts
@@ -1,5 +1,14 @@
 import { CdnConfig, Context, EventDomain, ResourceAttributes } from '../../types';
-import { getIacDefinition, isFunctionDomain, getContext, logger } from '../../common';
+import {
+  buildAliyunApigwApiName,
+  buildConstrainedName,
+  CONSTRAINT_NAME_LIMITS,
+  getIacDefinition,
+  generateApiKey,
+  isFunctionDomain,
+  getContext,
+  logger,
+} from '../../common';
 import { lang } from '../../lang';
 import { OWNERSHIP_TAG_KEY, buildOwnershipTagValue } from '../ownershipTag';
 // Re-export the info types from the shared client layer so there is a single
@@ -11,6 +20,7 @@ export type {
   ApigwCustomDomainItem,
   ApigwRequestParameter,
 } from '../../common/aliyunClient/apigwOperations';
+export { buildAliyunApigwApiName, generateApiKey } from '../../common';
 
 // API Group types
 export type ApigwGroupConfig = {
@@ -97,7 +107,14 @@ export const eventToApigwGroupConfig = (
   logicalId?: string,
 ): ApigwGroupConfig => {
   const groupConfig: ApigwGroupConfig = {
-    groupName: `${serviceName}-${stage}-agw-group`.replace(/_/g, '-'),
+    // Per-event group: each API_GATEWAY event owns its group so the
+    // single-owner adoption tag stays exact. 4-50 chars per Aliyun
+    // ALIYUN::ApiGateway::Group docs; charset proven in this repo (hyphens).
+    groupName: buildConstrainedName({
+      parts: [serviceName, stage, event.key ?? '', 'agw_group'],
+      maxLength: CONSTRAINT_NAME_LIMITS.ALIYUN_API_GROUP_NAME,
+      charset: 'hyphen',
+    }),
     description: `API Gateway group for ${serviceName}`,
   };
   if (context && logicalId) {
@@ -106,21 +123,6 @@ export const eventToApigwGroupConfig = (
     ];
   }
   return groupConfig;
-};
-
-/**
- * Generate a unique API key from method and path
- * Uses URL encoding to preserve path structure and avoid collisions
- */
-export const generateApiKey = (method: string, path: string): string => {
-  // Replace slashes with double underscores to preserve path structure
-  // Replace other non-alphanumeric chars with single underscore
-  const sanitizedPath = path
-    .replace(/\//g, '__')
-    .replace(/[^a-zA-Z0-9_]/g, '_')
-    .replace(/^__/, '') // Remove leading double underscore
-    .replace(/__$/, ''); // Remove trailing double underscore
-  return `${method}_${sanitizedPath}`;
 };
 
 /**
@@ -171,8 +173,7 @@ export const triggerToApigwApiConfig = (
 
   return {
     groupId,
-    // Aliyun CreateApi requires 4-50 chars of [A-Za-z0-9_] — no hyphens.
-    apiName: `${(event.name as string).replace(/-/g, '_')}_${stage}_agw_api_${apiKey}`.slice(0, 50),
+    apiName: buildAliyunApigwApiName(event.name as string, stage, apiKey),
     visibility: 'PRIVATE',
     authType: 'ANONYMOUS',
     requestConfig: {

--- a/src/stack/volcengineStack/apigwTypes.ts
+++ b/src/stack/volcengineStack/apigwTypes.ts
@@ -1,4 +1,10 @@
-import { getContext, getIacDefinition, isFunctionDomain, logger } from '../../common';
+import {
+  buildVolcengineRouteName,
+  getContext,
+  getIacDefinition,
+  isFunctionDomain,
+  logger,
+} from '../../common';
 import type {
   ApigwGatewayConfig,
   ApigwServiceConfig,
@@ -26,13 +32,8 @@ export const buildUpstreamName = (
   return `${event.name}-${stage}-upstream-${fnKey.replace(/_/g, '-')}`;
 };
 
-export const buildRouteName = (event: EventDomain, method: string, path: string): string => {
-  const sanitized = path
-    .replace(/\//g, '_')
-    .replace(/[^a-zA-Z0-9_]/g, '_')
-    .replace(/^_+|_+$/g, '');
-  return `${event.name}-${method}_${sanitized}`.replace(/_/g, '-').slice(0, 63);
-};
+export const buildRouteName = (event: EventDomain, method: string, path: string): string =>
+  buildVolcengineRouteName(event.name, method, path);
 
 /**
  * Resolves a function reference like ${functions.xxx} to the actual function name

--- a/src/validator/bucketSchema.ts
+++ b/src/validator/bucketSchema.ts
@@ -1,4 +1,10 @@
-import { resolvableBoolean, resolvableEnum } from './templateRefSchema';
+import {
+  resolvableBoolean,
+  resolvableEnum,
+  resolvableConstrained,
+  HOST_NAME_PATTERN,
+  BUCKET_NAME_PATTERN,
+} from './templateRefSchema';
 
 const cdnSchema = {
   oneOf: [
@@ -26,7 +32,7 @@ const bucketDomainSchema = {
     {
       type: 'object',
       properties: {
-        domain_name: { type: 'string' },
+        domain_name: resolvableConstrained({ pattern: HOST_NAME_PATTERN }),
         certificate_id: { type: 'string' },
         certificate_body: { type: 'string' },
         certificate_private_key: { type: 'string' },
@@ -78,7 +84,7 @@ const bucketWebsiteDomainSchema = {
     {
       type: 'object',
       properties: {
-        domain_name: { type: 'string' },
+        domain_name: resolvableConstrained({ pattern: HOST_NAME_PATTERN }),
         certificate_id: { type: 'string' },
         certificate_body: { type: 'string' },
         certificate_private_key: { type: 'string' },
@@ -178,9 +184,7 @@ export const bucketSchema = {
     '.*': {
       type: 'object',
       properties: {
-        name: {
-          type: 'string',
-        },
+        name: resolvableConstrained({ pattern: BUCKET_NAME_PATTERN }),
         storage: {
           type: 'object',
           properties: {

--- a/src/validator/eventSchema.ts
+++ b/src/validator/eventSchema.ts
@@ -1,4 +1,9 @@
-import { resolvableEnum, resolvableBoolean } from './templateRefSchema';
+import {
+  resolvableEnum,
+  resolvableBoolean,
+  resolvableConstrained,
+  HOST_NAME_PATTERN,
+} from './templateRefSchema';
 
 const cdnSchema = {
   oneOf: [
@@ -42,9 +47,12 @@ export const eventSchema = {
         triggers: {
           type: 'array',
           items: {
-            method: resolvableEnum(['GET', 'POST', 'PUT', 'DELETE', 'ANY']),
-            path: { type: 'string' },
-            backend: { type: 'string' },
+            type: 'object',
+            properties: {
+              method: resolvableEnum(['GET', 'POST', 'PUT', 'DELETE', 'ANY']),
+              path: resolvableConstrained({ pattern: '^/\\S*$' }),
+              backend: { type: 'string' },
+            },
             required: ['method', 'path', 'backend'],
           },
         },
@@ -53,7 +61,7 @@ export const eventSchema = {
           additionalProperties: false,
           required: ['domain_name'],
           properties: {
-            domain_name: { type: 'string' },
+            domain_name: resolvableConstrained({ pattern: HOST_NAME_PATTERN }),
             certificate_id: { type: 'string' },
             certificate_body: { type: 'string' },
             certificate_private_key: { type: 'string' },

--- a/src/validator/functionSchema.ts
+++ b/src/validator/functionSchema.ts
@@ -1,4 +1,10 @@
-import { resolvableNumber, resolvableBoolean, resolvableEnum } from './templateRefSchema';
+import {
+  resolvableNumber,
+  resolvableBoolean,
+  resolvableEnum,
+  resolvableConstrained,
+  HOST_NAME_PATTERN,
+} from './templateRefSchema';
 
 const securityGroupRulePattern =
   '^[A-Za-z]+:\\d{1,3}(?:\\.\\d{1,3}){3}\\/\\d{1,2}:(?:ALL|\\d{1,5}(?:\\/\\d{1,5})?)$';
@@ -52,8 +58,9 @@ export const functionSchema = {
               'node20/v1',
               'nodeprime14/v1',
               'python3.12/v1',
-              'python3.8/v1',
               'python3.9/v1',
+              'native-python3.12/v1',
+              'native-node20/v1',
             ]),
             handler: { type: 'string' },
             path: { type: 'string' },
@@ -179,7 +186,7 @@ export const functionSchema = {
           required: ['domain_name'],
           additionalProperties: false,
           properties: {
-            domain_name: { type: 'string' },
+            domain_name: resolvableConstrained({ pattern: HOST_NAME_PATTERN }),
             certificate_id: { type: 'string' },
             protocol: resolvableEnum(['HTTP', 'HTTPS']),
           },

--- a/src/validator/iacSchema.ts
+++ b/src/validator/iacSchema.ts
@@ -8,6 +8,7 @@ import { functionSchema } from './functionSchema';
 import { bucketSchema } from './bucketSchema';
 import { tableSchema } from './tableschema';
 import { lang } from '../lang';
+import { validateSemantics } from './semanticValidation';
 
 type IacSchemaError = {
   instancePath: string;
@@ -37,7 +38,7 @@ class IacSchemaErrors extends Error {
           `  Type: ${error.type}`,
           `  Message: ${error.message}`,
         ];
-        if (error.allowedValues) {
+        if (error.allowedValues && error.allowedValues.length > 0) {
           parts.push(`  Allowed values: ${error.allowedValues.join(', ')}`);
         }
         return parts.join('\n');
@@ -105,9 +106,17 @@ const validateRuntimeCompatibility = (iacJson: ServerlessIacRaw) => {
 
 export const validateYaml = (iacJson: ServerlessIacRaw) => {
   const valid = validate(iacJson);
-  if (!valid) {
-    logger.debug(lang.__('INVALID_YAML', { errors: JSON.stringify(validate.errors) }));
-    throw new IacSchemaErrors(validate.errors as Array<ErrorObject>);
+  const semanticErrors = validateSemantics(iacJson);
+  if (!valid || semanticErrors.length > 0) {
+    logger.debug(
+      lang.__('INVALID_YAML', {
+        errors: JSON.stringify([...(validate.errors ?? []), ...semanticErrors]),
+      }),
+    );
+    throw new IacSchemaErrors([
+      ...((validate.errors ?? []) as Array<ErrorObject>),
+      ...semanticErrors,
+    ]);
   }
 
   validateRuntimeCompatibility(iacJson);

--- a/src/validator/rootSchema.ts
+++ b/src/validator/rootSchema.ts
@@ -1,3 +1,32 @@
+import { templateRefSchema } from './templateRefSchema';
+
+// Provider-enforced function-name maximums (audit of issue #222)
+const FUNCTION_NAME_MAX_LENGTH: Record<string, number> = {
+  aliyun: 64,
+  tencent: 60,
+};
+
+const functionNameLimitBranch = (provider: string, maxLength: number): Record<string, unknown> => ({
+  if: {
+    properties: { provider: { properties: { name: { const: provider } }, required: ['name'] } },
+    required: ['provider'],
+  },
+  then: {
+    properties: {
+      functions: {
+        patternProperties: {
+          '.*': {
+            properties: {
+              // Whole-value template references bypass the literal limit.
+              name: { anyOf: [{ type: 'string', maxLength }, templateRefSchema] },
+            },
+          },
+        },
+      },
+    },
+  },
+});
+
 export const rootSchema = {
   $id: 'https://serverlessinsight.geekfun.club/schemas/schema.json',
   type: 'object',
@@ -115,4 +144,7 @@ export const rootSchema = {
   },
   required: ['version', 'provider', 'app', 'service'],
   additionalProperties: false,
+  allOf: Object.entries(FUNCTION_NAME_MAX_LENGTH).map(([provider, maxLength]) =>
+    functionNameLimitBranch(provider, maxLength),
+  ),
 };

--- a/src/validator/semanticValidation.ts
+++ b/src/validator/semanticValidation.ts
@@ -1,0 +1,142 @@
+import { ErrorObject } from 'ajv';
+import type { ServerlessIacRaw } from '../types';
+import { lang } from '../lang';
+// Direct leaf import on purpose: routing through the src/common barrel would
+// drag stateManager/lockManager/fs surfaces into the validator graph and
+// recreate an import cycle with src/parser. These helpers are pure.
+import {
+  buildAliyunApigwApiName,
+  buildVolcengineRouteName,
+  generateApiKey,
+} from '../common/providerNames';
+
+type EventTriggerRaw = {
+  method?: unknown;
+  path?: unknown;
+  backend?: unknown;
+};
+
+const FUNCTION_BACKEND_PATTERN = /^\$\{functions\.([\w.]+)\}$/;
+
+/**
+ * Stage is intentionally empty here: it is identical for every generated name
+ * inside one validation run, so collision detection is unaffected while avoiding
+ * coupling the validator to CLI context state.
+ */
+const STAGE_PLACEHOLDER = '';
+
+export const validateSemantics = (iacJson: ServerlessIacRaw): Array<ErrorObject> => {
+  const errors: Array<ErrorObject> = [];
+
+  if (!iacJson || typeof iacJson !== 'object') {
+    return errors;
+  }
+
+  const providerName = typeof iacJson.provider?.name === 'string' ? iacJson.provider.name : '';
+  const events = (iacJson.events ?? {}) as Record<string, Record<string, unknown>>;
+  const functionDefinitions = (iacJson.functions ?? {}) as Record<string, unknown>;
+
+  const definedFunctionKeys = new Set(Object.keys(functionDefinitions));
+
+  Object.entries(events).forEach(([eventKey, rawEvent]) => {
+    const triggers = Array.isArray(rawEvent.triggers)
+      ? (rawEvent.triggers as Array<EventTriggerRaw>)
+      : [];
+    const eventName = typeof rawEvent.name === 'string' ? rawEvent.name : '';
+
+    // Aliyun groups are per-event (each API_GATEWAY event owns its group), so
+    // apiName collisions are checked event-locally, matching Volcengine's
+    // per-event route scope.
+    const seenTriggerKeys = new Map<string, string>();
+    const seenRouteNames = new Map<string, string>();
+    const seenApiNames = new Map<string, string>();
+
+    triggers.forEach((trigger, index) => {
+      const method = typeof trigger.method === 'string' ? trigger.method.toUpperCase() : '';
+      const path = typeof trigger.path === 'string' ? trigger.path : '';
+      const instancePath = `/events/${eventKey}/triggers/${index}`;
+
+      if (method.length > 0 && path.length > 0) {
+        const triggerKey = `${method}:${path}`;
+        const firstPath = seenTriggerKeys.get(triggerKey);
+
+        if (firstPath !== undefined) {
+          errors.push({
+            instancePath,
+            schemaPath: '#/semantic/duplicateTrigger',
+            keyword: 'duplicateTrigger',
+            params: {},
+            message: lang.__('SEMANTIC_DUPLICATE_TRIGGER', { eventKey, method, path }),
+          });
+        } else {
+          seenTriggerKeys.set(triggerKey, path);
+        }
+      }
+
+      const backendRef =
+        typeof trigger.backend === 'string'
+          ? FUNCTION_BACKEND_PATTERN.exec(trigger.backend)?.[1]
+          : undefined;
+
+      if (backendRef && !definedFunctionKeys.has(backendRef)) {
+        errors.push({
+          instancePath,
+          schemaPath: '#/semantic/unresolvedBackendFunction',
+          keyword: 'unresolvedBackendFunction',
+          params: {},
+          message: lang.__('SEMANTIC_UNRESOLVED_FUNCTION_BACKEND', {
+            reference: `\${functions.${backendRef}}`,
+            eventKey,
+          }),
+        });
+      }
+
+      if (method.length > 0 && path.length > 0) {
+        if (providerName === 'aliyun') {
+          const apiKey = generateApiKey(method, path);
+          const apiName = buildAliyunApigwApiName(eventName, STAGE_PLACEHOLDER, apiKey);
+          const firstPath = seenApiNames.get(apiName);
+
+          if (firstPath) {
+            errors.push({
+              instancePath,
+              schemaPath: '#/semantic/duplicateGeneratedApiName',
+              keyword: 'duplicateGeneratedApiName',
+              params: {},
+              message: lang.__('SEMANTIC_DUPLICATE_GENERATED_API_NAME', {
+                apiName,
+                firstPath,
+                secondPath: path,
+              }),
+            });
+          } else {
+            seenApiNames.set(apiName, path);
+          }
+        }
+
+        if (providerName === 'volcengine') {
+          const routeName = buildVolcengineRouteName(eventName, method, path);
+          const firstPath = seenRouteNames.get(routeName);
+
+          if (firstPath) {
+            errors.push({
+              instancePath,
+              schemaPath: '#/semantic/duplicateRouteName',
+              keyword: 'duplicateRouteName',
+              params: {},
+              message: lang.__('SEMANTIC_DUPLICATE_ROUTE_NAME', {
+                routeName,
+                firstPath,
+                secondPath: path,
+              }),
+            });
+          } else {
+            seenRouteNames.set(routeName, path);
+          }
+        }
+      }
+    });
+  });
+
+  return errors;
+};

--- a/src/validator/semanticValidation.ts
+++ b/src/validator/semanticValidation.ts
@@ -56,11 +56,11 @@ export const validateSemantics = (iacJson: ServerlessIacRaw): Array<ErrorObject>
       const path = typeof trigger.path === 'string' ? trigger.path : '';
       const instancePath = `/events/${eventKey}/triggers/${index}`;
 
+      let isDuplicateTrigger = false;
       if (method.length > 0 && path.length > 0) {
         const triggerKey = `${method}:${path}`;
-        const firstPath = seenTriggerKeys.get(triggerKey);
-
-        if (firstPath !== undefined) {
+        if (seenTriggerKeys.has(triggerKey)) {
+          isDuplicateTrigger = true;
           errors.push({
             instancePath,
             schemaPath: '#/semantic/duplicateTrigger',
@@ -91,48 +91,52 @@ export const validateSemantics = (iacJson: ServerlessIacRaw): Array<ErrorObject>
         });
       }
 
-      if (method.length > 0 && path.length > 0) {
-        if (providerName === 'aliyun') {
-          const apiKey = generateApiKey(method, path);
-          const apiName = buildAliyunApigwApiName(eventName, STAGE_PLACEHOLDER, apiKey);
-          const firstPath = seenApiNames.get(apiName);
+      // Generated names derive from method+path, so a duplicate trigger would
+      // only re-report the duplicateTrigger error — skip name collision checks.
+      if (isDuplicateTrigger || method.length === 0 || path.length === 0) {
+        return;
+      }
 
-          if (firstPath) {
-            errors.push({
-              instancePath,
-              schemaPath: '#/semantic/duplicateGeneratedApiName',
-              keyword: 'duplicateGeneratedApiName',
-              params: {},
-              message: lang.__('SEMANTIC_DUPLICATE_GENERATED_API_NAME', {
-                apiName,
-                firstPath,
-                secondPath: path,
-              }),
-            });
-          } else {
-            seenApiNames.set(apiName, path);
-          }
+      if (providerName === 'aliyun') {
+        const apiKey = generateApiKey(method, path);
+        const apiName = buildAliyunApigwApiName(eventName, STAGE_PLACEHOLDER, apiKey);
+        const firstPath = seenApiNames.get(apiName);
+
+        if (firstPath !== undefined) {
+          errors.push({
+            instancePath,
+            schemaPath: '#/semantic/duplicateGeneratedApiName',
+            keyword: 'duplicateGeneratedApiName',
+            params: {},
+            message: lang.__('SEMANTIC_DUPLICATE_GENERATED_API_NAME', {
+              apiName,
+              firstPath,
+              secondPath: path,
+            }),
+          });
+        } else {
+          seenApiNames.set(apiName, path);
         }
+      }
 
-        if (providerName === 'volcengine') {
-          const routeName = buildVolcengineRouteName(eventName, method, path);
-          const firstPath = seenRouteNames.get(routeName);
+      if (providerName === 'volcengine') {
+        const routeName = buildVolcengineRouteName(eventName, method, path);
+        const firstPath = seenRouteNames.get(routeName);
 
-          if (firstPath) {
-            errors.push({
-              instancePath,
-              schemaPath: '#/semantic/duplicateRouteName',
-              keyword: 'duplicateRouteName',
-              params: {},
-              message: lang.__('SEMANTIC_DUPLICATE_ROUTE_NAME', {
-                routeName,
-                firstPath,
-                secondPath: path,
-              }),
-            });
-          } else {
-            seenRouteNames.set(routeName, path);
-          }
+        if (firstPath !== undefined) {
+          errors.push({
+            instancePath,
+            schemaPath: '#/semantic/duplicateRouteName',
+            keyword: 'duplicateRouteName',
+            params: {},
+            message: lang.__('SEMANTIC_DUPLICATE_ROUTE_NAME', {
+              routeName,
+              firstPath,
+              secondPath: path,
+            }),
+          });
+        } else {
+          seenRouteNames.set(routeName, path);
         }
       }
     });

--- a/src/validator/tableschema.ts
+++ b/src/validator/tableschema.ts
@@ -15,12 +15,14 @@ export const tableSchema = {
           type: 'object',
           properties: {
             type: resolvableEnum(['PUBLIC', 'PRIVATE']),
+            vpc_id: { type: 'string' },
             ingress_rules: {
               type: 'array',
               items: { type: 'string' },
             },
           },
           required: ['type'],
+          additionalProperties: false,
         },
         throughput: {
           type: 'object',

--- a/src/validator/templateRefSchema.ts
+++ b/src/validator/templateRefSchema.ts
@@ -4,7 +4,7 @@
 const templateRefPattern = '^\\$\\{(vars|stages|ctx|functions|certificates)\\.[\\w.]+\\}$';
 
 // Schema definition for a template reference string
-const templateRefSchema = {
+export const templateRefSchema = {
   type: 'string',
   pattern: templateRefPattern,
 };
@@ -22,3 +22,28 @@ export const resolvableBoolean = withTemplateRef({ type: 'boolean' });
 // Helper for enum types that can also be template refs
 export const resolvableEnum = (enumValues: string[]) =>
   withTemplateRef({ type: 'string', enum: enumValues });
+
+/**
+ * String field accepting either a whole template reference (`${vars.x}`) or a
+ * literal satisfying the given JSON-Schema string constraints. Partial
+ * interpolations deliberately fail so unresolved values never reach deploy.
+ */
+export const resolvableConstrained = (constraints: {
+  pattern?: string;
+  minLength?: number;
+  maxLength?: number;
+}): Record<string, unknown> =>
+  withTemplateRef({
+    type: 'string',
+    ...(constraints.pattern !== undefined ? { pattern: constraints.pattern } : {}),
+    ...(constraints.minLength !== undefined ? { minLength: constraints.minLength } : {}),
+    ...(constraints.maxLength !== undefined ? { maxLength: constraints.maxLength } : {}),
+  });
+
+/** Hostname optionally prefixed with a wildcard label (`*.example.com`). */
+export const HOST_NAME_PATTERN =
+  '^(?:\\*\\.)?(?:[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?\\.)+[A-Za-z]{2,63}$';
+
+/** Resource-style bucket name: lowercase labels (dotted forms permitted), 3–63 chars. */
+export const BUCKET_NAME_PATTERN =
+  '^(?:[a-z0-9](?:[a-z0-9-]{1,61}[a-z0-9])?|(?:[a-z0-9][a-z0-9-]*\\.)+[a-z0-9-]{1,61}[a-z0-9])$';

--- a/src/validator/templateRefSchema.ts
+++ b/src/validator/templateRefSchema.ts
@@ -44,6 +44,10 @@ export const resolvableConstrained = (constraints: {
 export const HOST_NAME_PATTERN =
   '^(?:\\*\\.)?(?:[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?\\.)+[A-Za-z]{2,63}$';
 
-/** Resource-style bucket name: lowercase labels (dotted forms permitted), 3–63 chars. */
+/**
+ * Resource-style bucket name: lowercase labels (dotted forms permitted), 3–63
+ * chars total. Both branches share the total-length lookahead; dotted labels
+ * each follow the hyphen rules (no leading/trailing hyphen per label).
+ */
 export const BUCKET_NAME_PATTERN =
-  '^(?:[a-z0-9](?:[a-z0-9-]{1,61}[a-z0-9])?|(?:[a-z0-9][a-z0-9-]*\\.)+[a-z0-9-]{1,61}[a-z0-9])$';
+  '^(?=.{3,63}$)(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?|(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\\.)+[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)$';

--- a/tests/unit/common/nameBuilder.test.ts
+++ b/tests/unit/common/nameBuilder.test.ts
@@ -1,0 +1,119 @@
+import { buildConstrainedName, CONSTRAINT_NAME_LIMITS } from '../../../src/common/nameBuilder';
+import { buildAliyunApigwApiName, generateApiKey } from '../../../src/common/providerNames';
+
+describe('buildConstrainedName', () => {
+  describe('legacy fit path', () => {
+    it('returns the sanitized join unchanged when it fits the maximum length', () => {
+      expect(
+        buildConstrainedName({
+          parts: ['test-gateway', 'dev', 'agw_api', 'GET_users'],
+          maxLength: 50,
+          charset: 'underscore',
+        }),
+      ).toBe('test_gateway_dev_agw_api_GET_users');
+    });
+
+    it('folds underscores into hyphens for the hyphen charset', () => {
+      expect(
+        buildConstrainedName({
+          parts: ['rest api', 'POST', 'api_v1'],
+          maxLength: 63,
+          charset: 'hyphen',
+        }),
+      ).toBe('rest-api-POST-api-v1');
+    });
+
+    it('is deterministic for identical inputs', () => {
+      const options = {
+        parts: ['a-name', 'stage-x'],
+        maxLength: 20,
+        charset: 'underscore' as const,
+      };
+      expect(buildConstrainedName(options)).toBe(buildConstrainedName(options));
+    });
+
+    it('skips empty segments instead of emitting dangling separators', () => {
+      expect(
+        buildConstrainedName({
+          parts: ['', 'only-part', ''],
+          maxLength: 30,
+          charset: 'underscore',
+        }),
+      ).toBe('only_part');
+    });
+  });
+
+  describe('constrained path', () => {
+    const longEventName = 'console-serverlessinsight-api-gateway';
+
+    const constrainedOptions = (apiKey: string) => ({
+      parts: [longEventName, 'prod', 'agw_api', apiKey],
+      maxLength: CONSTRAINT_NAME_LIMITS.ALIYUN_CREATE_API_NAME,
+      charset: 'underscore' as const,
+    });
+
+    it('preserves the discriminator segments of an over-long composition', () => {
+      const name = buildConstrainedName(constrainedOptions('GET_healthz'));
+
+      expect(name.length).toBeLessThanOrEqual(50);
+      expect(name).toContain('_GET_healthz_');
+    });
+
+    it('appends the hash after truncating only the leading segments', () => {
+      const name = buildConstrainedName(constrainedOptions('GET_healthz'));
+
+      expect(name.startsWith('console_serverlessinsight')).toBe(true);
+      expect(name.endsWith('GET_healthz')).toBe(false);
+      expect(name.split('_').pop()).toHaveLength(7);
+    });
+
+    it('never collapses distinct raw inputs that sanitise identically', () => {
+      const firstVariant = buildConstrainedName({
+        ...constrainedOptions('x y'),
+      });
+      const secondVariant = buildConstrainedName({
+        ...constrainedOptions('x_y'),
+      });
+
+      expect(new Set([firstVariant, secondVariant]).size).toBe(2);
+    });
+
+    it('degrades gracefully to a hash-only name for tiny maximum lengths', () => {
+      const name = buildConstrainedName({
+        parts: ['long-segment-here'],
+        maxLength: 8,
+        charset: 'underscore',
+      });
+
+      expect(name.length).toBeLessThanOrEqual(8);
+    });
+  });
+});
+
+describe('providerNames', () => {
+  it('generates the historic apiKey from method and path', () => {
+    expect(generateApiKey('GET', '/healthz')).toBe('GET_healthz');
+  });
+
+  it('keeps fitting aliyun apiNames byte-compatible with the pre-builder format', () => {
+    expect(buildAliyunApigwApiName('test-gateway-dev', 'default', 'GET_users')).toBe(
+      'test_gateway_dev_default_agw_api_GET_users',
+    );
+  });
+
+  it('produces unique aliyun apiNames for the issue #221 collision set', () => {
+    const eventName = 'console-serverlessinsight-api-gateway';
+    const apiKeys = [
+      generateApiKey('GET', '/healthz'),
+      generateApiKey('ANY', '/api/*'),
+      generateApiKey('ANY', '/*'),
+    ];
+    const apiNames = apiKeys.map((apiKey) => buildAliyunApigwApiName(eventName, 'prod', apiKey));
+
+    expect(new Set(apiNames).size).toBe(apiNames.length);
+    apiNames.forEach((name) => {
+      expect(name.length).toBeLessThanOrEqual(CONSTRAINT_NAME_LIMITS.ALIYUN_CREATE_API_NAME);
+      expect(name).toMatch(/^[A-Za-z0-9_]+$/);
+    });
+  });
+});

--- a/tests/unit/common/runtimeMapper.test.ts
+++ b/tests/unit/common/runtimeMapper.test.ts
@@ -33,6 +33,14 @@ describe('runtimeMapper', () => {
         expect(mapRuntime(StandardRuntime.NODEJS18, ProviderEnum.TENCENT)).toBe('Nodejs18.15');
       });
 
+      it('maps nodejs18 to Huawei nodejs18.15', () => {
+        expect(mapRuntime(StandardRuntime.NODEJS18, ProviderEnum.HUAWEI)).toBe('nodejs18.15');
+      });
+
+      it('maps go1 to Huawei go1.x', () => {
+        expect(mapRuntime(StandardRuntime.GO1, ProviderEnum.HUAWEI)).toBe('go1.x');
+      });
+
       it('maps nodejs16 to Aliyun nodejs16', () => {
         expect(mapRuntime(StandardRuntime.NODEJS16, ProviderEnum.ALIYUN)).toBe('nodejs16');
       });
@@ -244,9 +252,15 @@ describe('runtimeMapper', () => {
 
     it('returns true for Volcengine native runtimes', () => {
       expect(isRuntimeSupported('node14/v1', ProviderEnum.VOLCENGINE)).toBe(true);
-      expect(isRuntimeSupported('python3.8/v1', ProviderEnum.VOLCENGINE)).toBe(true);
+      expect(isRuntimeSupported('python3.12/v1', ProviderEnum.VOLCENGINE)).toBe(true);
       expect(isRuntimeSupported('golang/v1', ProviderEnum.VOLCENGINE)).toBe(true);
       expect(isRuntimeSupported('nativejava8/v1', ProviderEnum.VOLCENGINE)).toBe(true);
+      expect(isRuntimeSupported('native-python3.12/v1', ProviderEnum.VOLCENGINE)).toBe(true);
+      expect(isRuntimeSupported('native-node20/v1', ProviderEnum.VOLCENGINE)).toBe(true);
+    });
+
+    it('returns false for the retired python3.8/v1 runtime (product notice 2121844)', () => {
+      expect(isRuntimeSupported('python3.8/v1', ProviderEnum.VOLCENGINE)).toBe(false);
     });
 
     it('returns false for non-Volcengine runtimes when provider is Volcengine', () => {
@@ -304,7 +318,8 @@ describe('runtimeMapper', () => {
       const volcengineRuntimes = getSupportedRuntimes(ProviderEnum.VOLCENGINE);
       expect(volcengineRuntimes).toContain('node14/v1');
       expect(volcengineRuntimes).toContain('node20/v1');
-      expect(volcengineRuntimes).toContain('python3.8/v1');
+      expect(volcengineRuntimes).toContain('native-python3.12/v1');
+      expect(volcengineRuntimes).not.toContain('python3.8/v1');
       expect(volcengineRuntimes).toContain('golang/v1');
       expect(volcengineRuntimes).toContain('nativejava8/v1');
       expect(volcengineRuntimes).not.toContain('nodejs18');

--- a/tests/unit/samples.test.ts
+++ b/tests/unit/samples.test.ts
@@ -1,0 +1,38 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { parse } from 'yaml';
+import { validateYaml } from '../../src/validator/iacSchema';
+import { ServerlessIacRaw } from '../../src/types';
+import { ProviderEnum } from '../../src/common/providerEnum';
+
+jest.mock('../../src/common/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+}));
+
+jest.mock('../../src/lang', () => ({
+  lang: { __: (key: string) => key },
+}));
+
+/**
+ * Samples-as-canaries (issue #222): every shipped sample config must pass
+ * schema + semantic validation, so sample drift fails CI instead of users.
+ */
+describe('samples validate as canaries', () => {
+  const samplesDir = join(__dirname, '../../samples');
+  const sampleFiles = readdirSync(samplesDir).filter((file) => file.endsWith('.yml'));
+
+  it('discovers sample configs', () => {
+    expect(sampleFiles.length).toBeGreaterThan(5);
+  });
+
+  sampleFiles.forEach((file) => {
+    it(`validates samples/${file}`, () => {
+      const raw = parse(readFileSync(join(samplesDir, file), 'utf8')) as ServerlessIacRaw;
+      if (!raw.provider?.name) {
+        raw.provider = { name: ProviderEnum.ALIYUN, region: 'cn-hangzhou' };
+      }
+
+      expect(() => validateYaml(raw)).not.toThrow();
+    });
+  });
+});

--- a/tests/unit/stack/aliyunStack/apigwExecutor.test.ts
+++ b/tests/unit/stack/aliyunStack/apigwExecutor.test.ts
@@ -111,7 +111,7 @@ describe('ApigwExecutor', () => {
           'events.test_api': {
             mode: 'managed',
             region: 'cn-hangzhou',
-            definition: { groupName: 'test-service-default-agw-group' },
+            definition: { groupName: 'test-service-default-test-api-agw-group' },
             instances: [{ sid: 'si:test:test:default:test', id: 'test-group' }],
             lastUpdated: new Date().toISOString(),
           },
@@ -161,7 +161,7 @@ describe('ApigwExecutor', () => {
           'events.test_api': {
             mode: 'managed',
             region: 'cn-hangzhou',
-            definition: { groupName: 'test-service-default-agw-group' },
+            definition: { groupName: 'test-service-default-test-api-agw-group' },
             instances: [{ sid: 'si:test:test:default:test', id: 'test-group' }],
             lastUpdated: new Date().toISOString(),
           },
@@ -201,7 +201,7 @@ describe('ApigwExecutor', () => {
           'events.test_api': {
             mode: 'managed' as const,
             region: 'cn-hangzhou',
-            definition: { groupName: 'test-service-default-agw-group' },
+            definition: { groupName: 'test-service-default-test-api-agw-group' },
             instances: [{ sid: 'si:test:test:default:test', id: 'test-group' }],
             lastUpdated: new Date().toISOString(),
           },
@@ -423,7 +423,7 @@ describe('ApigwExecutor', () => {
           'events.test_api': {
             mode: 'managed' as const,
             region: 'cn-hangzhou',
-            definition: { groupName: 'test-service-default-agw-group' },
+            definition: { groupName: 'test-service-default-test-api-agw-group' },
             instances: [{ sid: 'si:test:test:default:test', id: 'test-group' }],
             lastUpdated: new Date().toISOString(),
           },
@@ -470,7 +470,7 @@ describe('ApigwExecutor', () => {
           'events.test_api': {
             mode: 'managed' as const,
             region: 'cn-hangzhou',
-            definition: { groupName: 'test-service-default-agw-group' },
+            definition: { groupName: 'test-service-default-test-api-agw-group' },
             instances: [{ sid: 'si:test:test:default:test', id: 'test-group' }],
             lastUpdated: new Date().toISOString(),
           },

--- a/tests/unit/stack/aliyunStack/apigwPlanner.test.ts
+++ b/tests/unit/stack/aliyunStack/apigwPlanner.test.ts
@@ -98,7 +98,7 @@ describe('Apigw Planner', () => {
         mode: 'managed',
         region: 'cn-hangzhou',
         definition: {
-          groupName: 'test-service-default-agw-group',
+          groupName: 'test-service-default-test-api-agw-group',
           description: 'API Gateway group for test-service',
           basePath: null,
           triggers: [{ method: 'GET', path: '/users', backend: 'userFunction' }],
@@ -109,7 +109,7 @@ describe('Apigw Planner', () => {
             type: 'ALIYUN_APIGW_GROUP',
             sid: 'si:aliyun:apigateway:default:group-123',
             id: 'group-123',
-            groupName: 'test-service-default-agw-group',
+            groupName: 'test-service-default-test-api-agw-group',
           },
         ],
         lastUpdated: new Date().toISOString(),
@@ -135,7 +135,7 @@ describe('Apigw Planner', () => {
         mode: 'managed',
         region: 'cn-hangzhou',
         definition: {
-          groupName: 'test-service-default-agw-group',
+          groupName: 'test-service-default-test-api-agw-group',
           description: 'API Gateway group for test-service',
           basePath: null,
           triggers: [{ method: 'GET', path: '/users', backend: 'userFunction' }],
@@ -147,7 +147,7 @@ describe('Apigw Planner', () => {
       });
       mockApigwOperations.findApiGroupByName.mockResolvedValue({
         groupId: 'group-123',
-        groupName: 'test-service-default-agw-group',
+        groupName: 'test-service-default-test-api-agw-group',
         tags: [{ Key: 'si-owned-by', Value: 'test-app-test-service:events.test_api' }],
       });
 
@@ -168,7 +168,7 @@ describe('Apigw Planner', () => {
         mode: 'managed',
         region: 'cn-hangzhou',
         definition: {
-          groupName: 'test-service-default-agw-group',
+          groupName: 'test-service-default-test-api-agw-group',
           description: 'API Gateway group for test-service',
           basePath: null,
           triggers: [{ method: 'GET', path: '/users', backend: 'userFunction' }],
@@ -180,7 +180,7 @@ describe('Apigw Planner', () => {
       });
       mockApigwOperations.findApiGroupByName.mockResolvedValue({
         groupId: 'group-123',
-        groupName: 'test-service-default-agw-group',
+        groupName: 'test-service-default-test-api-agw-group',
         tags: [{ Key: 'env', Value: 'prod' }],
       });
 
@@ -193,7 +193,7 @@ describe('Apigw Planner', () => {
       const state = loadState('aliyun', 'test-app', 'test-service', 'default', testDir);
       mockApigwOperations.findApiGroupByName.mockResolvedValue({
         groupId: 'group-123',
-        groupName: 'test-service-default-agw-group',
+        groupName: 'test-service-default-test-api-agw-group',
       });
 
       await expect(
@@ -205,7 +205,7 @@ describe('Apigw Planner', () => {
       const state = loadState('aliyun', 'test-app', 'test-service', 'default', testDir);
       mockApigwOperations.findApiGroupByName.mockResolvedValue({
         groupId: 'group-123',
-        groupName: 'test-service-default-agw-group',
+        groupName: 'test-service-default-test-api-agw-group',
         tags: [{ Key: 'si-owned-by', Value: 'test-app-test-service:events.test_api' }],
       });
 
@@ -227,7 +227,7 @@ describe('Apigw Planner', () => {
         mode: 'managed',
         region: 'cn-hangzhou',
         definition: {
-          groupName: 'test-service-default-agw-group',
+          groupName: 'test-service-default-test-api-agw-group',
           description: 'API Gateway group for test-service',
           basePath: null,
           triggers: [
@@ -244,7 +244,7 @@ describe('Apigw Planner', () => {
             type: 'ALIYUN_APIGW_GROUP',
             sid: 'si:aliyun:apigateway:default:group-123',
             id: 'group-123',
-            groupName: 'test-service-default-agw-group',
+            groupName: 'test-service-default-test-api-agw-group',
           },
         ],
         lastUpdated: new Date().toISOString(),
@@ -253,7 +253,7 @@ describe('Apigw Planner', () => {
       // Mock getApiGroup to return matching group
       mockApigwOperations.getApiGroup.mockResolvedValue({
         groupId: 'group-123',
-        groupName: 'test-service-default-agw-group',
+        groupName: 'test-service-default-test-api-agw-group',
         description: 'API Gateway group for test-service',
       });
 
@@ -274,7 +274,7 @@ describe('Apigw Planner', () => {
         mode: 'managed',
         region: 'cn-hangzhou',
         definition: {
-          groupName: 'test-service-default-agw-group',
+          groupName: 'test-service-default-test-api-agw-group',
           description: 'API Gateway group for test-service',
           basePath: null,
           triggers: [
@@ -291,7 +291,7 @@ describe('Apigw Planner', () => {
             type: 'ALIYUN_APIGW_GROUP',
             sid: 'si:aliyun:apigateway:default:group-123',
             id: 'group-123',
-            groupName: 'test-service-default-agw-group',
+            groupName: 'test-service-default-test-api-agw-group',
           },
         ],
         lastUpdated: new Date().toISOString(),
@@ -300,7 +300,7 @@ describe('Apigw Planner', () => {
       // Mock getApiGroup to return existing group
       mockApigwOperations.getApiGroup.mockResolvedValue({
         groupId: 'group-123',
-        groupName: 'test-service-default-agw-group',
+        groupName: 'test-service-default-test-api-agw-group',
       });
 
       const plan = await generateApigwPlan(mockContext, state, [testEvent], 'test-service');
@@ -363,7 +363,7 @@ describe('Apigw Planner', () => {
         mode: 'managed',
         region: 'cn-hangzhou',
         definition: {
-          groupName: 'test-service-default-agw-group',
+          groupName: 'test-service-default-test-api-agw-group',
           description: 'API Gateway group for test-service',
           basePath: null,
           triggers: [{ method: 'GET', path: '/users', backend: 'userFunction' }],
@@ -381,7 +381,7 @@ describe('Apigw Planner', () => {
             type: 'ALIYUN_APIGW_GROUP',
             sid: 'si:aliyun:apigateway:default:group-123',
             id: 'group-123',
-            groupName: 'test-service-default-agw-group',
+            groupName: 'test-service-default-test-api-agw-group',
           },
         ],
         lastUpdated: new Date().toISOString(),
@@ -389,7 +389,7 @@ describe('Apigw Planner', () => {
 
       mockApigwOperations.getApiGroup.mockResolvedValue({
         groupId: 'group-123',
-        groupName: 'test-service-default-agw-group',
+        groupName: 'test-service-default-test-api-agw-group',
         description: 'API Gateway group for test-service',
       });
 
@@ -418,7 +418,7 @@ describe('Apigw Planner', () => {
         mode: 'managed',
         region: 'cn-hangzhou',
         definition: {
-          groupName: 'test-service-default-agw-group',
+          groupName: 'test-service-default-test-api-agw-group',
           description: 'API Gateway group for test-service',
           basePath: null,
           triggers: [{ method: 'GET', path: '/users', backend: 'userFunction' }],
@@ -435,7 +435,7 @@ describe('Apigw Planner', () => {
             type: 'ALIYUN_APIGW_GROUP',
             sid: 'si:aliyun:apigateway:default:group-123',
             id: 'group-123',
-            groupName: 'test-service-default-agw-group',
+            groupName: 'test-service-default-test-api-agw-group',
           },
         ],
         lastUpdated: new Date().toISOString(),
@@ -443,7 +443,7 @@ describe('Apigw Planner', () => {
 
       mockApigwOperations.getApiGroup.mockResolvedValue({
         groupId: 'group-123',
-        groupName: 'test-service-default-agw-group',
+        groupName: 'test-service-default-test-api-agw-group',
       });
 
       const plan = await generateApigwPlan(mockContext, state, [eventWithHttps], 'test-service');
@@ -465,7 +465,7 @@ describe('Apigw Planner', () => {
         mode: 'managed',
         region: 'cn-hangzhou',
         definition: {
-          groupName: 'test-service-default-agw-group',
+          groupName: 'test-service-default-test-api-agw-group',
           description: 'API Gateway group for test-service',
           basePath: null,
           triggers: [
@@ -482,7 +482,7 @@ describe('Apigw Planner', () => {
             type: 'ALIYUN_APIGW_GROUP',
             sid: 'si:aliyun:apigateway:default:group-123',
             id: 'group-123',
-            groupName: 'test-service-default-agw-group',
+            groupName: 'test-service-default-test-api-agw-group',
           },
         ],
         lastUpdated: new Date().toISOString(),

--- a/tests/unit/stack/aliyunStack/apigwTypes.test.ts
+++ b/tests/unit/stack/aliyunStack/apigwTypes.test.ts
@@ -81,17 +81,26 @@ describe('Apigw Types', () => {
   });
 
   describe('eventToApigwGroupConfig', () => {
-    it('should convert EventDomain to ApigwGroupConfig', () => {
+    it('should convert EventDomain to ApigwGroupConfig with a per-event group name', () => {
       const config = eventToApigwGroupConfig(testEvent, 'my-service', 'default');
 
-      expect(config.groupName).toBe('my-service-default-agw-group');
+      expect(config.groupName).toBe('my-service-default-test-api-agw-group');
       expect(config.description).toBe('API Gateway group for my-service');
     });
 
     it('should handle service names with underscores', () => {
       const config = eventToApigwGroupConfig(testEvent, 'my_test_service', 'default');
 
-      expect(config.groupName).toBe('my-test-service-default-agw-group');
+      expect(config.groupName).toBe('my-test-service-default-test-api-agw-group');
+    });
+
+    it('should keep distinct group names for two events sharing one service+stage', () => {
+      const secondEvent: EventDomain = { ...testEvent, key: 'admin_api' };
+      const first = eventToApigwGroupConfig(testEvent, 'my-service', 'default');
+      const second = eventToApigwGroupConfig(secondEvent, 'my-service', 'default');
+
+      expect(first.groupName).not.toBe(second.groupName);
+      expect(second.groupName).toBe('my-service-default-admin-api-agw-group');
     });
   });
 
@@ -108,7 +117,7 @@ describe('Apigw Types', () => {
       );
 
       expect(config.groupId).toBe('group-123');
-      expect(config.apiName).toBe('Test API Gateway_default_agw_api_GET_users');
+      expect(config.apiName).toBe('Test_API_Gateway_default_agw_api_GET_users');
       expect(config.visibility).toBe('PRIVATE');
       expect(config.authType).toBe('ANONYMOUS');
       expect(config.requestConfig.requestHttpMethod).toBe('GET');
@@ -183,6 +192,37 @@ describe('Apigw Types', () => {
       );
 
       expect(config.requestConfig.requestProtocol).toBe('HTTP');
+    });
+
+    it('should keep generated apiNames distinct when a long event name truncates the discriminator (issue #221)', () => {
+      const longNameEvent: EventDomain = {
+        ...testEvent,
+        name: 'console-serverlessinsight-api-gateway',
+        triggers: [
+          { method: 'GET', path: '/healthz', backend: 'userFunction' },
+          { method: 'ANY', path: '/api/*', backend: 'userFunction' },
+          { method: 'ANY', path: '/*', backend: 'userFunction' },
+        ],
+      };
+
+      const apiNames = longNameEvent.triggers.map(
+        (trigger) =>
+          triggerToApigwApiConfig(
+            longNameEvent,
+            trigger,
+            'group-123',
+            'my-service',
+            'cn-hangzhou',
+            'prod',
+          ).apiName,
+      );
+
+      expect(new Set(apiNames).size).toBe(apiNames.length);
+      apiNames.forEach((name) => {
+        expect(name.length).toBeLessThanOrEqual(50);
+        expect(name).toMatch(/^[A-Za-z0-9_]+$/);
+      });
+      expect(apiNames[0]).toContain('_GET_healthz_');
     });
   });
 

--- a/tests/unit/stack/volcengineStack/apigwTypes.test.ts
+++ b/tests/unit/stack/volcengineStack/apigwTypes.test.ts
@@ -15,6 +15,7 @@ import type { EventDomain } from '../../../../src/types';
 import { getContext, getIacDefinition, isFunctionDomain, logger } from '../../../../src/common';
 
 jest.mock('../../../../src/common', () => ({
+  ...jest.requireActual('../../../../src/common'),
   getContext: jest.fn(),
   getIacDefinition: jest.fn(),
   isFunctionDomain: jest.fn(),
@@ -59,6 +60,21 @@ describe('apigwTypes', () => {
     const name = buildRouteName(mockEvent, 'POST', '/graphql');
     expect(name).toBe('rest-api-app-volcengine-gw-POST-graphql');
     expect(name.length).toBeLessThanOrEqual(63);
+  });
+
+  it('should keep route names distinct when a long event name truncates them (issue #221)', () => {
+    const longEvent: EventDomain = {
+      ...mockEvent,
+      name: 'console-serverlessinsight-api-gateway-volcengine-extended',
+    };
+    const routeNames = [
+      buildRouteName(longEvent, 'ANY', '/api/*'),
+      buildRouteName(longEvent, 'ANY', '/'),
+      buildRouteName(longEvent, 'GET', '/healthz'),
+    ];
+
+    expect(new Set(routeNames).size).toBe(routeNames.length);
+    routeNames.forEach((route) => expect(route.length).toBeLessThanOrEqual(63));
   });
 
   it('should resolve the function key from a backend ref', () => {

--- a/tests/unit/validator/semanticValidation.test.ts
+++ b/tests/unit/validator/semanticValidation.test.ts
@@ -134,7 +134,7 @@ describe('validateSemantics', () => {
       ).toHaveLength(0);
     });
 
-    it('surfaces generated-name duplicates together with trigger duplicates', () => {
+    it('reports duplicate triggers without repeating generated-name collisions', () => {
       const errors = validateSemantics(
         buildIac({
           gateway: {
@@ -147,9 +147,7 @@ describe('validateSemantics', () => {
         }) as ServerlessIacRaw,
       );
 
-      const keywords = errors.map((error) => error.keyword);
-      expect(keywords).toContain('duplicateTrigger');
-      expect(keywords).toContain('duplicateGeneratedApiName');
+      expect(errors.map((error) => error.keyword)).toEqual(['duplicateTrigger']);
     });
 
     it('scopes volcengine route checks to single events', () => {

--- a/tests/unit/validator/semanticValidation.test.ts
+++ b/tests/unit/validator/semanticValidation.test.ts
@@ -1,0 +1,217 @@
+import { validateSemantics } from '../../../src/validator/semanticValidation';
+import { validateYaml } from '../../../src/validator/iacSchema';
+import { ServerlessIacRaw } from '../../../src/types';
+import { ProviderEnum } from '../../../src/common';
+
+jest.mock('../../../src/lang', () => ({
+  lang: { __: (key: string) => key },
+}));
+
+describe('validateSemantics', () => {
+  const baseEvent = {
+    type: 'API_GATEWAY',
+    name: 'test-gateway',
+    triggers: [] as Array<Record<string, unknown>>,
+  };
+
+  const buildIac = (
+    events: Record<string, unknown>,
+    functions: Record<string, unknown> = {},
+  ): ServerlessIacRaw =>
+    ({
+      version: '0.0.1',
+      app: 'test-app',
+      service: 'test-service',
+      provider: { name: ProviderEnum.ALIYUN, region: 'cn-hangzhou' },
+      events,
+      functions,
+    }) as unknown as ServerlessIacRaw;
+
+  describe('trigger duplication', () => {
+    it('reports repeated method+path pairs inside one event', () => {
+      const errors = validateSemantics(
+        buildIac({
+          gateway: {
+            ...baseEvent,
+            triggers: [
+              { method: 'GET', path: '/api', backend: '${functions.fn}' },
+              { method: 'get', path: '/api', backend: '${functions.fn}' },
+            ],
+          },
+        }) as ServerlessIacRaw,
+      );
+
+      const duplicates = errors.filter((error) => error.keyword === 'duplicateTrigger');
+      expect(duplicates).toHaveLength(1);
+      expect(duplicates[0].instancePath).toBe('/events/gateway/triggers/1');
+    });
+
+    it('accepts the same path under different methods', () => {
+      const errors = validateSemantics(
+        buildIac({
+          gateway: {
+            ...baseEvent,
+            triggers: [
+              { method: 'GET', path: '/api', backend: '${functions.fn}' },
+              { method: 'POST', path: '/api', backend: '${functions.fn}' },
+            ],
+          },
+        }) as ServerlessIacRaw,
+      );
+
+      expect(errors.filter((error) => error.keyword === 'duplicateTrigger')).toHaveLength(0);
+    });
+  });
+
+  describe('backend references', () => {
+    it('flags dangling ${functions.x} references against configured definitions', () => {
+      const errors = validateSemantics(
+        buildIac({
+          gateway: {
+            ...baseEvent,
+            triggers: [{ method: 'GET', path: '/api', backend: '${functions.missing_fn}' }],
+          },
+        }) as ServerlessIacRaw,
+      );
+
+      const unresolved = errors.filter((error) => error.keyword === 'unresolvedBackendFunction');
+      expect(unresolved).toHaveLength(1);
+      expect(unresolved[0].instancePath).toBe('/events/gateway/triggers/0');
+    });
+
+    it('resolves backends that match a declared function definition key', () => {
+      const errors = validateSemantics(
+        buildIac(
+          {
+            gateway: {
+              ...baseEvent,
+              triggers: [{ method: 'GET', path: '/api', backend: '${functions.known_fn}' }],
+            },
+          },
+          { known_fn: { name: 'known-function' } },
+        ) as ServerlessIacRaw,
+      );
+
+      expect(errors.filter((error) => error.keyword === 'unresolvedBackendFunction')).toHaveLength(
+        0,
+      );
+    });
+
+    it('ignores non-template backend values', () => {
+      const errors = validateSemantics(
+        buildIac({
+          gateway: {
+            ...baseEvent,
+            triggers: [{ method: 'GET', path: '/api', backend: 'plain-name-fn' }],
+          },
+        }) as ServerlessIacRaw,
+      );
+
+      expect(errors).toHaveLength(0);
+    });
+  });
+
+  describe('generated gateway names', () => {
+    it('does not report collisions for the issue #221 long-name trigger set', () => {
+      const errors = validateSemantics(
+        buildIac({
+          gateway: {
+            ...baseEvent,
+            name: 'console-serverlessinsight-api-gateway',
+            triggers: [
+              { method: 'GET', path: '/healthz', backend: 'fn' },
+              { method: 'ANY', path: '/api/*', backend: 'fn' },
+              { method: 'ANY', path: '/*', backend: 'fn' },
+            ],
+          },
+        }) as ServerlessIacRaw,
+      );
+
+      expect(
+        errors.filter((error) =>
+          ['duplicateGeneratedApiName', 'duplicateRouteName'].includes(error.keyword),
+        ),
+      ).toHaveLength(0);
+    });
+
+    it('surfaces generated-name duplicates together with trigger duplicates', () => {
+      const errors = validateSemantics(
+        buildIac({
+          gateway: {
+            ...baseEvent,
+            triggers: [
+              { method: 'GET', path: '/dup', backend: 'fn' },
+              { method: 'GET', path: '/dup', backend: 'fn' },
+            ],
+          },
+        }) as ServerlessIacRaw,
+      );
+
+      const keywords = errors.map((error) => error.keyword);
+      expect(keywords).toContain('duplicateTrigger');
+      expect(keywords).toContain('duplicateGeneratedApiName');
+    });
+
+    it('scopes volcengine route checks to single events', () => {
+      const volcEvents = {
+        first_gateway: {
+          ...baseEvent,
+          triggers: [{ method: 'GET', path: '/shared', backend: 'fn' }],
+        },
+        second_gateway: {
+          ...baseEvent,
+          triggers: [{ method: 'GET', path: '/shared', backend: 'fn' }],
+        },
+      };
+      const volcIac = {
+        ...buildIac(volcEvents),
+        provider: { name: ProviderEnum.VOLCENGINE, region: 'cn-beijing' },
+      } as ServerlessIacRaw;
+
+      expect(validateSemantics(volcIac)).toHaveLength(0);
+    });
+  });
+
+  describe('robustness', () => {
+    it('returns no errors when events are absent', () => {
+      expect(validateSemantics(buildIac({}) as ServerlessIacRaw)).toHaveLength(0);
+    });
+  });
+});
+
+describe('validateYaml semantic integration', () => {
+  it('throws IacSchemaErrors aggregating schema and semantic failures', () => {
+    const invalidConfig = {
+      version: '0.0.1',
+      app: 'test-app',
+      service: 'test-service',
+      provider: { name: 'aliyun', region: 'cn-hangzhou' },
+      functions: {},
+      events: {
+        gateway: {
+          type: 'API_GATEWAY',
+          name: 'gw',
+          triggers: [
+            { method: 'GET', path: '/hello', backend: '${functions.absent}' },
+            { method: 'POST', path: 'missing-leading-slash', backend: 'fn' },
+          ],
+        },
+      },
+    } as unknown as ServerlessIacRaw;
+
+    let thrownError: unknown;
+    try {
+      validateYaml(invalidConfig);
+    } catch (error) {
+      thrownError = error;
+    }
+
+    expect(thrownError).toBeInstanceOf(Error);
+    const errorMessage = (thrownError as Error).message;
+    expect(errorMessage).toContain('Invalid yaml');
+    const serializedKeywords = JSON.stringify(
+      (thrownError as { errors?: Array<{ keyword?: string }> }).errors ?? [],
+    );
+    expect(serializedKeywords).toContain('unresolvedBackendFunction');
+  });
+});

--- a/tests/unit/validator/validate.test.ts
+++ b/tests/unit/validator/validate.test.ts
@@ -162,6 +162,7 @@ describe('unit test for validate', () => {
     const invalidYaml = {
       ...jsonIac,
       functions: {
+        insight_poc_fn: jsonIac.functions.insight_poc_fn,
         test_fn: {
           name: 'test-fn',
           code: {
@@ -189,6 +190,7 @@ describe('unit test for validate', () => {
     const validYaml = {
       ...jsonIac,
       functions: {
+        insight_poc_fn: jsonIac.functions.insight_poc_fn,
         test_fn: {
           name: 'test-fn',
           code: {
@@ -216,6 +218,7 @@ describe('unit test for validate', () => {
     const validYaml = {
       ...jsonIac,
       functions: {
+        insight_poc_fn: jsonIac.functions.insight_poc_fn,
         test_fn: {
           name: 'test-fn',
           code: {
@@ -272,6 +275,7 @@ describe('unit test for validate', () => {
       const yamlWithTemplateRef = {
         ...jsonIac,
         functions: {
+          insight_poc_fn: jsonIac.functions.insight_poc_fn,
           test_fn: {
             name: 'test-fn',
             code: {
@@ -291,6 +295,7 @@ describe('unit test for validate', () => {
       const yamlWithTemplateRef = {
         ...jsonIac,
         functions: {
+          insight_poc_fn: jsonIac.functions.insight_poc_fn,
           test_fn: {
             name: 'test-fn',
             code: {
@@ -310,6 +315,7 @@ describe('unit test for validate', () => {
       const yamlWithTemplateRef = {
         ...jsonIac,
         functions: {
+          insight_poc_fn: jsonIac.functions.insight_poc_fn,
           test_fn: {
             name: 'test-fn',
             code: {
@@ -328,6 +334,7 @@ describe('unit test for validate', () => {
       const yamlWithTemplateRef = {
         ...jsonIac,
         functions: {
+          insight_poc_fn: jsonIac.functions.insight_poc_fn,
           test_fn: {
             name: 'test-fn',
             code: {
@@ -346,6 +353,7 @@ describe('unit test for validate', () => {
       const yamlWithTemplateRef = {
         ...jsonIac,
         functions: {
+          insight_poc_fn: jsonIac.functions.insight_poc_fn,
           test_fn: {
             name: 'test-fn',
             code: {
@@ -363,6 +371,7 @@ describe('unit test for validate', () => {
       const yamlWithInvalidRef = {
         ...jsonIac,
         functions: {
+          insight_poc_fn: jsonIac.functions.insight_poc_fn,
           test_fn: {
             name: 'test-fn',
             code: {
@@ -381,6 +390,7 @@ describe('unit test for validate', () => {
       const yamlWithInvalidRef = {
         ...jsonIac,
         functions: {
+          insight_poc_fn: jsonIac.functions.insight_poc_fn,
           test_fn: {
             name: 'test-fn',
             code: {
@@ -401,6 +411,7 @@ describe('unit test for validate', () => {
       const validYaml = {
         ...jsonIac,
         functions: {
+          insight_poc_fn: jsonIac.functions.insight_poc_fn,
           test_fn: {
             name: 'test-fn',
             code: {
@@ -422,6 +433,7 @@ describe('unit test for validate', () => {
           region: 'cn-hangzhou',
         },
         functions: {
+          insight_poc_fn: jsonIac.functions.insight_poc_fn,
           test_fn: {
             name: 'test-fn',
             code: {
@@ -446,6 +458,7 @@ describe('unit test for validate', () => {
           region: 'ap-guangzhou',
         },
         functions: {
+          insight_poc_fn: jsonIac.functions.insight_poc_fn,
           test_fn: {
             name: 'test-fn',
             code: {
@@ -470,6 +483,7 @@ describe('unit test for validate', () => {
           region: 'us-east-1',
         },
         functions: {
+          insight_poc_fn: jsonIac.functions.insight_poc_fn,
           test_fn: {
             name: 'test-fn',
             code: {
@@ -490,6 +504,7 @@ describe('unit test for validate', () => {
       const validYaml = {
         ...jsonIac,
         functions: {
+          insight_poc_fn: jsonIac.functions.insight_poc_fn,
           test_fn: {
             name: 'test-fn',
             code: {
@@ -511,6 +526,7 @@ describe('unit test for validate', () => {
           region: 'cn-hangzhou',
         },
         functions: {
+          insight_poc_fn: jsonIac.functions.insight_poc_fn,
           test_fn1: {
             name: 'test-fn1',
             code: {
@@ -543,6 +559,7 @@ describe('unit test for validate', () => {
           region: 'cn-hangzhou',
         },
         functions: {
+          insight_poc_fn: jsonIac.functions.insight_poc_fn,
           test_fn: {
             name: 'test-fn',
             code: {
@@ -564,6 +581,11 @@ describe('unit test for validate', () => {
           region: 'cn-hangzhou',
         },
         functions: {
+          // insight_poc_fn carried over for resolvable backend refs; runtime kept AWS/Tencent-compatible.
+          insight_poc_fn: {
+            ...jsonIac.functions.insight_poc_fn,
+            code: { ...jsonIac.functions.insight_poc_fn.code, runtime: '${vars.function_runtime}' },
+          },
           test_fn: {
             name: 'test-fn',
             code: {
@@ -573,7 +595,7 @@ describe('unit test for validate', () => {
             },
           },
         },
-      };
+      } as unknown as ServerlessIacRaw;
       expect(validateYaml(aliyunYaml)).toBe(true);
 
       const tencentYaml = {
@@ -794,6 +816,7 @@ describe('unit test for validate', () => {
         const validYaml = {
           ...jsonIac,
           functions: {
+            insight_poc_fn: jsonIac.functions.insight_poc_fn,
             test_fn: {
               name: 'test-fn',
               code: {
@@ -814,6 +837,7 @@ describe('unit test for validate', () => {
         const validYaml = {
           ...jsonIac,
           functions: {
+            insight_poc_fn: jsonIac.functions.insight_poc_fn,
             test_fn: {
               name: 'test-fn',
               code: {
@@ -836,6 +860,7 @@ describe('unit test for validate', () => {
         const validYaml = {
           ...jsonIac,
           functions: {
+            insight_poc_fn: jsonIac.functions.insight_poc_fn,
             test_fn: {
               name: 'test-fn',
               code: {
@@ -858,6 +883,7 @@ describe('unit test for validate', () => {
         const validYaml = {
           ...jsonIac,
           functions: {
+            insight_poc_fn: jsonIac.functions.insight_poc_fn,
             test_fn: {
               name: 'test-fn',
               code: {
@@ -886,6 +912,7 @@ describe('unit test for validate', () => {
         const validYaml = {
           ...jsonIac,
           functions: {
+            insight_poc_fn: jsonIac.functions.insight_poc_fn,
             test_fn: {
               name: 'test-fn',
               code: {
@@ -922,6 +949,7 @@ describe('unit test for validate', () => {
         const validYaml = {
           ...jsonIac,
           functions: {
+            insight_poc_fn: jsonIac.functions.insight_poc_fn,
             test_fn: {
               name: 'test-fn',
               code: {
@@ -939,6 +967,7 @@ describe('unit test for validate', () => {
         const invalidYaml = {
           ...jsonIac,
           functions: {
+            insight_poc_fn: jsonIac.functions.insight_poc_fn,
             test_fn: {
               name: 'test-fn',
               code: {
@@ -965,6 +994,7 @@ describe('unit test for validate', () => {
         const invalidYaml = {
           ...jsonIac,
           functions: {
+            insight_poc_fn: jsonIac.functions.insight_poc_fn,
             test_fn: {
               name: 'test-fn',
               code: {
@@ -990,6 +1020,7 @@ describe('unit test for validate', () => {
         const invalidYaml = {
           ...jsonIac,
           functions: {
+            insight_poc_fn: jsonIac.functions.insight_poc_fn,
             test_fn: {
               name: 'test-fn',
               code: {
@@ -1029,6 +1060,122 @@ describe('unit test for validate', () => {
         },
       } as unknown as ServerlessIacRaw;
       expect(() => validateYaml(invalidYaml)).toThrow('Invalid yaml');
+    });
+  });
+
+  describe('identifier constraints (issue #222)', () => {
+    const overrideTrigger = (trigger: Record<string, unknown>) =>
+      ({
+        ...jsonIac,
+        events: {
+          gateway_event: {
+            ...jsonIac.events.gateway_event,
+            triggers: [trigger],
+          },
+        },
+      }) as unknown as ServerlessIacRaw;
+
+    it('accepts trigger paths starting with a slash including wildcards', () => {
+      expect(validateYaml(overrideTrigger({ method: 'ANY', path: '/api/*', backend: 'fn' }))).toBe(
+        true,
+      );
+    });
+
+    it('rejects trigger paths without a leading slash', () => {
+      expect(() =>
+        validateYaml(overrideTrigger({ method: 'GET', path: 'api/hello', backend: 'fn' })),
+      ).toThrow('Invalid yaml');
+    });
+
+    it('accepts whole template references in constrained string fields', () => {
+      expect(
+        validateYaml(overrideTrigger({ method: 'GET', path: '${vars.base_path}', backend: 'fn' })),
+      ).toBe(true);
+    });
+
+    it('rejects invalid hostnames in event domain', () => {
+      const invalidYaml = {
+        ...jsonIac,
+        events: {
+          gateway_event: {
+            ...jsonIac.events.gateway_event,
+            triggers: [{ method: 'GET', path: '/api/hello', backend: 'fn' }],
+            domain: { domain_name: '-bad-host-.example.com' },
+          },
+        },
+      } as unknown as ServerlessIacRaw;
+      expect(() => validateYaml(invalidYaml)).toThrow(/must match the pattern|Invalid yaml/);
+    });
+
+    it('enforces provider-specific function name lengths via if/then (aliyun 64)', () => {
+      const overLong = 'a'.repeat(65);
+      const config = {
+        ...jsonIac,
+        provider: { name: 'aliyun', region: 'cn-hangzhou' },
+        functions: {
+          insight_poc_fn: { ...jsonIac.functions.insight_poc_fn, name: overLong },
+        },
+        events: {},
+      } as unknown as ServerlessIacRaw;
+
+      let thrownError: unknown;
+      try {
+        validateYaml(config);
+      } catch (error) {
+        thrownError = error;
+      }
+      expect((thrownError as Error).message).toContain('must NOT have more than 64 characters');
+    });
+
+    it('does not enforce function name limits for providers without a defined limit', () => {
+      const longName = 'a'.repeat(100);
+      const config = {
+        ...jsonIac,
+        provider: { name: 'aws', region: 'us-east-1' },
+        functions: {
+          insight_poc_fn: {
+            ...jsonIac.functions.insight_poc_fn,
+            name: longName,
+            code: { ...jsonIac.functions.insight_poc_fn.code, runtime: '${vars.function_runtime}' },
+          },
+        },
+        events: {},
+      } as unknown as ServerlessIacRaw;
+      expect(validateYaml(config)).toBe(true);
+    });
+
+    it('accumulates multiple constraint violations into one error set', () => {
+      const config = {
+        ...jsonIac,
+        events: {
+          gateway_event: {
+            ...jsonIac.events.gateway_event,
+            triggers: [
+              { method: 'GET', path: 'no-leading-slash', backend: 'fn' },
+              {
+                method: 'GET',
+                path: '/dup',
+                backend: 'fn',
+              },
+              { method: 'GET', path: '/dup', backend: 'fn' },
+            ],
+          },
+        },
+      } as unknown as ServerlessIacRaw;
+
+      let thrownError: unknown;
+      try {
+        validateYaml(config);
+      } catch (error) {
+        thrownError = error;
+      }
+
+      const keywords = JSON.stringify(
+        (thrownError as { errors?: Array<{ keyword?: string }> }).errors ?? [],
+      );
+      expect(keywords).toContain('pattern');
+      expect(keywords).toContain('duplicateTrigger');
+      expect(keywords).toContain('duplicateGeneratedApiName');
     });
   });
 });

--- a/tests/unit/validator/validate.test.ts
+++ b/tests/unit/validator/validate.test.ts
@@ -1107,6 +1107,39 @@ describe('unit test for validate', () => {
       expect(() => validateYaml(invalidYaml)).toThrow(/must match the pattern|Invalid yaml/);
     });
 
+    it('accepts dotted bucket names within the provider length limit', () => {
+      const config = {
+        ...jsonIac,
+        buckets: { my_bucket: { name: 'my.bucket.name' } },
+      } as unknown as ServerlessIacRaw;
+      expect(validateYaml(config)).toBe(true);
+    });
+
+    it('accepts whole template references as bucket names (resolved post-validation)', () => {
+      const config = {
+        ...jsonIac,
+        buckets: { my_bucket: { name: '${vars.bucket_name}' } },
+      } as unknown as ServerlessIacRaw;
+      expect(validateYaml(config)).toBe(true);
+    });
+
+    it('rejects dotted bucket names exceeding 63 chars', () => {
+      const overLong = `${'a'.repeat(55)}.example.com`;
+      const config = {
+        ...jsonIac,
+        buckets: { my_bucket: { name: overLong } },
+      } as unknown as ServerlessIacRaw;
+      expect(() => validateYaml(config)).toThrow('Invalid yaml');
+    });
+
+    it('rejects hyphen-terminated labels in dotted bucket names', () => {
+      const config = {
+        ...jsonIac,
+        buckets: { my_bucket: { name: 'foo-.example.com' } },
+      } as unknown as ServerlessIacRaw;
+      expect(() => validateYaml(config)).toThrow('Invalid yaml');
+    });
+
     it('enforces provider-specific function name lengths via if/then (aliyun 64)', () => {
       const overLong = 'a'.repeat(65);
       const config = {
@@ -1158,6 +1191,7 @@ describe('unit test for validate', () => {
                 backend: 'fn',
               },
               { method: 'GET', path: '/dup', backend: 'fn' },
+              { method: 'GET', path: '/dup/', backend: 'fn' },
             ],
           },
         },


### PR DESCRIPTION
## Summary

Closes the root cause of #221 and implements the unified solution decided in #222: deterministic constrained name generation across providers, plus a hardened pre-deploy validation layer so provider-limit violations surface at `si validate`/`si plan` time instead of as raw cloud API errors mid-deploy.

### Constrained name generation (fixes #221)
- New `src/common/nameBuilder.ts`: fits → verbatim (legacy names stay byte-identical); over-long → leading segments truncated first, method/path discriminator preserved, FNV-1a base36 hash over the **raw** parts guarantees distinctness even when inputs sanitize identically.
- `src/common/providerNames.ts` = single source of truth for `generateApiKey` / `buildAliyunApigwApiName` / `buildVolcengineRouteName`; both stacks delegate.
- The exact #221 collision set (`GET /healthz` / `ANY /api/*` / `ANY /*` with a 37-char event name) now yields three unique names ≤ 50 chars — regression-tested on both providers.

### Per-event Aliyun gateway groups
Group names now include the event key (`<service>-<stage>-<eventKey>-agw-group`, constrained to the verified 4–50 GroupName limit), so multiple `API_GATEWAY` events own distinct groups instead of fighting over one ownership tag. Adoption/destroy semantics stay single-owner; the semantic pass' apiName scope moved to event-local to match.

### Pre-deploy validation hardening
- New post-schema semantic pass beside `validateRuntimeCompatibility`, accumulating through `IacSchemaErrors`: duplicate `method+path` triggers per event, duplicate generated api/route names, dangling `${functions.x}` backends.
- Provider-conditional function-name limits via JSON Schema `if/then` (Aliyun ≤ 64, Tencent ≤ 60); trigger-path `^/…`, bucket-name and hostname patterns; whole template refs bypass literal rules by design.
- **Latent bug fixed:** `events.*.triggers` subschema was missing its `type:'object'` envelope — Ajv silently treated every trigger as always-valid, so trigger constraints were never enforced before.

### Runtime support
- **Huawei FunctionGraph** now first-class: verified official runtimes (Node.js 10–20, Python 3.6/3.9/3.10/3.12, Java 8/11/17/21, Go 1.x, .NET Core 3.1; stage-3-deprecated ids excluded).
- **Volcengine**: `python3.8/v1` removed (retired per product notice); `native-python3.12/v1`, `native-node20/v1` added from Volcengine-maintained tooling.

### Samples-as-canaries
`tests/unit/samples.test.ts` validates every `samples/*.yml` through full schema + semantic validation — it immediately surfaced stale volcengine runtimes, object-form security-group rules, a broken YAML alias and an array-valued env var in the GPU sample.

### Review hardening (post-review fixes)
- `BUCKET_NAME_PATTERN`: the dotted branch now enforces the same 3–63 total length as the single-label branch (shared length lookahead) and rejects hyphen-terminated labels (`foo-.example.com`). Whole `${vars.x}` references still bypass literal rules by design — bucket names via template refs are accepted and now covered by a dedicated test.
- Duplicate `method+path` triggers report once (`duplicateTrigger` only) instead of also emitting a redundant generated-name collision error for the identical name; generated-name lookups unified on `!== undefined` emptiness checks.
- Tests added/updated: dotted-length cap, hyphen-label rejection, template-ref bucket acceptance, single-report duplicate semantics.

## ⚠️ Breaking changes (documented in CHANGELOG)
- Regenerated names: affected deployments orphan old cloud APIs/routes/groups on the next plan (same migration story throughout — delete superseded gateway resources manually after upgrading).
- Aliyun groups are per-event (old shared group orphaned).
- Volcengine `python3.8/v1` no longer passes validation.

## Verification
- `npm run lint:check` ✓ · `npm run build` ✓
- Full suite: **155 suites / 3216 tests green** at the unchanged 85% coverage gate
- Sample audit vs `master` baseline: 7 pre-existing failures → 0

Refs #222, Fixes #221

