### PR TITLE
fix(state): keep stages as the only persisted resource store (#225)

### DIFF
--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -1,7 +1,15 @@
 import * as readline from 'node:readline';
 import crypto from 'node:crypto';
 import { deployStack } from '../stack';
-import { getContext, getIacLocation, logger, setContext, setIac, ProviderEnum } from '../common';
+import {
+  getContext,
+  getIacLocation,
+  logger,
+  setContext,
+  setIac,
+  ProviderEnum,
+  toPersistedState,
+} from '../common';
 import { createStateBackend } from '../common/stateBackend';
 import { parseYaml, revalYaml } from '../parser';
 import { generateTencentPlan, displayPlan } from '../stack/scfStack';
@@ -156,7 +164,7 @@ export const deploy = async (options: {
               iac.service,
               options.stage ?? 'dev',
             );
-            failure.stateJson = partialState ?? {};
+            failure.stateJson = partialState ? toPersistedState(partialState) : {};
           } catch {
             // state may be unreadable mid-failure — plan alone is still useful
           }
@@ -171,13 +179,11 @@ export const deploy = async (options: {
           iac.service,
           options.stage ?? 'dev',
         );
+        const stateJson = finalState ? toPersistedState(finalState) : {};
         return {
           plan: { items: planResult.items },
-          stateJson: finalState ?? {},
-          contentHash: crypto
-            .createHash('sha256')
-            .update(JSON.stringify(finalState ?? {}))
-            .digest('hex'),
+          stateJson,
+          contentHash: crypto.createHash('sha256').update(JSON.stringify(stateJson)).digest('hex'),
           resourceCount: Object.keys(finalState?.resources ?? {}).length,
         };
       },

--- a/src/common/stateBackend/remoteStateBackend.ts
+++ b/src/common/stateBackend/remoteStateBackend.ts
@@ -1,6 +1,12 @@
 import os from 'node:os';
-import { StateFile, LockOptions, LockMetadata, CURRENT_STATE_VERSION } from '../../types';
-import { migrateState } from '../stateManager';
+import {
+  StateFile,
+  PersistedStateFile,
+  LockOptions,
+  LockMetadata,
+  CURRENT_STATE_VERSION,
+} from '../../types';
+import { migrateState, toPersistedState } from '../stateManager';
 import { DEFAULT_LOCK_TIMEOUT, DEFAULT_LOCK_RETRY_DELAY } from '../constants';
 import { LockError, formatLockInfo } from '../lockManager';
 import { logger } from '../logger';
@@ -124,21 +130,20 @@ export const createRemoteStateBackend = (
       service: string,
       stage: string,
     ): Promise<void> => {
-      let existing: StateFile = {
+      let existing: PersistedStateFile = {
         version: CURRENT_STATE_VERSION,
         provider: state.provider,
         app,
         service,
         stages: {},
-        resources: {},
       };
       try {
         const raw = await adapter.read<StateFile>(config.key);
-        if (raw) existing = raw;
+        if (raw) existing = toPersistedState(raw);
       } catch {
         // noop
       }
-      const stateToSave: StateFile = {
+      const stateToSave: PersistedStateFile = {
         ...existing,
         version: CURRENT_STATE_VERSION,
         app,
@@ -151,7 +156,6 @@ export const createRemoteStateBackend = (
             shared: state.stages?.[stage]?.shared ?? existing.stages?.[stage]?.shared ?? {},
           },
         },
-        resources: state.resources,
       };
       await adapter.write(config.key, stateToSave);
     },

--- a/src/common/stateBackend/saasStateBackend.ts
+++ b/src/common/stateBackend/saasStateBackend.ts
@@ -3,7 +3,7 @@ import type { ApiClient } from '../apiClient';
 import { loadCredentials, getConsoleUrl } from '../credentialStore';
 import { StateBackend } from './types';
 import { StateFile, LockMetadata, LockOptions, CURRENT_STATE_VERSION } from '../../types';
-import { migrateState } from '../stateManager';
+import { migrateState, toPersistedState } from '../stateManager';
 import { EventQueue, DeploymentEventRecord } from '../eventQueue';
 import { lang } from '../../lang';
 import crypto from 'node:crypto';
@@ -129,9 +129,20 @@ export const createSaasStateBackend = (context: SaasBackendContext): StateBacken
         const state = await client.get<{ stateJson: StateFile }>(
           `/api/v1/apps/${resolvedAppId}/services/${resolvedServiceId}/state/current?stage=${encodeURIComponent(stage)}`,
         );
+        const migrated = migrateState(state.stateJson);
+        // Legacy Console states hold fresh resources only in the top-level
+        // field (pre-stage-syncing saves) — prefer the stage store, fall back.
+        const stageResources = migrated.stages?.[stage]?.resources;
+        const resources =
+          stageResources && Object.keys(stageResources).length > 0
+            ? stageResources
+            : migrated.resources && Object.keys(migrated.resources).length > 0
+              ? migrated.resources
+              : {};
         // Attach console metadata so subsequent deploys have the UUIDs
         return {
-          ...migrateState(state.stateJson),
+          ...migrated,
+          resources,
           orgId,
           appId: resolvedAppId!,
           serviceId: resolvedServiceId!,
@@ -156,15 +167,26 @@ export const createSaasStateBackend = (context: SaasBackendContext): StateBacken
       // If not provisioned yet, use the state's provider for provisioning
       await ensureProvisioned(state.provider, stage);
 
-      // The backend persists the full state file under state_json — send the whole
-      // StateFile (not just resources) so loadState round-trips it unchanged.
+      // Sync the runtime projection into the stage store before stripping, so
+      // stages[stage].resources carries the fresh working set (mirrors the fs
+      // and remote backends' save contract)
+      const stateJson = toPersistedState({
+        ...state,
+        stages: {
+          ...state.stages,
+          [stage]: {
+            ...state.stages?.[stage],
+            resources: state.resources,
+          },
+        },
+      });
       const body = {
         appName: app,
         serviceName: service,
         provider: state.provider,
         stage,
-        stateJson: state,
-        contentHash: crypto.createHash('sha256').update(JSON.stringify(state)).digest('hex'),
+        stateJson,
+        contentHash: crypto.createHash('sha256').update(JSON.stringify(stateJson)).digest('hex'),
         resourceCount: Object.keys(state.resources).length,
       };
       await client.post(

--- a/src/common/stateManager.ts
+++ b/src/common/stateManager.ts
@@ -4,6 +4,7 @@ import crypto from 'node:crypto';
 import {
   ResourceState,
   StateFile,
+  PersistedStateFile,
   StateCorruptError,
   StateVersionError,
   CURRENT_STATE_VERSION,
@@ -110,6 +111,12 @@ export const migrateState = (raw: StateFile): StateFile => {
   return migrated as unknown as StateFile;
 };
 
+/** Strip the runtime-only `resources` projection — `stages` is the authoritative store (issue #225). */
+export const toPersistedState = (state: StateFile): PersistedStateFile => {
+  const { resources: _projection, ...persisted } = state;
+  return persisted;
+};
+
 /**
  * Load state file, scoped to the given stage.
  * The returned StateFile has `resources` populated from `stages[stage].resources`.
@@ -179,25 +186,24 @@ export const saveState = (
   const backupPath = `${statePath}.backup`;
 
   // Read the existing file to preserve other stages
-  let existing: StateFile = {
+  let existing: PersistedStateFile = {
     version: CURRENT_STATE_VERSION,
     provider: state.provider,
     app,
     service,
     stages: {},
-    resources: {},
   };
   try {
     if (fs.existsSync(statePath)) {
       const content = fs.readFileSync(statePath, 'utf-8');
-      existing = JSON.parse(content) as StateFile;
+      existing = toPersistedState(JSON.parse(content) as StateFile);
     }
   } catch {
     // use default
   }
 
   // Write updated stage resources, preserve all other stages
-  const stateToSave: StateFile = {
+  const stateToSave: PersistedStateFile = {
     ...existing,
     version: CURRENT_STATE_VERSION,
     lineage: existing.lineage || crypto.randomUUID(),
@@ -212,7 +218,6 @@ export const saveState = (
         shared: state.stages?.[stage]?.shared ?? existing.stages?.[stage]?.shared ?? {},
       },
     },
-    resources: state.resources,
   };
 
   // Atomic write: back up the previous state, then write tmp + fsync + rename

--- a/src/types/domains/state.ts
+++ b/src/types/domains/state.ts
@@ -84,6 +84,14 @@ export type StateFile = {
   resources: Record<string, ResourceState>;
 };
 
+/**
+ * Persisted shape of a state file (disk / remote storage / API payloads).
+ * `StateFile.resources` is a runtime-only projection of `stages[stage].resources`
+ * (hydrated by loadState) and is never serialized — `stages` is the single
+ * authoritative store. See issue #225.
+ */
+export type PersistedStateFile = Omit<StateFile, 'resources'>;
+
 export type PlanAction = 'create' | 'update' | 'delete' | 'noop' | 'refresh';
 
 export type PlanItem = {

--- a/tests/unit/common/stateBackend/remoteStateBackend.test.ts
+++ b/tests/unit/common/stateBackend/remoteStateBackend.test.ts
@@ -159,6 +159,7 @@ describe('remoteStateBackend', () => {
       expect(mockAdapter.write).toHaveBeenCalled();
       const savedState = (mockAdapter.write as jest.Mock).mock.calls[0][1] as StateFile;
       expect(savedState.stages.dev.resources).toEqual({ func1: resource });
+      expect(savedState.resources).toBeUndefined();
     });
 
     it('should merge with existing stages', async () => {

--- a/tests/unit/common/stateBackend/saasStateBackend.test.ts
+++ b/tests/unit/common/stateBackend/saasStateBackend.test.ts
@@ -99,6 +99,91 @@ describe('saasStateBackend', () => {
       );
     });
 
+    it('should hydrate the resources projection from stages[stage]', async () => {
+      mockApiClient.post.mockResolvedValueOnce({
+        id: 'deploy-1',
+        appId: 'app-1',
+        serviceId: 'svc-1',
+        status: 'active',
+        isNewApp: false,
+        isNewService: false,
+      });
+      mockApiClient.get.mockResolvedValueOnce({
+        stateJson: {
+          version: '3.0',
+          provider: 'aliyun',
+          app: 'myapp',
+          service: 'myservice',
+          stages: {
+            dev: {
+              resources: {
+                func1: {
+                  mode: 'managed',
+                  region: 'cn-hk',
+                  definition: {},
+                  instances: [],
+                  lastUpdated: '',
+                },
+              },
+            },
+          },
+        },
+      });
+
+      const result = await backend.loadState('aliyun', 'myapp', 'myservice', 'dev');
+
+      expect(result.resources).toEqual({
+        func1: {
+          mode: 'managed',
+          region: 'cn-hk',
+          definition: {},
+          instances: [],
+          lastUpdated: '',
+        },
+      });
+    });
+
+    it('should fall back to the legacy top-level resources when stages is empty', async () => {
+      mockApiClient.post.mockResolvedValueOnce({
+        id: 'deploy-1',
+        appId: 'app-1',
+        serviceId: 'svc-1',
+        status: 'active',
+        isNewApp: false,
+        isNewService: false,
+      });
+      mockApiClient.get.mockResolvedValueOnce({
+        stateJson: {
+          version: '3.0',
+          provider: 'aliyun',
+          app: 'myapp',
+          service: 'myservice',
+          stages: {},
+          resources: {
+            func1: {
+              mode: 'managed',
+              region: 'cn-hk',
+              definition: {},
+              instances: [],
+              lastUpdated: '',
+            },
+          },
+        },
+      });
+
+      const result = await backend.loadState('aliyun', 'myapp', 'myservice', 'dev');
+
+      expect(result.resources).toEqual({
+        func1: {
+          mode: 'managed',
+          region: 'cn-hk',
+          definition: {},
+          instances: [],
+          lastUpdated: '',
+        },
+      });
+    });
+
     it('should return default state when Console state fetch fails', async () => {
       mockApiClient.post.mockResolvedValueOnce({
         id: 'deploy-1',
@@ -188,6 +273,14 @@ describe('saasStateBackend', () => {
           resourceCount: 1,
         }),
       );
+
+      const syncPayload = mockApiClient.post.mock.calls.find(
+        (call) => call[0] === '/api/v1/apps/app-1/services/svc-1/state/sync',
+      )?.[1] as { stateJson: Record<string, unknown> };
+      expect(syncPayload.stateJson.resources).toBeUndefined();
+      expect(syncPayload.stateJson.stages).toEqual({
+        dev: { resources: state.resources },
+      });
     });
   });
 

--- a/tests/unit/common/stateManager.test.ts
+++ b/tests/unit/common/stateManager.test.ts
@@ -453,6 +453,61 @@ describe('StateManager', () => {
       expect(getResource(state2, 'functions.test')).toEqual(resourceState);
     });
 
+    describe('persisted shape (issue #225)', () => {
+      const makeResourceState = (name: string): ResourceState => ({
+        mode: 'managed',
+        region: 'ap-guangzhou',
+        definition: { functionName: name },
+        instances: [{ sid: `si:tencent:scf:default:${name}`, id: name }],
+        lastUpdated: '2025-01-01T00:00:00Z',
+      });
+
+      it('saveState does not persist the top-level resources projection', () => {
+        let state = loadState('tencent', 'test-app', 'test-service', 'default', testDir);
+        state = setResource(state, 'functions.test', makeResourceState('test-fn'));
+        saveState(state, 'test-app', 'test-service', 'default', testDir);
+
+        const onDisk = JSON.parse(fs.readFileSync(statePath, 'utf-8'));
+        expect(onDisk.resources).toBeUndefined();
+        expect(onDisk.stages.default.resources['functions.test']).toEqual(
+          makeResourceState('test-fn'),
+        );
+      });
+
+      it('saveState drops a stale top-level resources field left by an older CLI', () => {
+        const legacyOnDisk = {
+          version: CURRENT_STATE_VERSION,
+          provider: 'tencent',
+          app: 'test-app',
+          service: 'test-service',
+          stages: {
+            default: { resources: { 'functions.current': makeResourceState('current-fn') } },
+          },
+          resources: { 'functions.stale': makeResourceState('stale-fn') },
+        };
+        ensureStateDir(testDir);
+        fs.writeFileSync(statePath, JSON.stringify(legacyOnDisk, null, 2));
+
+        const state = loadState('tencent', 'test-app', 'test-service', 'default', testDir);
+        saveState(state, 'test-app', 'test-service', 'default', testDir);
+
+        const onDisk = JSON.parse(fs.readFileSync(statePath, 'utf-8'));
+        expect(onDisk.resources).toBeUndefined();
+        expect(onDisk.stages.default.resources['functions.current']).toEqual(
+          makeResourceState('current-fn'),
+        );
+      });
+
+      it('round-trips resources through stages for the same stage', () => {
+        let state = loadState('tencent', 'test-app', 'test-service', 'default', testDir);
+        state = setResource(state, 'functions.test', makeResourceState('round-trip-fn'));
+        saveState(state, 'test-app', 'test-service', 'default', testDir);
+
+        const reloaded = loadState('tencent', 'test-app', 'test-service', 'default', testDir);
+        expect(getResource(reloaded, 'functions.test')).toEqual(makeResourceState('round-trip-fn'));
+      });
+    });
+
     describe('atomic persistence (B1)', () => {
       const makeResourceState = (name: string): ResourceState => ({
         mode: 'managed',
@@ -474,7 +529,10 @@ describe('StateManager', () => {
           expect(fs.existsSync(`${statePath}.tmp`)).toBe(false);
 
           const onDisk = JSON.parse(fs.readFileSync(statePath, 'utf-8'));
-          expect(onDisk.resources['functions.test']).toEqual(makeResourceState('test-fn'));
+          expect(onDisk.resources).toBeUndefined();
+          expect(onDisk.stages.default.resources['functions.test']).toEqual(
+            makeResourceState('test-fn'),
+          );
         } finally {
           renameSpy.mockRestore();
         }
@@ -490,7 +548,9 @@ describe('StateManager', () => {
 
         expect(fs.existsSync(`${statePath}.backup`)).toBe(true);
         const backup = JSON.parse(fs.readFileSync(`${statePath}.backup`, 'utf-8'));
-        expect(backup.resources['functions.test']).toEqual(makeResourceState('v1-fn'));
+        expect(backup.stages.default.resources['functions.test']).toEqual(
+          makeResourceState('v1-fn'),
+        );
       });
 
       it('saveState leaves original intact if write fails', () => {


### PR DESCRIPTION
## Summary

Fixes #225: `state.json` stored the same resources twice — top-level `resources` and `stages[stage].resources`. The top-level field was a runtime projection that every `loadState` overwrites from `stages`, so persisting it was pure redundancy with a real cost: manual edits to the (visually authoritative) top-level field were silently discarded, causing deploys to replay stale state.

After this change, **`stages[stage].resources` is the only persisted resource store**; the top-level `resources` field becomes a runtime-only projection (hydrated by every backend's `loadState`) and is never serialized.

## Changes

| Commit | Scope |
|---|---|
| `fix(state)` | New `PersistedStateFile = Omit<StateFile, 'resources'>` type + `toPersistedState` helper; local `saveState` writes stages only and strips stale top-level fields inherited from legacy files |
| `fix(state-backend)` | OSS/COS bucket-store saves follow the same contract |
| `fix(saas-state)` | SaaS path: saves now sync the projection into `stages[stage].resources` before stripping (mirrors fs/remote); `loadState` hydrates client-side with a **legacy fallback** to the old top-level field; deploy summary/failure payloads carry the persisted shape; `contentHash` computed over the persisted shape |

## Deployment safety

- **Old CLI reads new state files** → hydrate only trusts `stages` (never trusted the top-level field) → compatible
- **New CLI reads old local/OSS files** → stages was always written atomically alongside the projection since #166 → strict hydrate is safe
- **New CLI reads old Console states** → saas `loadState` falls back to the legacy top-level field when the stage store is empty → no data loss
- **Rollback** → old CLI resumes writing the redundant field; loads ignore it either way
- Crash safety unchanged: both fields were written in the same atomic write, so the projection never carried independent information; incremental saves, `.backup` recovery, and drift detection all operate on `stages`

## Verification

- `npm test`: 155 suites / 3225 tests passing (85% coverage gates met)
- `npm run lint:check` clean, `npm run build` clean
- New regression tests: no-projection-on-disk (local/bucket/saas), legacy stale-field stripping, save→load round-trip, multi-stage isolation, saas stage hydration + legacy fallback

## Coordination

- Console counterpart: wentsen/console-serverlessinsight#28 — `fetchResourcesApi` reads `stateJson.resources` and must switch to `stages[stage].resources` (with legacy fallback) once this lands.

Closes #225
