### PR TITLE
fix(provider): align trigger backend semantics and introduce per-function execution roles (#227)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -171,6 +171,35 @@ import { createRamOperations } from '../../common/aliyunClient/ramOperations';
 - Keep abstractions provider-agnostic
 - Clean separation of concerns between providers
 
+## Resource Naming (Cross-Platform) - MANDATORY
+
+All si-generated cloud resource names MUST come from shared builders — never inline name templates. One name template appearing in more than one place (planner / executor / validator) is a defect: duplicated templates drift.
+
+### Canonical Builders
+
+| Resource | Builder (single source of truth) | Shape |
+|---|---|---|
+| Function execution role | `buildFunctionRoleName` (`src/common/nameBuilder.ts`) | `${app}-${service}-${stage}-${fn.key}-role` — identical on every provider |
+| Role execution policy | `buildRolePolicyName` (`src/common/nameBuilder.ts`) | `${roleName}-policy` |
+| Function log topic/logstore | per-provider shared-log module (`buildFunctionLogTopicName` / `buildFunctionLogstoreName`) | `${service}-${stage}-${fn.key}-fn-logs` |
+| Shared log project/logset | `buildSharedProjectName` / `buildSharedLogsetName` | `${app}-${stage}-sls` / `-tls` / `-cls` |
+| Length-limited names | `buildConstrainedName` with the provider's cloud limit | truncate + hash deterministically |
+
+```typescript
+// GOOD
+const policyName = buildRolePolicyName(roleName);
+
+// AVOID - duplicated template, drifts from the other call sites
+const policyName = `${roleName}-policy`;
+```
+
+### Rules
+
+1. **Per-owner teardown**: a log container owned by a function/event includes that owner's key in its name (issue #214), so removing one owner never deletes a container another owner still uses. Provider-level singletons (e.g. the aliyun gateway log config, instance id `${region}:PROVIDER`) are the exception: service-scoped, with deletion guarded by active-reference checks.
+2. **Stored-first on rename**: when a name derivation changes, executors and planners MUST read the recorded name from state instances first and apply the new derivation only to fresh creates (see `resolveTlsTopicNameFromInstances` in volcengine `apigwResource.ts`). Otherwise existing deployments phantom-drift and orphan containers.
+3. **In-place migration**: reuse branches key on instance type — existing deployments keep their recorded role/container and get trust/policy updated in place; new names apply only to newly created resources. Never recreate a role or container just to change its name.
+4. **SIDs are per-provider**: `si:<provider>:<service>:<stage>:<id>` — intentionally NOT unified cross-provider; a SID's lifecycle is bound to its physical resource.
+
 ## Code Style
 
 ### TypeScript

--- a/src/common/aliyunClient/ramOperations.ts
+++ b/src/common/aliyunClient/ramOperations.ts
@@ -7,6 +7,7 @@ import {
   parseBuiltInStatements,
   buildPolicyDocument,
 } from '../iamStatements';
+import { buildRolePolicyName } from '../nameBuilder';
 import type { IamStatement } from '../iamStatements';
 import { RamRoleInfo } from './types';
 
@@ -89,27 +90,36 @@ const mapToAliyunStatement = (stmt: IamStatement): Record<string, unknown> => {
   return result;
 };
 
-const buildExecutionPolicy = (customStatements?: IamStatement[]): string => {
-  const merged = mergePolicyStatements(
-    FC_EXECUTION_STATEMENTS,
-    customStatements,
-    mapToAliyunStatement,
-  );
+/** @public Exec policy document from a derived baseline; falls back to the static FC_EXECUTION_STATEMENTS when omitted. */
+export const buildFc3ExecutionPolicyDocument = (
+  executionStatements?: IamStatement[],
+  customStatements?: IamStatement[],
+): string => {
+  const nativeBaseline = executionStatements
+    ? executionStatements.map(mapToAliyunStatement)
+    : FC_EXECUTION_STATEMENTS;
+  const merged = mergePolicyStatements(nativeBaseline, customStatements, mapToAliyunStatement);
   return buildPolicyDocument(merged, { version: '1' });
 };
+
+const buildExecutionPolicy = (
+  executionStatements?: IamStatement[],
+  customStatements?: IamStatement[],
+): string => buildFc3ExecutionPolicyDocument(executionStatements, customStatements);
 
 /* istanbul ignore next */ export const createRamOperations = (ramClient: RamSdkClient) => {
   const attachRolePolicyForFc = async (
     roleName: string,
     customStatements?: IamStatement[],
+    executionStatements?: IamStatement[],
   ): Promise<string> => {
-    const policyName = `${roleName}-policy`;
+    const policyName = buildRolePolicyName(roleName);
 
     // Create policy
     try {
       const createPolicyRequest = new ram.CreatePolicyRequest({
         policyName,
-        policyDocument: buildExecutionPolicy(customStatements),
+        policyDocument: buildExecutionPolicy(executionStatements, customStatements),
         description: `FC execution policy for ${roleName}`,
       });
       await ramClient.createPolicy(createPolicyRequest);
@@ -211,6 +221,112 @@ const buildExecutionPolicy = (customStatements?: IamStatement[]): string => {
     }
   };
 
+  const updateExecutionPolicyDocumentFn = async (
+    roleName: string,
+    policyDocument: string,
+  ): Promise<void> => {
+    const policyName = buildRolePolicyName(roleName);
+
+    const ensureAttached = async (): Promise<void> => {
+      try {
+        await ramClient.attachPolicyToRole(
+          new ram.AttachPolicyToRoleRequest({ policyType: 'Custom', policyName, roleName }),
+        );
+      } catch (error: unknown) {
+        if (!(
+          error &&
+          typeof error === 'object' &&
+          'code' in error &&
+          error.code === 'EntityAlreadyExists.Role.Policy'
+        )) {
+          throw error;
+        }
+      }
+    };
+
+    let currentDocument: string | undefined;
+    try {
+      const getPolicyResponse = await ramClient.getPolicy(
+        new ram.GetPolicyRequest({ policyName, policyType: 'Custom' }),
+      );
+      const defaultVersionId = getPolicyResponse.body?.policy?.defaultVersion;
+      if (defaultVersionId) {
+        const versionResponse = await ramClient.getPolicyVersion(
+          new ram.GetPolicyVersionRequest({
+            policyName,
+            policyType: 'Custom',
+            versionId: defaultVersionId,
+          }),
+        );
+        currentDocument = versionResponse.body?.policyVersion?.policyDocument;
+      }
+    } catch (error: unknown) {
+      if (!(
+        error &&
+        typeof error === 'object' &&
+        'code' in error &&
+        error.code === 'EntityNotExist.Policy'
+      )) {
+        throw error;
+      }
+      try {
+        await ramClient.createPolicy(
+          new ram.CreatePolicyRequest({
+            policyName,
+            policyDocument,
+            description: `FC execution policy for ${roleName}`,
+          }),
+        );
+      } catch (error2: unknown) {
+        if (!(
+          error2 &&
+          typeof error2 === 'object' &&
+          'code' in error2 &&
+          error2.code === 'EntityAlreadyExists.Policy'
+        )) {
+          throw error2;
+        }
+      }
+      await ensureAttached();
+      return;
+    }
+
+    if (currentDocument === policyDocument) {
+      return;
+    }
+
+    try {
+      const listResponse = await ramClient.listPolicyVersions(
+        new ram.ListPolicyVersionsRequest({ policyName, policyType: 'Custom' }),
+      );
+      const versions = listResponse.body?.policyVersions?.policyVersion ?? [];
+      const keepBeforeCreate = 4;
+      const toDelete = versions
+        .filter((v) => !v.isDefaultVersion)
+        .sort((a, b) => (a.createDate ?? '').localeCompare(b.createDate ?? ''))
+        .slice(0, Math.max(0, versions.length - keepBeforeCreate));
+      for (const version of toDelete) {
+        if (version.versionId) {
+          await ramClient.deletePolicyVersion(
+            new ram.DeletePolicyVersionRequest({ policyName, versionId: version.versionId }),
+          );
+        }
+      }
+    } catch (error: unknown) {
+      logger.warn(lang.__('RAM_POLICY_VERSION_PRUNE_FAILED', { policyName, error: String(error) }));
+    }
+
+    await ramClient.createPolicyVersion(
+      new ram.CreatePolicyVersionRequest({
+        policyName,
+        policyDocument,
+        setAsDefault: true,
+      }),
+    );
+
+    await ensureAttached();
+  };
+
   return {
     createRole: async (
       roleName: string,
@@ -218,6 +334,7 @@ const buildExecutionPolicy = (customStatements?: IamStatement[]): string => {
       description?: string,
       customStatements?: IamStatement[],
       managedPolicies?: string[],
+      executionStatements?: IamStatement[],
     ): Promise<RamRoleInfo> => {
       const assumeRolePolicy = buildAssumeRolePolicy(trustedServices);
 
@@ -241,7 +358,11 @@ const buildExecutionPolicy = (customStatements?: IamStatement[]): string => {
           assumeRolePolicyDocument: assumeRolePolicy,
         };
 
-        const policyName = await attachRolePolicyForFc(roleName, customStatements);
+        const policyName = await attachRolePolicyForFc(
+          roleName,
+          customStatements,
+          executionStatements,
+        );
 
         if (managedPolicies && managedPolicies.length > 0) {
           await attachManagedPoliciesFn(roleName, managedPolicies);
@@ -267,7 +388,11 @@ const buildExecutionPolicy = (customStatements?: IamStatement[]): string => {
             });
             await ramClient.updateRole(updateRequest);
 
-            const policyName = await attachRolePolicyForFc(roleName, customStatements);
+            const policyName = buildRolePolicyName(roleName);
+            await updateExecutionPolicyDocumentFn(
+              roleName,
+              buildFc3ExecutionPolicyDocument(executionStatements, customStatements),
+            );
 
             if (managedPolicies && managedPolicies.length > 0) {
               await attachManagedPoliciesFn(roleName, managedPolicies);
@@ -319,7 +444,7 @@ const buildExecutionPolicy = (customStatements?: IamStatement[]): string => {
           updateDate: getResponse.body?.role?.updateDate,
           maxSessionDuration: getResponse.body?.role?.maxSessionDuration,
           assumeRolePolicyDocument: assumeRolePolicy,
-          policyName: `${roleName}-policy`,
+          policyName: buildRolePolicyName(roleName),
         };
 
         const updateRequest = new ram.UpdateRoleRequest({
@@ -346,8 +471,9 @@ const buildExecutionPolicy = (customStatements?: IamStatement[]): string => {
     updateRolePolicy: async (
       roleName: string,
       customStatements?: IamStatement[],
+      executionStatements?: IamStatement[],
     ): Promise<void> => {
-      const policyName = `${roleName}-policy`;
+      const policyName = buildRolePolicyName(roleName);
       try {
         await ramClient.detachPolicyFromRole(
           new ram.DetachPolicyFromRoleRequest({ policyType: 'Custom', policyName, roleName }),
@@ -364,7 +490,7 @@ const buildExecutionPolicy = (customStatements?: IamStatement[]): string => {
         await ramClient.createPolicy(
           new ram.CreatePolicyRequest({
             policyName,
-            policyDocument: buildExecutionPolicy(customStatements),
+            policyDocument: buildExecutionPolicy(executionStatements, customStatements),
             description: `FC execution policy for ${roleName}`,
           }),
         );
@@ -394,6 +520,8 @@ const buildExecutionPolicy = (customStatements?: IamStatement[]): string => {
       }
     },
 
+    updateExecutionPolicyDocument: updateExecutionPolicyDocumentFn,
+
     getRole: async (roleName: string): Promise<RamRoleInfo | null> => {
       try {
         const request = new ram.GetRoleRequest({
@@ -414,7 +542,7 @@ const buildExecutionPolicy = (customStatements?: IamStatement[]): string => {
           updateDate: response.body.role.updateDate,
           maxSessionDuration: response.body.role.maxSessionDuration,
           assumeRolePolicyDocument: response.body.role.assumeRolePolicyDocument,
-          policyName: `${roleName}-policy`,
+          policyName: buildRolePolicyName(roleName),
         };
       } catch (error: unknown) {
         if (
@@ -430,7 +558,7 @@ const buildExecutionPolicy = (customStatements?: IamStatement[]): string => {
     },
 
     deleteRole: async (roleName: string, managedPolicies?: string[]): Promise<void> => {
-      const policyName = `${roleName}-policy`;
+      const policyName = buildRolePolicyName(roleName);
 
       if (managedPolicies && managedPolicies.length > 0) {
         await detachManagedPoliciesFn(roleName, managedPolicies);

--- a/src/common/iacHelper.ts
+++ b/src/common/iacHelper.ts
@@ -118,7 +118,9 @@ export const getIacDefinition = (
     return iac.functions?.find((fc) => fc.key === matchFn[1]);
   }
 
-  return iac.functions?.find((fc) => fc.key === rawValue);
+  // Bare values are the function's deployed NAME, never its key — resolving by
+  // key here would reintroduce the issue #227 trust-policy incident.
+  return iac.functions?.find((fc) => fc.name === rawValue);
 };
 
 /* istanbul ignore next */

--- a/src/common/iamStatements.ts
+++ b/src/common/iamStatements.ts
@@ -31,6 +31,25 @@ export const mergePolicyStatements = <S extends Record<string, unknown>>(
 };
 
 /**
+ * Union statement lists (e.g. the derived baselines of several functions
+ * sharing one legacy role), deduplicating identical statements. Returns a NEW
+ * array — the inputs are never mutated.
+ */
+export const unionPolicyStatements = <S>(statementLists: S[][]): S[] => {
+  const seen = new Set<string>();
+  const merged: S[] = [];
+  for (const list of statementLists) {
+    for (const statement of list) {
+      const fingerprint = JSON.stringify(statement);
+      if (seen.has(fingerprint)) continue;
+      seen.add(fingerprint);
+      merged.push(statement);
+    }
+  }
+  return merged;
+};
+
+/**
  * Parse a provider's built-in policy JSON string into its raw Statement array.
  * Returns an empty array when the JSON is invalid or has no Statement field.
  */

--- a/src/common/nameBuilder.ts
+++ b/src/common/nameBuilder.ts
@@ -101,4 +101,16 @@ export const CONSTRAINT_NAME_LIMITS = {
   ALIYUN_CREATE_API_NAME: 50,
   ALIYUN_API_GROUP_NAME: 50,
   VOLCENGINE_ROUTE_NAME: 63,
+  FUNCTION_ROLE_NAME: 64,
 } as const;
+
+/** Single source of truth for per-function execution role names across all providers. */
+export const buildFunctionRoleName = (serviceName: string, stage: string, fnKey: string): string =>
+  buildConstrainedName({
+    parts: [serviceName, stage, fnKey, 'role'],
+    maxLength: CONSTRAINT_NAME_LIMITS.FUNCTION_ROLE_NAME,
+    charset: 'hyphen',
+  });
+
+/** Single source of truth for the execution policy name attached to a role. */
+export const buildRolePolicyName = (roleName: string): string => `${roleName}-policy`;

--- a/src/common/tencentClient/camOperations.ts
+++ b/src/common/tencentClient/camOperations.ts
@@ -4,6 +4,7 @@ import {
   parseBuiltInStatements,
   buildPolicyDocument,
 } from '../iamStatements';
+import { buildRolePolicyName } from '../nameBuilder';
 import type { IamStatement } from '../iamStatements';
 import { logger } from '../logger';
 import { lang } from '../../lang';
@@ -47,12 +48,12 @@ const mapToCamStatement = (stmt: IamStatement): Record<string, unknown> => {
   return result;
 };
 
-const buildExecutionPolicy = (customStatements?: IamStatement[]): string => {
-  const merged = mergePolicyStatements(
-    SCF_EXECUTION_STATEMENTS,
-    customStatements,
-    mapToCamStatement,
-  );
+const buildExecutionPolicy = (
+  customStatements?: IamStatement[],
+  executionStatements?: IamStatement[],
+): string => {
+  const baseline = executionStatements?.map(mapToCamStatement) ?? SCF_EXECUTION_STATEMENTS;
+  const merged = mergePolicyStatements(baseline, customStatements, mapToCamStatement);
   return buildPolicyDocument(merged, { version: '2.0' });
 };
 
@@ -129,6 +130,7 @@ export const createCamOperations = (camClient: CamSdkClient) => {
       description?: string,
       customStatements?: IamStatement[],
       managedPolicies?: string[],
+      executionStatements?: IamStatement[],
     ): Promise<CamRoleInfo> => {
       const assumeRolePolicy = buildAssumeRolePolicy(trustedServices);
       try {
@@ -156,11 +158,11 @@ export const createCamOperations = (camClient: CamSdkClient) => {
         };
 
         // Attach inline policy with built-in + custom statements
-        const policyName = `${roleName}-policy`;
+        const policyName = buildRolePolicyName(roleName);
         try {
           await camClient.CreatePolicy({
             PolicyName: policyName,
-            PolicyDocument: buildExecutionPolicy(customStatements),
+            PolicyDocument: buildExecutionPolicy(customStatements, executionStatements),
             Description: `SCF execution policy for ${roleName}`,
           });
           await attachPolicy(roleName, policyName);
@@ -195,12 +197,12 @@ export const createCamOperations = (camClient: CamSdkClient) => {
             try {
               const getResponse = await camClient.GetRole({ RoleName: roleName });
               const roleData = getResponse.RoleInfo;
-              const policyName = `${roleName}-policy`;
+              const policyName = buildRolePolicyName(roleName);
               // Re-attach built-in policy (idempotent)
               try {
                 await camClient.CreatePolicy({
                   PolicyName: policyName,
-                  PolicyDocument: buildExecutionPolicy(customStatements),
+                  PolicyDocument: buildExecutionPolicy(customStatements, executionStatements),
                   Description: `SCF execution policy for ${roleName}`,
                 });
                 await attachPolicy(roleName, policyName);
@@ -245,7 +247,7 @@ export const createCamOperations = (camClient: CamSdkClient) => {
           roleId: roleData.RoleId,
           roleArn: roleData.RoleArn,
           description: roleData.Description,
-          policyName: `${roleName}-policy`,
+          policyName: buildRolePolicyName(roleName),
         };
       } catch (error: unknown) {
         if (error && typeof error === 'object' && 'code' in error) {
@@ -257,7 +259,7 @@ export const createCamOperations = (camClient: CamSdkClient) => {
     },
 
     deleteRole: async (roleName: string, managedPolicies?: string[]): Promise<void> => {
-      const policyName = `${roleName}-policy`;
+      const policyName = buildRolePolicyName(roleName);
 
       // Detach managed policies first (don't delete them)
       if (managedPolicies && managedPolicies.length > 0) {
@@ -286,8 +288,9 @@ export const createCamOperations = (camClient: CamSdkClient) => {
     updateRolePolicy: async (
       roleName: string,
       customStatements?: IamStatement[],
+      executionStatements?: IamStatement[],
     ): Promise<void> => {
-      const policyName = `${roleName}-policy`;
+      const policyName = buildRolePolicyName(roleName);
       // Detach + delete old
       await detachPolicy(roleName, policyName);
       await deletePolicyByName(camClient, policyName);
@@ -295,7 +298,7 @@ export const createCamOperations = (camClient: CamSdkClient) => {
       try {
         await camClient.CreatePolicy({
           PolicyName: policyName,
-          PolicyDocument: buildExecutionPolicy(customStatements),
+          PolicyDocument: buildExecutionPolicy(customStatements, executionStatements),
           Description: `SCF execution policy for ${roleName}`,
         });
       } catch (error: unknown) {

--- a/src/common/volcengineClient/iamOperations.ts
+++ b/src/common/volcengineClient/iamOperations.ts
@@ -368,7 +368,11 @@ export const createIamOperations = (iamClient: IamSdkClient) => {
                 },
               });
 
-              const policyName = await createAndAttachPolicy(roleName, config.executionStatements);
+              const policyName = await createAndAttachPolicy(
+                roleName,
+                config.executionStatements,
+                config.customStatements,
+              );
 
               if (config.managedPolicies && config.managedPolicies.length > 0) {
                 for (const policyArn of config.managedPolicies) {

--- a/src/common/volcengineClient/iamOperations.ts
+++ b/src/common/volcengineClient/iamOperations.ts
@@ -5,6 +5,7 @@ import {
   parseBuiltInStatements,
   buildPolicyDocument,
 } from '../iamStatements';
+import { buildRolePolicyName } from '../nameBuilder';
 import type { IamStatement } from '../iamStatements';
 import { logger } from '../logger';
 import { lang } from '../../lang';
@@ -66,12 +67,14 @@ const mapToVolcengineStatement = (stmt: IamStatement): Record<string, unknown> =
   return result;
 };
 
-const buildExecutionPolicy = (customStatements?: IamStatement[]): string => {
-  const merged = mergePolicyStatements(
-    VEFAAS_EXECUTION_STATEMENTS,
-    customStatements,
-    mapToVolcengineStatement,
-  );
+const buildExecutionPolicy = (
+  baseline?: IamStatement[],
+  customStatements?: IamStatement[],
+): string => {
+  const nativeBaseline = baseline
+    ? baseline.map(mapToVolcengineStatement)
+    : VEFAAS_EXECUTION_STATEMENTS;
+  const merged = mergePolicyStatements(nativeBaseline, customStatements, mapToVolcengineStatement);
   return buildPolicyDocument(merged);
 };
 
@@ -95,9 +98,10 @@ const buildTagResourceQuery = (
 export const createIamOperations = (iamClient: IamSdkClient) => {
   const createAndAttachPolicy = async (
     roleName: string,
+    baseline?: IamStatement[],
     customStatements?: IamStatement[],
   ): Promise<string> => {
-    const policyName = `${roleName}-policy`;
+    const policyName = buildRolePolicyName(roleName);
 
     try {
       await iamClient.fetchOpenAPI({
@@ -107,7 +111,7 @@ export const createIamOperations = (iamClient: IamSdkClient) => {
         headers: { 'content-type': 'application/json' },
         query: {
           PolicyName: policyName,
-          PolicyDocument: buildExecutionPolicy(customStatements),
+          PolicyDocument: buildExecutionPolicy(baseline, customStatements),
           Description: `veFaaS execution policy for ${roleName}`,
         },
       });
@@ -165,7 +169,7 @@ export const createIamOperations = (iamClient: IamSdkClient) => {
   };
 
   const detachAndDeletePolicy = async (roleName: string): Promise<void> => {
-    const policyName = `${roleName}-policy`;
+    const policyName = buildRolePolicyName(roleName);
 
     try {
       await iamClient.fetchOpenAPI({
@@ -314,7 +318,11 @@ export const createIamOperations = (iamClient: IamSdkClient) => {
         const data = (response.Result || {}) as Record<string, unknown>;
         const roleData = (data.Role || {}) as Record<string, unknown>;
 
-        const policyName = await createAndAttachPolicy(roleName, customStatements);
+        const policyName = await createAndAttachPolicy(
+          roleName,
+          config.executionStatements,
+          customStatements,
+        );
 
         if (config.managedPolicies && config.managedPolicies.length > 0) {
           for (const policyArn of config.managedPolicies) {
@@ -360,7 +368,7 @@ export const createIamOperations = (iamClient: IamSdkClient) => {
                 },
               });
 
-              const policyName = await createAndAttachPolicy(roleName);
+              const policyName = await createAndAttachPolicy(roleName, config.executionStatements);
 
               if (config.managedPolicies && config.managedPolicies.length > 0) {
                 for (const policyArn of config.managedPolicies) {
@@ -425,7 +433,7 @@ export const createIamOperations = (iamClient: IamSdkClient) => {
           createdTime: roleData.CreateTime as string | undefined,
           maxSessionDuration: roleData.MaxSessionDuration as number | undefined,
           trustPolicyDocument: roleData.TrustPolicyDocument as string | undefined,
-          policyName: `${roleName}-policy`,
+          policyName: buildRolePolicyName(roleName),
         };
       } catch (error: unknown) {
         if (error && typeof error === 'object' && 'code' in error) {
@@ -511,10 +519,11 @@ export const createIamOperations = (iamClient: IamSdkClient) => {
 
     updateRolePolicy: async (
       roleName: string,
+      baseline?: IamStatement[],
       customStatements?: IamStatement[],
     ): Promise<void> => {
       await detachAndDeletePolicy(roleName);
-      await createAndAttachPolicy(roleName, customStatements);
+      await createAndAttachPolicy(roleName, baseline, customStatements);
       logger.info(lang.__('IAM_ROLE_POLICY_UPDATED', { roleName }));
     },
 

--- a/src/common/volcengineClient/types.ts
+++ b/src/common/volcengineClient/types.ts
@@ -273,6 +273,7 @@ export type IamRoleConfig = {
     Statement: IamTrustPolicyStatement[];
   };
   maxSessionDuration?: number;
+  executionStatements?: IamStatement[];
   customStatements?: IamStatement[];
   managedPolicies?: string[];
 };
@@ -640,7 +641,11 @@ export type VolcengineClient = {
       policyType: 'System' | 'Custom',
     ) => Promise<void>;
     detachRolePolicy: (roleName: string, policyName: string) => Promise<void>;
-    updateRolePolicy: (roleName: string, customStatements?: IamStatement[]) => Promise<void>;
+    updateRolePolicy: (
+      roleName: string,
+      baseline?: IamStatement[],
+      customStatements?: IamStatement[],
+    ) => Promise<void>;
     updateManagedPolicies: (roleName: string, desiredPolicies: string[]) => Promise<void>;
     listAttachedRolePolicies: (roleName: string) => Promise<string[]>;
     tagRole: (roleName: string, tags: Array<{ key: string; value: string }>) => Promise<void>;

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -520,6 +520,8 @@ export const en = {
     'Trigger backend "{{backend}}" in event "{{eventKey}}" matches function key "{{key}}", but bare backend values must be deployed function names. For template functions use the reference form "${functions.{{key}}}"',
   SEMANTIC_BACKEND_BARE_NAME:
     'Trigger backend "{{backend}}" in event "{{eventKey}}" resolves to template function "{{key}}" by name; prefer the reference form "${functions.{{key}}}"',
+  SEMANTIC_EXTERNAL_BACKEND_VOLCENGINE:
+    'Trigger backend "{{backend}}" in event "{{eventKey}}" is not a function in this template. Volcengine API Gateway upstreams require a template-managed function — use the reference form "${functions.key}" or define the function in this template',
   EXTERNAL_FUNCTION_BACKEND:
     'Backend "{{backendRef}}" is not defined in this template; treating it as an external deployed function name',
 

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -516,6 +516,12 @@ export const en = {
     'Generated API Gateway route name "{{routeName}}" collides between "{{firstPath}}" and "{{secondPath}}" in this deployment; shorten the event name or differentiate trigger method/path',
   SEMANTIC_UNRESOLVED_FUNCTION_BACKEND:
     'Trigger backend "{{reference}}" in event "{{eventKey}}" does not match any function definition in the configuration',
+  SEMANTIC_BACKEND_BARE_KEY:
+    'Trigger backend "{{backend}}" in event "{{eventKey}}" matches function key "{{key}}", but bare backend values must be deployed function names. For template functions use the reference form "${functions.{{key}}}"',
+  SEMANTIC_BACKEND_BARE_NAME:
+    'Trigger backend "{{backend}}" in event "{{eventKey}}" resolves to template function "{{key}}" by name; prefer the reference form "${functions.{{key}}}"',
+  EXTERNAL_FUNCTION_BACKEND:
+    'Backend "{{backendRef}}" is not defined in this template; treating it as an external deployed function name',
 
   // Show command messages
   LOADING_STATE_FOR: 'Loading state for app: {{app}}, service: {{service}}, stage: {{stage}}...',
@@ -609,6 +615,9 @@ export const en = {
     'Failed to recover from RAM role state drift for "{{roleName}}": {{error}}. ' +
     'The role existed in the cloud but recovery operations failed. ' +
     'To fix: manually verify the role in the cloud console, remove it from state, and redeploy.',
+  RAM_POLICY_VERSION_PRUNE_FAILED:
+    'Failed to prune old policy versions for "{{policyName}}": {{error}}. ' +
+    'The policy may exceed the version limit on the next update.',
 
   // Certificate messages
   CERT_INVALID_CONFIGURATION:

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -520,8 +520,8 @@ export const en = {
     'Trigger backend "{{backend}}" in event "{{eventKey}}" matches function key "{{key}}", but bare backend values must be deployed function names. For template functions use the reference form "${functions.{{key}}}"',
   SEMANTIC_BACKEND_BARE_NAME:
     'Trigger backend "{{backend}}" in event "{{eventKey}}" resolves to template function "{{key}}" by name; prefer the reference form "${functions.{{key}}}"',
-  SEMANTIC_EXTERNAL_BACKEND_VOLCENGINE:
-    'Trigger backend "{{backend}}" in event "{{eventKey}}" is not a function in this template. Volcengine API Gateway upstreams require a template-managed function — use the reference form "${functions.key}" or define the function in this template',
+  EXTERNAL_FUNCTION_NOT_FOUND_VOLCENGINE:
+    'Backend "{{backendRef}}" is not defined in this template and no deployed veFaaS function with that name exists in the provider. External backends must exist in the same account and region',
   EXTERNAL_FUNCTION_BACKEND:
     'Backend "{{backendRef}}" is not defined in this template; treating it as an external deployed function name',
 

--- a/src/lang/zh-CN.ts
+++ b/src/lang/zh-CN.ts
@@ -466,6 +466,8 @@ export const zhCN = {
     '事件 "{{eventKey}}" 的触发器后端 "{{backend}}" 匹配的是函数 key "{{key}}"，但裸值必须是已部署函数名。模板函数请使用引用形式 "${functions.{{key}}}"',
   SEMANTIC_BACKEND_BARE_NAME:
     '事件 "{{eventKey}}" 的触发器后端 "{{backend}}" 按名称解析为模板函数 "{{key}}"，建议使用引用形式 "${functions.{{key}}}"',
+  SEMANTIC_EXTERNAL_BACKEND_VOLCENGINE:
+    '事件 "{{eventKey}}" 的触发器后端 "{{backend}}" 不是本模板中的函数。Volcengine API Gateway 上游要求使用模板管理的函数——请使用引用形式 "${functions.{{key}}}" 或在本模板中定义该函数',
   EXTERNAL_FUNCTION_BACKEND: '后端 "{{backendRef}}" 未在当前模板中定义，将按外部已部署函数名处理',
 
   // Show command messages

--- a/src/lang/zh-CN.ts
+++ b/src/lang/zh-CN.ts
@@ -462,6 +462,11 @@ export const zhCN = {
     '生成的 API Gateway route name "{{routeName}}" 在 "{{firstPath}}" 与 "{{secondPath}}" 之间发生冲突；请缩短事件名称或区分触发器的 method/path',
   SEMANTIC_UNRESOLVED_FUNCTION_BACKEND:
     '事件 "{{eventKey}}" 的触发器后端 "{{reference}}" 未匹配到配置中的任何函数定义',
+  SEMANTIC_BACKEND_BARE_KEY:
+    '事件 "{{eventKey}}" 的触发器后端 "{{backend}}" 匹配的是函数 key "{{key}}"，但裸值必须是已部署函数名。模板函数请使用引用形式 "${functions.{{key}}}"',
+  SEMANTIC_BACKEND_BARE_NAME:
+    '事件 "{{eventKey}}" 的触发器后端 "{{backend}}" 按名称解析为模板函数 "{{key}}"，建议使用引用形式 "${functions.{{key}}}"',
+  EXTERNAL_FUNCTION_BACKEND: '后端 "{{backendRef}}" 未在当前模板中定义，将按外部已部署函数名处理',
 
   // Show command messages
   LOADING_STATE_FOR: '正在加载应用 {{app}}、服务 {{service}}、阶段 {{stage}} 的状态...',
@@ -552,6 +557,8 @@ export const zhCN = {
     'RAM 角色 "{{roleName}}" 状态漂移恢复失败：{{error}}。' +
     '角色在云端存在但恢复操作失败。' +
     '修复方法：在云控制台手动确认角色状态，从状态中移除该角色并重新部署。',
+  RAM_POLICY_VERSION_PRUNE_FAILED:
+    '策略 "{{policyName}}" 旧版本清理失败：{{error}}。' + '下次更新时策略版本数可能超出上限。',
 
   // 证书消息
   CERT_INVALID_CONFIGURATION:

--- a/src/lang/zh-CN.ts
+++ b/src/lang/zh-CN.ts
@@ -466,8 +466,8 @@ export const zhCN = {
     '事件 "{{eventKey}}" 的触发器后端 "{{backend}}" 匹配的是函数 key "{{key}}"，但裸值必须是已部署函数名。模板函数请使用引用形式 "${functions.{{key}}}"',
   SEMANTIC_BACKEND_BARE_NAME:
     '事件 "{{eventKey}}" 的触发器后端 "{{backend}}" 按名称解析为模板函数 "{{key}}"，建议使用引用形式 "${functions.{{key}}}"',
-  SEMANTIC_EXTERNAL_BACKEND_VOLCENGINE:
-    '事件 "{{eventKey}}" 的触发器后端 "{{backend}}" 不是本模板中的函数。Volcengine API Gateway 上游要求使用模板管理的函数——请使用引用形式 "${functions.{{key}}}" 或在本模板中定义该函数',
+  EXTERNAL_FUNCTION_NOT_FOUND_VOLCENGINE:
+    '后端 "{{backendRef}}" 未在本模板中定义，且提供商中不存在同名已部署 veFaaS 函数。外部后端必须位于同一账号和区域',
   EXTERNAL_FUNCTION_BACKEND: '后端 "{{backendRef}}" 未在当前模板中定义，将按外部已部署函数名处理',
 
   // Show command messages

--- a/src/stack/aliyunStack/apigwExecutor.ts
+++ b/src/stack/aliyunStack/apigwExecutor.ts
@@ -9,6 +9,7 @@ import {
   PartialResourceError,
 } from '../../types';
 import { createApigwResource, deleteApigwResource, updateApigwResource } from './apigwResource';
+import { RoleArnParam } from './apigwTypes';
 import { logger } from '../../common';
 import { reportResourceEvent } from '../../common/reportResourceEvent';
 import { getResource } from '../../common/stateManager';
@@ -19,7 +20,7 @@ const executeSingleItem = async (
   item: PlanItem,
   eventsMap: Map<string, EventDomain>,
   serviceName: string,
-  roleArn: string | undefined,
+  resolveRoleArn: RoleArnParam,
   currentState: StateFile,
 ): Promise<StateFile | null> => {
   switch (item.action) {
@@ -39,7 +40,7 @@ const executeSingleItem = async (
         context,
         event,
         serviceName,
-        roleArn,
+        resolveRoleArn,
         currentState,
       );
       logger.info(
@@ -60,7 +61,7 @@ const executeSingleItem = async (
         context,
         event,
         serviceName,
-        roleArn,
+        resolveRoleArn,
         currentState,
       );
       logger.info(
@@ -107,7 +108,7 @@ export const executeApigwPlan = async (
   plan: Plan,
   events: Array<EventDomain> | undefined,
   serviceName: string,
-  roleArn: string | undefined,
+  resolveRoleArn: RoleArnParam,
   initialState: StateFile,
   onStateChange?: SaveStateFn,
 ): Promise<ExecutionResult> => {
@@ -131,7 +132,7 @@ export const executeApigwPlan = async (
         item,
         eventsMap,
         serviceName,
-        roleArn,
+        resolveRoleArn,
         currentState,
       );
       if (newState !== null) {

--- a/src/stack/aliyunStack/apigwResource.ts
+++ b/src/stack/aliyunStack/apigwResource.ts
@@ -23,6 +23,8 @@ import {
   generateApiKey,
   inferProtocolConfig,
   buildEventLogSnapshot,
+  normalizeRoleArnResolver,
+  RoleArnParam,
 } from './apigwTypes';
 import {
   setResource,
@@ -43,6 +45,7 @@ import {
   SHARED_LOG_PROJECT_KEY,
   adoptSharedSlsProjectState,
   buildSharedProjectName,
+  buildGatewayLogstoreName,
   ensureSharedSlsProject,
   ensureGatewayLogstore,
   buildSharedProjectResourceState,
@@ -458,7 +461,7 @@ const ensureGatewayLogConfig = async (
   client: ReturnType<typeof createAliyunClient>,
   state: StateFile,
 ): Promise<{ instance?: ResourceInstance; sharedProject?: ResourceState }> => {
-  const slsLogStore = `${context.service}-${context.stage}-apigw-logs`;
+  const slsLogStore = buildGatewayLogstoreName(context.service, context.stage);
   const ours = { slsProject: buildSharedProjectName(context.app, context.stage), slsLogStore };
 
   const existing = await client.apigw.describeGatewayLogConfig();
@@ -596,11 +599,12 @@ export const createApigwResource = async (
   context: Context,
   event: EventDomain,
   serviceName: string,
-  roleArn: string | undefined,
+  resolveRoleArn: RoleArnParam,
   state: StateFile,
 ): Promise<StateFile> => {
   const logicalId = `events.${event.key}`;
   const client = createAliyunClient(context);
+  const roleArnFor = normalizeRoleArnResolver(resolveRoleArn);
 
   const groupConfig = eventToApigwGroupConfig(
     event,
@@ -731,7 +735,7 @@ export const createApigwResource = async (
         serviceName,
         context.region,
         context.stage,
-        roleArn,
+        roleArnFor(String(trigger.backend)),
       );
 
       const apiId = await client.apigw.createApi(apiConfig);
@@ -893,12 +897,13 @@ export const updateApigwResource = async (
   context: Context,
   event: EventDomain,
   serviceName: string,
-  roleArn: string | undefined,
+  resolveRoleArn: RoleArnParam,
   state: StateFile,
 ): Promise<StateFile> => {
   const logicalId = `events.${event.key}`;
   const existingState = getResource(state, logicalId);
   const client = createAliyunClient(context);
+  const roleArnFor = normalizeRoleArnResolver(resolveRoleArn);
   let existingInstances: Array<ResourceInstance>;
   let groupId: string;
 
@@ -912,7 +917,7 @@ export const updateApigwResource = async (
         serviceName,
         context.region,
         context.stage,
-        roleArn,
+        roleArnFor(String(trigger.backend)),
       );
       return apiConfig.apiName;
     }),
@@ -947,7 +952,7 @@ export const updateApigwResource = async (
   // Shared helper: try to find the group from cloud. On any error (or not found),
   // fall back to full creation since there's nothing to update.
   const findCloudGroupOrCreate = async (): Promise<never> => {
-    return createApigwResource(context, event, serviceName, roleArn, state) as never;
+    return createApigwResource(context, event, serviceName, resolveRoleArn, state) as never;
   };
 
   if (existingState) {
@@ -1029,7 +1034,7 @@ export const updateApigwResource = async (
       serviceName,
       context.region,
       context.stage,
-      roleArn,
+      roleArnFor(String(trigger.backend)),
     );
 
     const apiKey = generateApiKey(trigger.method as string, trigger.path as string);
@@ -1075,7 +1080,7 @@ export const updateApigwResource = async (
           serviceName,
           context.region,
           context.stage,
-          roleArn,
+          roleArnFor(String(t.backend)),
         ).apiName;
         return apiInfo.apiName === expectedName;
       });

--- a/src/stack/aliyunStack/apigwTypes.ts
+++ b/src/stack/aliyunStack/apigwTypes.ts
@@ -11,6 +11,7 @@ import {
 } from '../../common';
 import { lang } from '../../lang';
 import { OWNERSHIP_TAG_KEY, buildOwnershipTagValue } from '../ownershipTag';
+import { buildSharedProjectName, buildGatewayLogstoreName } from './sharedLogProject';
 // Re-export the info types from the shared client layer so there is a single
 // source of truth — the operations layer owns the cloud-returned field shape
 // and the stack layer consumes it (previous duplicated copies could drift).
@@ -79,6 +80,18 @@ export type ApigwDeploymentConfig = {
   description?: string;
 };
 
+/** @public Resolves a trigger backend to its execution role ARN; accepts a closure or a legacy fixed ARN. */
+export type RoleArnResolver = (backend: string) => string | undefined;
+
+export type RoleArnParam = string | undefined | RoleArnResolver;
+
+export const normalizeRoleArnResolver = (param: RoleArnParam): RoleArnResolver => {
+  if (typeof param === 'function') {
+    return param;
+  }
+  return () => param;
+};
+
 // Custom domain types
 export type ApigwCustomDomainConfig = {
   groupId: string;
@@ -128,6 +141,8 @@ export const eventToApigwGroupConfig = (
 /**
  * Resolves a function reference like ${functions.xxx} to the actual function name
  */
+const FUNCTION_REF_PATTERN = /^\$\{functions\.[\w.]+\}$/;
+
 const resolveFunctionReference = (backendRef: string): string => {
   // Get IAC from context
   const context = getContext();
@@ -140,8 +155,13 @@ const resolveFunctionReference = (backendRef: string): string => {
   const functionDef = getIacDefinition(context.iac, backendRef);
 
   if (!functionDef || !isFunctionDomain(functionDef)) {
-    // Not a function reference or function not found, return as is
-    logger.warn(lang.__('FUNCTION_REF_NOT_RESOLVED', { backendRef }));
+    // Dangling template refs fail semantic validation; a bare value that matches
+    // no template function is an external deployed function name (issue #227).
+    if (FUNCTION_REF_PATTERN.test(backendRef)) {
+      logger.warn(lang.__('FUNCTION_REF_NOT_RESOLVED', { backendRef }));
+    } else {
+      logger.info(lang.__('EXTERNAL_FUNCTION_BACKEND', { backendRef }));
+    }
     return backendRef;
   }
 
@@ -352,8 +372,8 @@ export const buildEventLogSnapshot = (
   return {
     logEnabled: event.log === true || event.log === 'true',
     logConfig: {
-      project: `${context.app}-${context.stage}-sls`,
-      logstore: `${context.service}-${context.stage}-apigw-logs`,
+      project: buildSharedProjectName(context.app, context.stage),
+      logstore: buildGatewayLogstoreName(context.service, context.stage),
     },
   };
 };

--- a/src/stack/aliyunStack/deployer.ts
+++ b/src/stack/aliyunStack/deployer.ts
@@ -5,14 +5,7 @@ import {
   PlanItem,
   StateFile,
 } from '../../types';
-import {
-  getContext,
-  logger,
-  getRoleArnFromState,
-  setIac,
-  getDependencyInfo,
-  toDotFormat,
-} from '../../common';
+import { getContext, logger, setIac, getDependencyInfo, toDotFormat } from '../../common';
 import { StateBackend } from '../../common/stateBackend';
 import { lang } from '../../lang';
 import { generateFunctionPlan } from './fc3Planner';
@@ -64,6 +57,42 @@ const logDependencyGraph = (orderedItems: Array<PlanItem>, dotGraph: string): vo
     );
   });
   logger.debug(`${lang.__('DOT_GRAPH_OUTPUT')}:\n${dotGraph}`);
+};
+
+const TEMPLATE_FUNCTION_REF_PATTERN = /^\$\{functions\.([\w.]+)\}$/;
+
+const findFirstManagedRoleArn = (state: StateFile): string | undefined => {
+  for (const [logicalId, resourceState] of Object.entries(state.resources ?? {})) {
+    if (logicalId.startsWith('functions.')) {
+      const ramRoleInstance = resourceState.instances?.find((i) => i.type === 'ALIYUN_RAM_ROLE');
+      if (ramRoleInstance?.roleArn) {
+        return ramRoleInstance.roleArn as string;
+      }
+    }
+  }
+  return undefined;
+};
+
+/** @public Resolves a trigger backend to its role ARN; template refs and bare names map to that function's role, else first managed role. */
+export const buildRoleArnResolver = (
+  state: StateFile,
+  functions: ServerlessIac['functions'],
+): ((backend: string) => string | undefined) => {
+  const fallbackArn = findFirstManagedRoleArn(state);
+  const keyByName = new Map((functions ?? []).map((f) => [f.name, f.key]));
+
+  return (backend: string): string | undefined => {
+    const refMatch = backend.match(TEMPLATE_FUNCTION_REF_PATTERN);
+    const fnKey = refMatch ? refMatch[1] : keyByName.get(backend);
+    if (fnKey) {
+      const resourceState = state.resources?.[`functions.${fnKey}`];
+      const ramRoleInstance = resourceState?.instances?.find((i) => i.type === 'ALIYUN_RAM_ROLE');
+      if (ramRoleInstance?.roleArn) {
+        return ramRoleInstance.roleArn as string;
+      }
+    }
+    return fallbackArn;
+  };
 };
 
 export const deployAliyunStack = async (
@@ -185,13 +214,13 @@ export const deployAliyunStack = async (
   }
 
   // Execute event plan after functions are created (events depend on functions)
-  const roleArn = getRoleArnFromState(state);
+  const resolveRoleArn = buildRoleArnResolver(state, iac.functions);
   const eventResult = await executeApigwPlan(
     context,
     eventPlan,
     iac.events,
     iac.service,
-    roleArn,
+    resolveRoleArn,
     state,
     onStateChange,
   );

--- a/src/stack/aliyunStack/fc3Resource.ts
+++ b/src/stack/aliyunStack/fc3Resource.ts
@@ -4,6 +4,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 import {
+  getAllResources,
   getResource,
   removeResource,
   setResource,
@@ -35,7 +36,7 @@ import {
 } from '../../types';
 import { extractFc3Definition, Fc3FunctionInfo, functionToFc3Config } from './fc3Types';
 import { logger } from '../../common/logger';
-import type { IamStatement } from '../../common/iamStatements';
+import { unionPolicyStatements, type IamStatement } from '../../common/iamStatements';
 import { buildFc3ExecutionPolicyDocument } from '../../common/aliyunClient/ramOperations';
 import { lang } from '../../lang';
 import { OWNERSHIP_TAG_KEY, buildOwnershipTagValue, isOwnedByStack } from '../ownershipTag';
@@ -110,6 +111,66 @@ const buildDefaultRoleName = buildFunctionRoleName;
 
 const buildFc3CertName = (service: string, stage: string): string =>
   `${service}-${stage}-fc3-domain`;
+
+type RolePeer = { fn: FunctionDomain; logConfig?: { project: string; logstore: string } };
+
+const collectRolePeers = (state: StateFile, context: Context, roleId: string): RolePeer[] => {
+  const peers: RolePeer[] = [];
+  for (const [logicalId, resourceState] of Object.entries(getAllResources(state))) {
+    if (!logicalId.startsWith('functions.')) continue;
+    const roleInstance = resourceState.instances?.find(
+      (i) => (i as { type?: string }).type === 'ALIYUN_RAM_ROLE',
+    ) as { id?: string } | undefined;
+    if (roleInstance?.id !== roleId) continue;
+    const fn = context.iac?.functions?.find(
+      (candidate) => candidate.key === logicalId.slice('functions.'.length),
+    );
+    if (!fn) continue;
+    const logstoreInstance = resourceState.instances?.find(
+      (i) => (i as { type?: string }).type === 'ALIYUN_SLS_LOGSTORE',
+    ) as { id?: string } | undefined;
+    const [project, logstore] = logstoreInstance?.id?.split('/') ?? [];
+    peers.push({ fn, ...(project && logstore ? { logConfig: { project, logstore } } : {}) });
+  }
+  return peers;
+};
+
+const unionTrustedServices = (serviceLists: string[][]): string[] => [
+  ...new Set(serviceLists.flat()),
+];
+
+/**
+ * Legacy shared roles serve every function that recorded them, so their trust
+ * and derived policy must be the union across those functions — a single
+ * function's update would otherwise strip another function's requirements.
+ */
+const resolveRoleGrant = (
+  context: Context,
+  state: StateFile | undefined,
+  fn: FunctionDomain,
+  logConfig: { project: string; logstore: string } | undefined,
+  roleId: string,
+): { trustedServices: string[]; executionStatements: IamStatement[] } => {
+  const storedPeers = state ? collectRolePeers(state, context, roleId) : [];
+  const currentStored = storedPeers.find((peer) => peer.fn.key === fn.key);
+  const peers: RolePeer[] = currentStored
+    ? [...storedPeers]
+    : [{ fn, ...(logConfig ? { logConfig } : {}) }, ...storedPeers];
+  if (peers.length <= 1) {
+    return {
+      trustedServices: getTrustedServicesForFunction(context, fn),
+      executionStatements: deriveFc3ExecutionStatements(fn, context, logConfig),
+    };
+  }
+  return {
+    trustedServices: unionTrustedServices(
+      peers.map((peer) => getTrustedServicesForFunction(context, peer.fn)),
+    ),
+    executionStatements: unionPolicyStatements(
+      peers.map((peer) => deriveFc3ExecutionStatements(peer.fn, context, peer.logConfig)),
+    ),
+  };
+};
 
 export const deriveFc3ExecutionStatements = (
   fn: FunctionDomain,
@@ -388,10 +449,11 @@ const createDependentResources = async (
     const ramRoleInstance = existingInstances.find((i) => i.type === 'ALIYUN_RAM_ROLE');
     if (ramRoleInstance) {
       instances.push(ramRoleInstance);
-      await client.ram.updateRoleTrustPolicy(ramRoleInstance.id, trustedServices);
+      const roleGrant = resolveRoleGrant(context, state, fn, logConfig, ramRoleInstance.id);
+      await client.ram.updateRoleTrustPolicy(ramRoleInstance.id, roleGrant.trustedServices);
       await client.ram.updateExecutionPolicyDocument(
         ramRoleInstance.id,
-        buildFc3ExecutionPolicyDocument(executionStatements, statements),
+        buildFc3ExecutionPolicyDocument(roleGrant.executionStatements, statements),
       );
     }
   } else {
@@ -1016,11 +1078,11 @@ export const updateResource = async (
         arn: ramRoleInstance.roleArn ?? `acs:ram::${context.accountId}:role/${ramRoleInstance.id}`,
       };
 
-      const trustedServices = getTrustedServicesForFunction(context, fn);
-      await client.ram.updateRoleTrustPolicy(ramRoleInstance.id, trustedServices);
+      const roleGrant = resolveRoleGrant(context, state, fn, logConfig, ramRoleInstance.id);
+      await client.ram.updateRoleTrustPolicy(ramRoleInstance.id, roleGrant.trustedServices);
       await client.ram.updateExecutionPolicyDocument(
         ramRoleInstance.id,
-        buildFc3ExecutionPolicyDocument(executionStatements, customStatements),
+        buildFc3ExecutionPolicyDocument(roleGrant.executionStatements, customStatements),
       );
 
       const existingIam = existingState?.definition?.iam as Record<string, unknown> | undefined;

--- a/src/stack/aliyunStack/fc3Resource.ts
+++ b/src/stack/aliyunStack/fc3Resource.ts
@@ -13,6 +13,7 @@ import {
   computeZipContentHash,
   getContext,
   buildSid,
+  buildFunctionRoleName,
   attributesEqual,
   mapAuthType,
   mapAliyunAccess,
@@ -35,6 +36,7 @@ import {
 import { extractFc3Definition, Fc3FunctionInfo, functionToFc3Config } from './fc3Types';
 import { logger } from '../../common/logger';
 import type { IamStatement } from '../../common/iamStatements';
+import { buildFc3ExecutionPolicyDocument } from '../../common/aliyunClient/ramOperations';
 import { lang } from '../../lang';
 import { OWNERSHIP_TAG_KEY, buildOwnershipTagValue, isOwnedByStack } from '../ownershipTag';
 import { isResourceAlreadyExistsError } from '../alreadyExists';
@@ -63,11 +65,84 @@ const delay = async (ms: number): Promise<void> => {
   });
 };
 
-const getTrustedServicesForFunction = (context: Context, fnKey: string): string[] => {
+const TEMPLATE_REF_PATTERN = /^\$\{[^}]+\}$/;
+
+const getTrustedServicesForFunction = (context: Context, fn: FunctionDomain): string[] => {
+  const templateFunctions = context.iac?.functions ?? [];
+  const templateKeys = new Set(templateFunctions.map((templateFn) => templateFn.key));
+  const templateNames = new Set(templateFunctions.map((templateFn) => templateFn.name));
   const fnHasApiGateway = context.iac?.events?.some((event) =>
-    event.triggers?.some((trigger) => String(trigger.backend) === `\${functions.${fnKey}}`),
+    event.triggers?.some((trigger) => {
+      const backend = String(trigger.backend);
+      if (backend === `\${functions.${fn.key}}` || backend === fn.name) {
+        return true;
+      }
+      // External backend (issue #227): the gateway assumes this managed role as
+      // its invocation identity, so bare external names still require apigateway trust.
+      return (
+        !TEMPLATE_REF_PATTERN.test(backend) &&
+        !templateKeys.has(backend) &&
+        !templateNames.has(backend)
+      );
+    }),
   );
   return fnHasApiGateway ? ['fc.aliyuncs.com', 'apigateway.aliyuncs.com'] : ['fc.aliyuncs.com'];
+};
+
+const FC3_LOG_ACTIONS = [
+  'log:PostLogStoreLogs',
+  'log:CreateLogStore',
+  'log:GetLogStore',
+  'log:ListShards',
+  'log:GetCursorOrData',
+];
+
+const FC3_ENI_ACTIONS = [
+  'ecs:CreateNetworkInterface',
+  'ecs:DeleteNetworkInterface',
+  'ecs:DescribeNetworkInterfaces',
+  'ecs:CreateNetworkInterfacePermission',
+  'ecs:DescribeNetworkInterfacePermissions',
+  'ecs:DeleteNetworkInterfacePermission',
+];
+
+const buildDefaultRoleName = buildFunctionRoleName;
+
+const buildFc3CertName = (service: string, stage: string): string =>
+  `${service}-${stage}-fc3-domain`;
+
+export const deriveFc3ExecutionStatements = (
+  fn: FunctionDomain,
+  context: Context,
+  logConfig?: { project: string; logstore: string },
+): IamStatement[] => {
+  const statements: IamStatement[] = [
+    // Broad on purpose: the API gateway assumes this role as its invocation identity.
+    { effect: 'Allow', action: ['fc:InvokeFunction'], resource: ['*'] },
+    {
+      effect: 'Allow',
+      action: FC3_LOG_ACTIONS,
+      resource:
+        logConfig && context.accountId
+          ? [
+              `acs:log:${context.region}:${context.accountId}:project/${logConfig.project}/logstore/${logConfig.logstore}`,
+            ]
+          : ['*'],
+    },
+  ];
+
+  if (fn.network) {
+    statements.push(
+      { effect: 'Allow', action: FC3_ENI_ACTIONS, resource: ['*'] },
+      { effect: 'Allow', action: ['vpc:DescribeVSwitchAttributes'], resource: ['*'] },
+    );
+  }
+
+  if (fn.storage?.nas && fn.storage.nas.length > 0) {
+    statements.push({ effect: 'Allow', action: ['nas:*'], resource: ['*'] });
+  }
+
+  return statements;
 };
 
 const isRecoverableCreateError = (error: unknown): boolean => {
@@ -220,6 +295,7 @@ const createDependentResources = async (
   serviceName: string,
   existingInstances: Array<DependentInstance> = [],
   state?: StateFile,
+  executionStatementsOverride?: IamStatement[],
 ): Promise<{
   logConfig?: { project: string; logstore: string };
   role?: { roleName: string; arn: string };
@@ -269,7 +345,7 @@ const createDependentResources = async (
       }
     } else {
       const shared = await ensureSharedSlsProject(context, client, state);
-      const logstore = await ensureFunctionLogstore(context, client, shared.projectName);
+      const logstore = await ensureFunctionLogstore(context, client, shared.projectName, fn.key);
       instances.push({
         type: 'ALIYUN_SLS_LOGSTORE',
         id: `${shared.projectName}/${logstore.logstoreName}`,
@@ -291,9 +367,11 @@ const createDependentResources = async (
   const managedPolicies =
     iamConfig && typeof iamConfig !== 'string' ? iamConfig.managed_policies : undefined;
   const customRoleName = iamConfig && typeof iamConfig !== 'string' ? iamConfig.name : undefined;
-  const defaultRoleName = `${serviceName}-${context.stage}-fc-role`;
+  const defaultRoleName = buildDefaultRoleName(serviceName, context.stage, fn.key);
 
-  const trustedServices = getTrustedServicesForFunction(context, fn.key);
+  const trustedServices = getTrustedServicesForFunction(context, fn);
+  const executionStatements =
+    executionStatementsOverride ?? deriveFc3ExecutionStatements(fn, context, logConfig);
 
   const isExternalRole = typeof iamConfig === 'string';
 
@@ -311,6 +389,10 @@ const createDependentResources = async (
     if (ramRoleInstance) {
       instances.push(ramRoleInstance);
       await client.ram.updateRoleTrustPolicy(ramRoleInstance.id, trustedServices);
+      await client.ram.updateExecutionPolicyDocument(
+        ramRoleInstance.id,
+        buildFc3ExecutionPolicyDocument(executionStatements, statements),
+      );
     }
   } else {
     const roleName = customRoleName ?? defaultRoleName;
@@ -321,6 +403,7 @@ const createDependentResources = async (
       undefined,
       statements,
       managedPolicies,
+      executionStatements,
     );
     instances.push({
       type: 'ALIYUN_RAM_ROLE',
@@ -784,7 +867,7 @@ export const createResource = async (
           throw new Error(lang.__('CERT_REFERENCE_NOT_FOUND', { reference: certId }));
         }
         certConfig = {
-          certName: `${context.service}-${context.stage}-fc3-domain`,
+          certName: buildFc3CertName(context.service, context.stage),
           certificate: detail.cert,
           privateKey: detail.key,
         };
@@ -907,6 +990,9 @@ export const updateResource = async (
   }
 
   const newIamRole = fn.iam?.role;
+  const executionStatements = deriveFc3ExecutionStatements(fn, context, logConfig);
+  const customStatements =
+    newIamRole && typeof newIamRole !== 'string' ? newIamRole.statements : undefined;
 
   if (typeof newIamRole === 'string') {
     // External role - use ARN directly, skip management
@@ -918,6 +1004,7 @@ export const updateResource = async (
       serviceName,
       undefined,
       state,
+      executionStatements,
     );
     role = deps.role;
     newDependentInstances.push(...deps.instances.filter((i) => i.type === 'ALIYUN_RAM_ROLE'));
@@ -929,8 +1016,12 @@ export const updateResource = async (
         arn: ramRoleInstance.roleArn ?? `acs:ram::${context.accountId}:role/${ramRoleInstance.id}`,
       };
 
-      const trustedServices = getTrustedServicesForFunction(context, fn.key);
+      const trustedServices = getTrustedServicesForFunction(context, fn);
       await client.ram.updateRoleTrustPolicy(ramRoleInstance.id, trustedServices);
+      await client.ram.updateExecutionPolicyDocument(
+        ramRoleInstance.id,
+        buildFc3ExecutionPolicyDocument(executionStatements, customStatements),
+      );
 
       const existingIam = existingState?.definition?.iam as Record<string, unknown> | undefined;
       const desiredIam = fn.iam;
@@ -953,6 +1044,7 @@ export const updateResource = async (
           await client.ram.updateRolePolicy(
             ramRoleInstance.id,
             desiredStatements as IamStatement[] | undefined,
+            executionStatements,
           );
         }
 
@@ -987,6 +1079,7 @@ export const updateResource = async (
       serviceName,
       undefined,
       state,
+      executionStatements,
     );
     securityGroup = deps.securityGroup;
     newDependentInstances.push(
@@ -1006,6 +1099,7 @@ export const updateResource = async (
       serviceName,
       undefined,
       state,
+      executionStatements,
     );
     nasConfig = deps.nasConfig;
     newDependentInstances.push(...deps.instances.filter((i) => i.type.startsWith('ALIYUN_NAS_')));
@@ -1187,7 +1281,7 @@ export const updateResource = async (
         throw new Error(lang.__('CERT_REFERENCE_NOT_FOUND', { reference: certId }));
       }
       certConfig = {
-        certName: `${context.service}-${context.stage}-fc3-domain`,
+        certName: buildFc3CertName(context.service, context.stage),
         certificate: detail.cert,
         privateKey: detail.key,
       };
@@ -1231,7 +1325,7 @@ export const updateResource = async (
           throw new Error(lang.__('CERT_REFERENCE_NOT_FOUND', { reference: certId }));
         }
         certConfig = {
-          certName: `${context.service}-${context.stage}-fc3-domain`,
+          certName: buildFc3CertName(context.service, context.stage),
           certificate: detail.cert,
           privateKey: detail.key,
         };

--- a/src/stack/aliyunStack/sharedLogProject.ts
+++ b/src/stack/aliyunStack/sharedLogProject.ts
@@ -1,5 +1,5 @@
 import { createAliyunClient } from '../../common/aliyunClient';
-import { getSharedResource, buildSid } from '../../common';
+import { getSharedResource, buildSid, buildConstrainedName } from '../../common';
 import type { Context, ResourceState, StateFile } from '../../types';
 import { logger } from '../../common/logger';
 import { lang } from '../../lang';
@@ -16,7 +16,28 @@ type AliyunClient = ReturnType<typeof createAliyunClient>;
  */
 export const SHARED_LOG_PROJECT_KEY = 'logs.project';
 
-export const buildSharedProjectName = (app: string, stage: string): string => `${app}-${stage}-sls`;
+const SLS_NAME_MAX_LENGTH = 63;
+
+export const buildSharedProjectName = (app: string, stage: string): string =>
+  buildConstrainedName({
+    parts: [app, stage, 'sls'],
+    maxLength: SLS_NAME_MAX_LENGTH,
+    charset: 'hyphen',
+  });
+
+export const buildFunctionLogstoreName = (service: string, stage: string, fnKey: string): string =>
+  buildConstrainedName({
+    parts: [service, stage, fnKey, 'fn-logs'],
+    maxLength: SLS_NAME_MAX_LENGTH,
+    charset: 'hyphen',
+  });
+
+export const buildGatewayLogstoreName = (service: string, stage: string): string =>
+  buildConstrainedName({
+    parts: [service, stage, 'apigw-logs'],
+    maxLength: SLS_NAME_MAX_LENGTH,
+    charset: 'hyphen',
+  });
 
 export const resolveSharedProjectName = (shared: ResourceState): string | undefined => {
   const instanceId = (shared.instances?.[0] as { id?: string } | undefined)?.id;
@@ -171,12 +192,13 @@ export const ensureFunctionLogstore = async (
   context: Context,
   client: AliyunClient,
   projectName: string,
+  fnKey: string,
 ): Promise<{ logstoreName: string }> => {
   return ensureLogstoreInSharedProject(
     context,
     client,
     projectName,
-    `${context.service}-${context.stage}-fn-logs`,
+    buildFunctionLogstoreName(context.service, context.stage, fnKey),
   );
 };
 
@@ -189,6 +211,6 @@ export const ensureGatewayLogstore = async (
     context,
     client,
     projectName,
-    `${context.service}-${context.stage}-apigw-logs`,
+    buildGatewayLogstoreName(context.service, context.stage),
   );
 };

--- a/src/stack/scfStack/scfPlanner.ts
+++ b/src/stack/scfStack/scfPlanner.ts
@@ -46,7 +46,7 @@ export const generateFunctionPlan = async (
         config = {
           ...config,
           ClsLogsetName: buildSharedLogsetName(context.app, context.stage),
-          ClsTopicName: buildFunctionTopicName(context),
+          ClsTopicName: buildFunctionTopicName(context, fn.key),
         };
       }
       const codePath = fn.code!.path;

--- a/src/stack/scfStack/scfResource.ts
+++ b/src/stack/scfStack/scfResource.ts
@@ -17,7 +17,14 @@ import {
   setSharedResource,
   removeSharedResource,
 } from '../../common/stateManager';
-import { buildSid, attributesEqual, ProviderEnum, mapAuthType, mapAccess } from '../../common';
+import {
+  buildSid,
+  attributesEqual,
+  ProviderEnum,
+  mapAuthType,
+  mapAccess,
+  buildFunctionRoleName,
+} from '../../common';
 import { RAM_ROLE_PROPAGATION_DELAY_MS } from '../../common/constants';
 import { computeZipContentHash } from '../../common/hashUtils';
 import { logger } from '../../common/logger';
@@ -341,11 +348,44 @@ const buildScfInstanceFromProvider = (info: ScfFunctionInfo, sid: string) => {
   };
 };
 
+/**
+ * Least-privilege SCF execution statements for a function's CAM role.
+ *
+ * Tencent SCF resolves its code package from COS, writes function logs to CLS,
+ * and invokes other functions via the role, so the scf/CLS/COS-GetObject
+ * actions are unconditional. The tencent FunctionDomain.storage shape carries
+ * only disk/nas — no function-level signal proves COS runtime usage — so the
+ * remaining COS actions stay alongside GetObject rather than being gated (no
+ * invented signals). The fn/context parameters are reserved for per-function
+ * derivation (e.g. COS gating) once such a signal exists.
+ */
+export const deriveScfExecutionStatements = (
+  fn: FunctionDomain,
+  context: Context,
+): IamStatement[] => {
+  void fn;
+  void context;
+  return [
+    { effect: 'Allow', action: ['scf:InvokeFunction'], resource: ['*'] },
+    {
+      effect: 'Allow',
+      action: ['cls:logset:putlog', 'cls:logset:create*', 'cls:logset:get*'],
+      resource: ['*'],
+    },
+    {
+      effect: 'Allow',
+      action: ['cos:GetObject', 'cos:PutObject', 'cos:DeleteObject', 'cos:ListBucket'],
+      resource: ['*'],
+    },
+  ];
+};
+
 const createDependentResources = async (
   context: Context,
   fn: FunctionDomain,
   existingInstances: Array<Record<string, unknown>> = [],
   state?: StateFile,
+  existingDefinition?: Record<string, unknown>,
 ): Promise<{
   role?: { roleName?: string; arn?: string };
   clsConfig?: { logsetId: string; logsetName: string; topicId: string; topicName: string };
@@ -391,7 +431,7 @@ const createDependentResources = async (
         const topic = await ensureFunctionTopic(context, client, {
           logsetId: shared.logsetId,
           logsetName: shared.logsetName,
-          topicName: buildFunctionTopicName(context),
+          topicName: buildFunctionTopicName(context, fn.key),
           logicalId: `functions.${fn.key}`,
         });
         clsInstances.push(
@@ -437,12 +477,42 @@ const createDependentResources = async (
 
   const hasCamRole = existingInstances.some((i) => i.type === 'TENCENT_SCF_ROLE');
   const serviceName = `${context.app}-${context.service}`;
-  const defaultRoleName = `${serviceName}-${context.stage}-scf-role`;
+  const defaultRoleName = buildFunctionRoleName(serviceName, context.stage, fn.key);
   const roleName = customRoleName ?? defaultRoleName;
+  const executionStatements = deriveScfExecutionStatements(fn, context);
 
   if (hasCamRole) {
-    // Role already exists - reuse it
-    return { role: { roleName, arn: roleName }, clsConfig, clsInstances, sharedInstance };
+    // Role already exists - reuse it. Keyed on the TENCENT_SCF_ROLE instance
+    // type (not the desired name), so pre-existing deployments keep the role
+    // they were created with even though the default name now includes fn.key.
+    const existingRoleInstance = existingInstances.find(
+      (i) => i.type === ResourceTypeEnum.TENCENT_SCF_ROLE && !(i as ScfDependentInstance).external,
+    ) as ScfDependentInstance | undefined;
+    const reusedRoleName = existingRoleInstance?.id ?? roleName;
+
+    // Propagate the inline policy (derived baseline + custom statements) only
+    // when the custom statements drifted from the last stored definition.
+    const desiredStatements = statements as IamStatement[] | undefined;
+    const existingRole = existingDefinition?.iam as Record<string, unknown> | undefined;
+    const existingStatements =
+      existingRole && existingRole.role && typeof existingRole.role !== 'string'
+        ? (existingRole.role as Record<string, unknown>).statements
+        : undefined;
+    if (
+      !attributesEqual(
+        (existingStatements ?? []) as unknown as Record<string, unknown>,
+        (desiredStatements ?? []) as unknown as Record<string, unknown>,
+      )
+    ) {
+      await client.cam.updateRolePolicy(reusedRoleName, desiredStatements, executionStatements);
+    }
+
+    return {
+      role: { roleName: reusedRoleName, arn: reusedRoleName },
+      clsConfig,
+      clsInstances,
+      sharedInstance,
+    };
   }
 
   // Create new CAM role
@@ -454,6 +524,7 @@ const createDependentResources = async (
     `ServerlessInsight SCF execution role for ${serviceName}`,
     statements as IamStatement[] | undefined,
     managedPolicies,
+    executionStatements,
   );
 
   await delay(RAM_ROLE_PROPAGATION_DELAY_MS);
@@ -514,6 +585,7 @@ export const createResource = async (
     fn,
     existingResourceState?.instances ?? [],
     state,
+    existingResourceState?.definition as Record<string, unknown> | undefined,
   );
 
   let config = functionToScfConfig(fn);
@@ -835,6 +907,7 @@ export const updateResource = async (
           await client.cam.updateRolePolicy(
             ramRoleInstance.id,
             desiredStatements as IamStatement[] | undefined,
+            deriveScfExecutionStatements(fn, context),
           );
         }
 
@@ -894,7 +967,7 @@ export const updateResource = async (
       const topic = await ensureFunctionTopic(context, client, {
         logsetId: logset.logsetId,
         logsetName: logset.logsetName,
-        topicName: buildFunctionTopicName(context),
+        topicName: buildFunctionTopicName(context, fn.key),
         logicalId,
       });
       clsConfig = {

--- a/src/stack/scfStack/sharedLogset.ts
+++ b/src/stack/scfStack/sharedLogset.ts
@@ -25,8 +25,16 @@ export const SHARED_LOGSET_KEY = 'logs.project';
 
 export const buildSharedLogsetName = (app: string, stage: string): string => `${app}-${stage}-cls`;
 
-export const buildFunctionTopicName = (context: Context): string =>
-  `${context.service}-${context.stage}-fn-logs`;
+/**
+ * Topic names are per-function (#214 per-owner teardown): the function key is
+ * part of the name. The fnKey-less legacy shape only matches topics created
+ * before per-function naming — used by legacy-state branches and delete
+ * fallbacks where the actual topic predates this scheme.
+ */
+export const buildFunctionTopicName = (context: Context, fnKey?: string): string =>
+  fnKey
+    ? `${context.service}-${context.stage}-${fnKey}-fn-logs`
+    : `${context.service}-${context.stage}-fn-logs`;
 
 const resolveSharedLogsetName = (shared: ResourceState): string | undefined => {
   const instanceId = (shared.instances?.[0] as { id?: string } | undefined)?.id;

--- a/src/stack/volcengineStack/apigwPlanner.ts
+++ b/src/stack/volcengineStack/apigwPlanner.ts
@@ -34,7 +34,14 @@ export const generateApigwPlan = async (
       const currentState = getResource(state, logicalId);
       const client = createVolcengineClient(context);
 
-      const desiredDefinition = buildEventResourceDefinition(event);
+      // Stored-first: an existing event keeps its recorded topic name so the
+      // desired definition never phantom-drifts against legacy state.
+      const storedTlsTopic = currentState?.instances?.find(
+        (i) => (i as { type?: string }).type === 'VOLCENGINE_TLS_TOPIC',
+      ) as { id?: string } | undefined;
+      const storedTopicName = storedTlsTopic?.id?.split('/')[1];
+
+      const desiredDefinition = buildEventResourceDefinition(event, storedTopicName);
 
       if (!currentState || currentState.status === 'tainted') {
         // No usable local state: probe the provider before planning create.

--- a/src/stack/volcengineStack/apigwResource.ts
+++ b/src/stack/volcengineStack/apigwResource.ts
@@ -70,11 +70,20 @@ const buildGatewayInstance = (info: ApigwGatewayInfo, stage: string): ResourceIn
   resourceSpec: info.resourceSpec ?? null,
 });
 
+const resolveTlsTopicNameFromInstances = (
+  instances: Array<ResourceInstance>,
+): string | undefined => {
+  const tlsTopic = instances.find((i) => i.type === 'VOLCENGINE_TLS_TOPIC') as
+    { id?: string } | undefined;
+  return tlsTopic?.id?.split('/')[1];
+};
+
 const ensureApigwLogResources = async (
   context: Context,
   existingInstances: Array<ResourceInstance>,
   state: StateFile,
   logicalId: string,
+  eventKey: string,
 ): Promise<{
   projectId: string;
   topicId: string;
@@ -98,7 +107,7 @@ const ensureApigwLogResources = async (
   // Shared app-scoped TLS project (#214) with a per-event topic nested under it.
   const shared = await ensureSharedLogProject(context, client, state);
   const sharedInstance = buildSharedProjectResourceState(context, shared);
-  const topicName = buildApigwLogTopicName(context.service, context.stage);
+  const topicName = buildApigwLogTopicName(context.service, context.stage, eventKey);
   const topic = await ensureOwnedTopic(context, client, {
     projectName: shared.projectName,
     topicName,
@@ -301,6 +310,7 @@ export const createApigwResource = async (
       existingInstances,
       state,
       logicalId,
+      event.key,
     );
     if (logResources.sharedInstance) {
       state = setSharedResource(state, context.stage, 'logs.project', logResources.sharedInstance);
@@ -348,7 +358,7 @@ export const createApigwResource = async (
   const partialResourceState: ResourceState = {
     mode: 'managed',
     region: context.region,
-    definition: buildEventResourceDefinition(event),
+    definition: buildEventResourceDefinition(event, resolveTlsTopicNameFromInstances(instances)),
     instances,
     status: 'tainted',
     lastUpdated: new Date().toISOString(),
@@ -444,7 +454,7 @@ export const createApigwResource = async (
   const finalResourceState: ResourceState = {
     mode: 'managed',
     region: context.region,
-    definition: buildEventResourceDefinition(event),
+    definition: buildEventResourceDefinition(event, resolveTlsTopicNameFromInstances(instances)),
     instances,
     status: 'ready',
     lastUpdated: new Date().toISOString(),
@@ -493,6 +503,7 @@ export const updateApigwResource = async (
         existingState.instances,
         state,
         `events.${event.key}`,
+        event.key,
       );
       if (logResources.sharedInstance) {
         state = setSharedResource(
@@ -601,7 +612,7 @@ export const updateApigwResource = async (
   const resourceState: ResourceState = {
     mode: 'managed',
     region: context.region,
-    definition: buildEventResourceDefinition(event),
+    definition: buildEventResourceDefinition(event, resolveTlsTopicNameFromInstances(instances)),
     instances,
     lastUpdated: new Date().toISOString(),
   };

--- a/src/stack/volcengineStack/apigwResource.ts
+++ b/src/stack/volcengineStack/apigwResource.ts
@@ -7,6 +7,7 @@ import {
   PartialResourceError,
 } from '../../types';
 import { createVolcengineClient } from '../../common/volcengineClient';
+import type { VolcengineClient } from '../../common/volcengineClient/types';
 import { getContext } from '../../common';
 import type {
   ApigwGatewayConfig,
@@ -219,27 +220,47 @@ const buildRouteInstance = (
 });
 
 /**
- * Resolve the veFaaS function Id for a backend ref from state. Template refs
- * carry the key directly; bare values are the deployed function name and are
- * mapped to the template key first. The function resource must already be
- * deployed (functions deploy before events).
+ * Resolve the veFaaS function Id for a backend ref. Template refs carry the
+ * key directly; bare values are the deployed function name — mapped to the
+ * template key first, then resolved from state. A bare name matching no
+ * template function is an EXTERNAL deployed function: its Id is resolved
+ * from the provider by name (same account/region, function must exist).
  */
-const resolveFunctionIdFromState = (state: StateFile, backendRef: string): string => {
+const resolveFunctionIdFromState = async (
+  state: StateFile,
+  backendRef: string,
+  client: VolcengineClient,
+): Promise<string> => {
   const context = getContext();
   const refMatch = /^\$\{functions\.([\w.]+)\}$/.exec(String(backendRef ?? ''));
+  const templateKey = refMatch?.[1];
   const fnKey =
-    refMatch?.[1] ?? context.iac?.functions?.find((f) => f.name === String(backendRef))?.key;
-  const fnState = fnKey ? getResource(state, `functions.${fnKey}`) : undefined;
-  const instance = fnState?.instances?.find((i) => i.type === 'VOLCENGINE_VEFAAS_FUNCTION');
-  const functionId = (instance as { functionId?: string | null } | undefined)?.functionId;
-  if (!functionId) {
+    templateKey ?? context.iac?.functions?.find((f) => f.name === String(backendRef))?.key;
+
+  if (fnKey) {
+    const fnState = getResource(state, `functions.${fnKey}`);
+    const instance = fnState?.instances?.find((i) => i.type === 'VOLCENGINE_VEFAAS_FUNCTION');
+    const functionId = (instance as { functionId?: string | null } | undefined)?.functionId;
+    if (functionId) {
+      return functionId;
+    }
+    if (templateKey) {
+      // Template function with no state Id: deploy failed or state is stale —
+      // do not mask it by adopting a same-named foreign function.
+      throw new Error(
+        `Cannot resolve veFaaS function Id for backend ${backendRef} (functions.${fnKey} has no functionId in state). Deploy the function first.`,
+      );
+    }
+  }
+
+  const external = await client.vefaas.getFunction(String(backendRef ?? ''));
+  const externalId = external?.functionId;
+  if (!externalId) {
     throw new Error(
-      `Cannot resolve veFaaS function Id for backend ${backendRef}${
-        fnKey ? ` (functions.${fnKey})` : ''
-      } — no functionId in state. Deploy the function first. External functions (not defined in this template) are not supported for volcengine API Gateway backends.`,
+      lang.__('EXTERNAL_FUNCTION_NOT_FOUND_VOLCENGINE', { backendRef: String(backendRef ?? '') }),
     );
   }
-  return functionId;
+  return externalId;
 };
 
 export const createApigwResource = async (
@@ -383,7 +404,7 @@ export const createApigwResource = async (
 
       let upstreamId = upstreamByFunction.get(fnKey);
       if (!upstreamId) {
-        const functionId = resolveFunctionIdFromState(state, backendRef);
+        const functionId = await resolveFunctionIdFromState(state, backendRef, client);
         const upstreamName = buildUpstreamName(event, backendRef, context.stage);
         const existingUpstream = await client.apigw.findUpstreamByName(gatewayId, upstreamName);
         if (existingUpstream?.upstreamId) {
@@ -558,7 +579,7 @@ export const updateApigwResource = async (
 
     for (const trigger of event.triggers) {
       const backendRef = String(trigger.backend);
-      const functionId = resolveFunctionIdFromState(state, backendRef);
+      const functionId = await resolveFunctionIdFromState(state, backendRef, client);
 
       let upstreamId = upstreamByFunction.get(functionId);
       if (!upstreamId) {

--- a/src/stack/volcengineStack/apigwResource.ts
+++ b/src/stack/volcengineStack/apigwResource.ts
@@ -21,6 +21,7 @@ import {
   triggerToApigwUpstreamConfig,
   triggerToApigwRouteConfig,
   buildEventResourceDefinition,
+  buildUpstreamName,
   resolveFunctionKey,
 } from './apigwTypes';
 import {
@@ -42,6 +43,7 @@ import {
   ensureOwnedTopic,
   deleteTlsLogResources,
   buildSharedProjectName,
+  buildApigwLogTopicName,
   releaseSharedLogProjectIfUnused,
   SHARED_LOG_PROJECT_KEY,
 } from './sharedLogProject';
@@ -96,7 +98,7 @@ const ensureApigwLogResources = async (
   // Shared app-scoped TLS project (#214) with a per-event topic nested under it.
   const shared = await ensureSharedLogProject(context, client, state);
   const sharedInstance = buildSharedProjectResourceState(context, shared);
-  const topicName = `${context.service}-${context.stage}-apigw-logs`;
+  const topicName = buildApigwLogTopicName(context.service, context.stage);
   const topic = await ensureOwnedTopic(context, client, {
     projectName: shared.projectName,
     topicName,
@@ -364,7 +366,7 @@ export const createApigwResource = async (
       let upstreamId = upstreamByFunction.get(fnKey);
       if (!upstreamId) {
         const functionId = resolveFunctionIdFromState(state, backendRef);
-        const upstreamName = `${event.name}-${context.stage}-upstream-${fnKey.replace(/_/g, '-')}`;
+        const upstreamName = buildUpstreamName(event, backendRef, context.stage);
         const existingUpstream = await client.apigw.findUpstreamByName(gatewayId, upstreamName);
         if (existingUpstream?.upstreamId) {
           upstreamId = existingUpstream.upstreamId;
@@ -537,12 +539,11 @@ export const updateApigwResource = async (
 
     for (const trigger of event.triggers) {
       const backendRef = String(trigger.backend);
-      const fnKey = resolveFunctionKey(backendRef);
       const functionId = resolveFunctionIdFromState(state, backendRef);
 
       let upstreamId = upstreamByFunction.get(functionId);
       if (!upstreamId) {
-        const upstreamName = `${event.name}-${context.stage}-upstream-${fnKey.replace(/_/g, '-')}`;
+        const upstreamName = buildUpstreamName(event, backendRef, context.stage);
         const existing = await client.apigw.findUpstreamByName(
           serviceInstance.gatewayId as string,
           upstreamName,

--- a/src/stack/volcengineStack/apigwResource.ts
+++ b/src/stack/volcengineStack/apigwResource.ts
@@ -7,6 +7,7 @@ import {
   PartialResourceError,
 } from '../../types';
 import { createVolcengineClient } from '../../common/volcengineClient';
+import { getContext } from '../../common';
 import type {
   ApigwGatewayConfig,
   ApigwGatewayInfo,
@@ -218,17 +219,24 @@ const buildRouteInstance = (
 });
 
 /**
- * Resolve the veFaaS function Id for a ${functions.xxx} backend ref from state.
- * The function resource must already be deployed (functions deploy before events).
+ * Resolve the veFaaS function Id for a backend ref from state. Template refs
+ * carry the key directly; bare values are the deployed function name and are
+ * mapped to the template key first. The function resource must already be
+ * deployed (functions deploy before events).
  */
 const resolveFunctionIdFromState = (state: StateFile, backendRef: string): string => {
-  const fnKey = resolveFunctionKey(backendRef);
-  const fnState = getResource(state, `functions.${fnKey}`);
+  const context = getContext();
+  const refMatch = /^\$\{functions\.([\w.]+)\}$/.exec(String(backendRef ?? ''));
+  const fnKey =
+    refMatch?.[1] ?? context.iac?.functions?.find((f) => f.name === String(backendRef))?.key;
+  const fnState = fnKey ? getResource(state, `functions.${fnKey}`) : undefined;
   const instance = fnState?.instances?.find((i) => i.type === 'VOLCENGINE_VEFAAS_FUNCTION');
   const functionId = (instance as { functionId?: string | null } | undefined)?.functionId;
   if (!functionId) {
     throw new Error(
-      `Cannot resolve veFaaS function Id for backend ${backendRef} (functions.${fnKey} has no functionId in state). Deploy the function first.`,
+      `Cannot resolve veFaaS function Id for backend ${backendRef}${
+        fnKey ? ` (functions.${fnKey})` : ''
+      } — no functionId in state. Deploy the function first. External functions (not defined in this template) are not supported for volcengine API Gateway backends.`,
     );
   }
   return functionId;

--- a/src/stack/volcengineStack/apigwTypes.ts
+++ b/src/stack/volcengineStack/apigwTypes.ts
@@ -13,6 +13,8 @@ import type {
 } from '../../common/volcengineClient/types';
 import type { EventDomain, ResourceAttributes } from '../../types';
 import { lang } from '../../lang';
+import { OWNERSHIP_TAG_KEY } from '../ownershipTag';
+import { buildSharedProjectName, buildApigwLogTopicName } from './sharedLogProject';
 
 /**
  * Gateway instance name — reused for find-by-name adoption across deploys.
@@ -38,6 +40,8 @@ export const buildRouteName = (event: EventDomain, method: string, path: string)
 /**
  * Resolves a function reference like ${functions.xxx} to the actual function name
  */
+const FUNCTION_REF_PATTERN = /^\$\{functions\.[\w.]+\}$/;
+
 const resolveFunctionReference = (backendRef: string): string => {
   const context = getContext();
   if (!context.iac) {
@@ -48,7 +52,13 @@ const resolveFunctionReference = (backendRef: string): string => {
   const functionDef = getIacDefinition(context.iac, backendRef);
 
   if (!functionDef || !isFunctionDomain(functionDef)) {
-    logger.warn(lang.__('FUNCTION_REF_NOT_RESOLVED', { backendRef }));
+    // Dangling template refs fail semantic validation; a bare value that matches
+    // no template function is an external deployed function name (issue #227).
+    if (FUNCTION_REF_PATTERN.test(backendRef)) {
+      logger.warn(lang.__('FUNCTION_REF_NOT_RESOLVED', { backendRef }));
+    } else {
+      logger.info(lang.__('EXTERNAL_FUNCTION_BACKEND', { backendRef }));
+    }
     return backendRef;
   }
 
@@ -76,7 +86,7 @@ export const eventToApigwGatewayConfig = (
       network: { vpcId: event.network.vpc_id, subnetIds: event.network.subnet_ids },
     }),
     logConfig: event.log ? { enable: true, projectId: '', topicId: '' } : undefined,
-    Tags: [{ Key: 'si-owned-by', Value: ownershipValue }],
+    Tags: [{ Key: OWNERSHIP_TAG_KEY, Value: ownershipValue }],
   };
 };
 
@@ -146,8 +156,8 @@ export const extractEventDomainDefinition = (
     ...(event.log && context
       ? {
           logConfig: {
-            project: `${context.app}-${context.stage}-tls`,
-            topic: `${context.service}-${context.stage}-apigw-logs`,
+            project: buildSharedProjectName(context.app, context.stage),
+            topic: buildApigwLogTopicName(context.service, context.stage),
           },
         }
       : {}),

--- a/src/stack/volcengineStack/apigwTypes.ts
+++ b/src/stack/volcengineStack/apigwTypes.ts
@@ -138,6 +138,7 @@ export const triggerToApigwRouteConfig = (
 
 export const extractEventDomainDefinition = (
   event: EventDomain,
+  logTopicOverride?: string,
 ): {
   gatewayName: string;
   network?: { vpcId: string; subnetIds: string[] };
@@ -157,7 +158,9 @@ export const extractEventDomainDefinition = (
       ? {
           logConfig: {
             project: buildSharedProjectName(context.app, context.stage),
-            topic: buildApigwLogTopicName(context.service, context.stage),
+            topic:
+              logTopicOverride ??
+              buildApigwLogTopicName(context.service, context.stage, String(event.key)),
           },
         }
       : {}),
@@ -177,8 +180,11 @@ export const extractEventDomainDefinition = (
 
 export type EventDomainDefinition = ReturnType<typeof extractEventDomainDefinition>;
 
-export const buildEventResourceDefinition = (event: EventDomain): ResourceAttributes => {
-  return extractEventDomainDefinition(event) as unknown as ResourceAttributes;
+export const buildEventResourceDefinition = (
+  event: EventDomain,
+  logTopicOverride?: string,
+): ResourceAttributes => {
+  return extractEventDomainDefinition(event, logTopicOverride) as unknown as ResourceAttributes;
 };
 
 export { resolveFunctionReference };

--- a/src/stack/volcengineStack/sharedLogProject.ts
+++ b/src/stack/volcengineStack/sharedLogProject.ts
@@ -22,6 +22,13 @@ export const SHARED_LOG_PROJECT_KEY = 'logs.project';
 
 export const buildSharedProjectName = (app: string, stage: string): string => `${app}-${stage}-tls`;
 
+/** Per-function fn-logs topic (#214 per-owner teardown): the function key is part of the name. */
+export const buildFunctionLogTopicName = (service: string, stage: string, fnKey: string): string =>
+  `${service}-${stage}-${fnKey}-fn-logs`;
+
+export const buildApigwLogTopicName = (service: string, stage: string): string =>
+  `${service}-${stage}-apigw-logs`;
+
 const resolveSharedProjectName = (shared: ResourceState): string | undefined => {
   const instanceId = (shared.instances?.[0] as { id?: string } | undefined)?.id;
   return instanceId ?? (shared.definition as { projectName?: string } | undefined)?.projectName;
@@ -162,8 +169,8 @@ export const ensureOwnedTopic = async (
 
   const existing = await client.tls.getTopic(projectName, topicName);
   if (existing) {
-    // Service-scoped topics are shared across a service's functions/events, so
-    // ownership is verified at the owning-stack level, not per logical id.
+    // fn-logs topics are per-function (the key is in the name); the apigw topic
+    // stays service-scoped. Adoption verifies the owning stack either way.
     const tag = (existing.tags ?? []).find((t) => t.Key === OWNERSHIP_TAG_KEY);
     const parsed = parseOwnershipTagValue(tag?.Value);
     if (parsed?.stack === `${context.app}-${context.service}`) {

--- a/src/stack/volcengineStack/sharedLogProject.ts
+++ b/src/stack/volcengineStack/sharedLogProject.ts
@@ -26,8 +26,9 @@ export const buildSharedProjectName = (app: string, stage: string): string => `$
 export const buildFunctionLogTopicName = (service: string, stage: string, fnKey: string): string =>
   `${service}-${stage}-${fnKey}-fn-logs`;
 
-export const buildApigwLogTopicName = (service: string, stage: string): string =>
-  `${service}-${stage}-apigw-logs`;
+/** Per-event apigw-logs topic (#214 per-owner teardown): the event key is part of the name. */
+export const buildApigwLogTopicName = (service: string, stage: string, eventKey: string): string =>
+  `${service}-${stage}-${eventKey}-apigw-logs`;
 
 const resolveSharedProjectName = (shared: ResourceState): string | undefined => {
   const instanceId = (shared.instances?.[0] as { id?: string } | undefined)?.id;

--- a/src/stack/volcengineStack/vefaasPlanner.ts
+++ b/src/stack/volcengineStack/vefaasPlanner.ts
@@ -10,6 +10,7 @@ import {
   StateFile,
 } from '../../types';
 import { extractVefaasDefinition, functionToVefaasConfig } from './vefaasTypes';
+import { buildSharedProjectName, buildFunctionLogTopicName } from './sharedLogProject';
 import { OWNERSHIP_TAG_KEY, isOwnedByStack } from '../ownershipTag';
 
 const planFunctionDeletion = (logicalId: string, definition: ResourceAttributes): PlanItem => ({
@@ -65,7 +66,7 @@ export const generateFunctionPlan = async (
       // planner would report `noop` forever, so `UpdateFunction`'s `TlsConfig`
       // never gets sent. Derive the same project/topic names the executor
       // would use (shared stage slot → tracked topic instance → deterministic
-      // shared names `${app}-${stage}-tls` / `${service}-${stage}-fn-logs`) so
+      // names `${app}-${stage}-tls` / `${service}-${stage}-${fn.key}-fn-logs`) so
       // the diff can see the field change without phantom drift.
       if (fn.log) {
         const tlsTopicInstance = currentState?.instances?.find(
@@ -81,13 +82,13 @@ export const generateFunctionPlan = async (
           if (projectName) {
             config.logConfig = {
               project: projectName,
-              topic: `${context.service}-${context.stage}-fn-logs`,
+              topic: buildFunctionLogTopicName(context.service, context.stage, fn.key),
             };
           }
         } else {
           config.logConfig = {
-            project: `${context.app}-${context.stage}-tls`,
-            topic: `${context.service}-${context.stage}-fn-logs`,
+            project: buildSharedProjectName(context.app, context.stage),
+            topic: buildFunctionLogTopicName(context.service, context.stage, fn.key),
           };
         }
       }

--- a/src/stack/volcengineStack/vefaasResource.ts
+++ b/src/stack/volcengineStack/vefaasResource.ts
@@ -1,5 +1,6 @@
 import { createVolcengineClient } from '../../common/volcengineClient';
 import {
+  getAllResources,
   getResource,
   removeResource,
   setResource,
@@ -11,6 +12,7 @@ import {
   attributesEqual,
   buildFunctionRoleName,
 } from '../../common';
+import { unionPolicyStatements } from '../../common/iamStatements';
 import {
   Context,
   FunctionDomain,
@@ -209,6 +211,78 @@ const buildVefaasInstanceFromProvider = (
   };
 };
 
+type RolePeer = { fn: FunctionDomain; hadVpc: boolean; hadTosMount: boolean };
+
+const collectRolePeers = (state: StateFile, context: Context, roleId: string): RolePeer[] => {
+  const peers: RolePeer[] = [];
+  for (const [logicalId, resourceState] of Object.entries(getAllResources(state))) {
+    if (!logicalId.startsWith('functions.')) continue;
+    const roleInstance = resourceState.instances?.find(
+      (i) => (i as { type?: string }).type === 'VOLCENGINE_IAM_ROLE',
+    ) as { id?: string } | undefined;
+    if (roleInstance?.id !== roleId) continue;
+    const fn = context.iac?.functions?.find(
+      (candidate) => candidate.key === logicalId.slice('functions.'.length),
+    );
+    if (!fn) continue;
+    const definition = (resourceState.definition ?? {}) as {
+      vpcConfig?: unknown;
+      tosMountConfig?: unknown;
+    };
+    peers.push({
+      fn,
+      hadVpc: Boolean(definition.vpcConfig),
+      hadTosMount: Boolean(definition.tosMountConfig),
+    });
+  }
+  return peers;
+};
+
+/**
+ * Legacy shared roles serve every function that recorded them, so their trust
+ * and derived policy must be the union across those functions — a single
+ * function's update would otherwise strip another function's requirements.
+ */
+const resolveRoleGrant = (
+  context: Context,
+  state: StateFile | undefined,
+  fn: FunctionDomain,
+  roleId: string,
+): {
+  trustedServices: string[];
+  executionStatements: IamStatement[];
+  derivedBaselineChanged: boolean;
+} => {
+  const storedPeers = state ? collectRolePeers(state, context, roleId) : [];
+  const currentStored = storedPeers.find((peer) => peer.fn.key === fn.key);
+  const peers: RolePeer[] = currentStored
+    ? [...storedPeers]
+    : [{ fn, hadVpc: false, hadTosMount: false }, ...storedPeers];
+
+  const desiredVpc = peers.some((peer) => Boolean(peer.fn.network));
+  const desiredTos = peers.some((peer) => Boolean(peer.fn.storage?.nas?.[0]));
+  const derivedBaselineChanged =
+    desiredVpc !== peers.some((peer) => peer.hadVpc) ||
+    desiredTos !== peers.some((peer) => peer.hadTosMount);
+
+  if (peers.length <= 1) {
+    return {
+      trustedServices: getTrustedServicesForFunction(fn, context),
+      executionStatements: deriveVefaasExecutionStatements(fn, context),
+      derivedBaselineChanged,
+    };
+  }
+  return {
+    trustedServices: [
+      ...new Set(peers.map((peer) => getTrustedServicesForFunction(peer.fn, context)).flat()),
+    ],
+    executionStatements: unionPolicyStatements(
+      peers.map((peer) => deriveVefaasExecutionStatements(peer.fn, context)),
+    ),
+    derivedBaselineChanged,
+  };
+};
+
 const createDependentResources = async (
   context: Context,
   fn: FunctionDomain,
@@ -286,9 +360,15 @@ const createDependentResources = async (
     const iamRoleInstance = existingInstances.find((i) => i.type === 'VOLCENGINE_IAM_ROLE');
     if (iamRoleInstance) {
       instances.push(iamRoleInstance);
+      const roleGrant = resolveRoleGrant(context, state, fn, iamRoleInstance.id);
       await client.iam.updateRoleTrustPolicy(
         iamRoleInstance.id,
-        buildDefaultTrustPolicy(trustedServices),
+        buildDefaultTrustPolicy(roleGrant.trustedServices),
+      );
+      await client.iam.updateRolePolicy(
+        iamRoleInstance.id,
+        roleGrant.executionStatements,
+        statements as IamStatement[] | undefined,
       );
     }
   } else {
@@ -651,7 +731,10 @@ export const updateResource = async (
     newDependentInstances.push(...deps.instances.filter((i) => i.type === 'VOLCENGINE_IAM_ROLE'));
   } else {
     const iamRoleInstance = existingInstances.find((i) => i.type === 'VOLCENGINE_IAM_ROLE');
-    if (iamRoleInstance) {
+    const roleGrant = iamRoleInstance
+      ? resolveRoleGrant(context, state, fn, iamRoleInstance.id)
+      : undefined;
+    if (iamRoleInstance && roleGrant) {
       const trn = await resolveRoleTrn(client, context, iamRoleInstance.id, iamRoleInstance.trn);
 
       if (!trn) {
@@ -663,10 +746,9 @@ export const updateResource = async (
         trn,
       };
 
-      const trustedServices = getTrustedServicesForFunction(fn, context);
       await client.iam.updateRoleTrustPolicy(
         iamRoleInstance.id,
-        buildDefaultTrustPolicy(trustedServices),
+        buildDefaultTrustPolicy(roleGrant.trustedServices),
       );
     }
 
@@ -681,17 +763,17 @@ export const updateResource = async (
     const customStatementsChanged =
       JSON.stringify(currentStatementList) !== JSON.stringify(desiredIamStatements);
 
-    // The derived execution baseline depends only on whether the function
-    // configures a network / TOS mount. The last deployed state records those
-    // as vpcConfig / tosMountConfig, so presence comparison detects drift.
-    const existingDefinition = currentState.definition ?? {};
-    const derivedBaselineChanged =
-      Boolean(fn.network) !== Boolean(existingDefinition.vpcConfig) ||
-      Boolean(fn.storage?.nas?.[0]) !== Boolean(existingDefinition.tosMountConfig);
+    // The derived execution baseline is the union across all functions sharing
+    // the role: drift is detected by comparing desired peer signals (network /
+    // TOS mount) against those recorded in each stored definition.
+    const derivedBaselineChanged = roleGrant?.derivedBaselineChanged ?? false;
 
     if ((derivedBaselineChanged || customStatementsChanged) && iamRoleInstance) {
-      const baseline = deriveVefaasExecutionStatements(fn, context);
-      await client.iam.updateRolePolicy(iamRoleInstance.id, baseline, desiredIamStatements);
+      await client.iam.updateRolePolicy(
+        iamRoleInstance.id,
+        roleGrant?.executionStatements ?? deriveVefaasExecutionStatements(fn, context),
+        desiredIamStatements,
+      );
     }
 
     // Check managed policy changes

--- a/src/stack/volcengineStack/vefaasResource.ts
+++ b/src/stack/volcengineStack/vefaasResource.ts
@@ -9,6 +9,7 @@ import {
   computeZipContentHash,
   buildSid,
   attributesEqual,
+  buildFunctionRoleName,
 } from '../../common';
 import {
   Context,
@@ -23,6 +24,7 @@ import {
   functionToVefaasConfig,
   getTrustedServicesForFunction,
   buildDefaultTrustPolicy,
+  deriveVefaasExecutionStatements,
   VefaasFunctionInfo,
 } from './vefaasTypes';
 import type { IamStatement } from '../../common/iamStatements';
@@ -37,6 +39,7 @@ import {
   deleteTlsLogResources,
   releaseSharedLogProjectIfUnused,
   SHARED_LOG_PROJECT_KEY,
+  buildFunctionLogTopicName,
 } from './sharedLogProject';
 
 type DependentInstance = {
@@ -241,7 +244,7 @@ const createDependentResources = async (
       const shared = await ensureSharedLogProject(context, client, state);
       sharedInstance = buildSharedProjectResourceState(context, shared);
 
-      const topicName = `${context.service}-${context.stage}-fn-logs`;
+      const topicName = buildFunctionLogTopicName(context.service, context.stage, fn.key);
       const topic = await ensureOwnedTopic(context, client, {
         projectName: shared.projectName,
         topicName,
@@ -275,8 +278,9 @@ const createDependentResources = async (
     return { logConfig, role, instances, sharedInstance };
   }
 
-  const roleName = customRoleName ?? `${serviceName}-${context.stage}-role`;
+  const roleName = customRoleName ?? buildFunctionRoleName(serviceName, context.stage, fn.key);
   const trustedServices = getTrustedServicesForFunction(fn, context);
+  const executionStatements = deriveVefaasExecutionStatements(fn, context);
 
   if (hasIamRole) {
     const iamRoleInstance = existingInstances.find((i) => i.type === 'VOLCENGINE_IAM_ROLE');
@@ -294,6 +298,7 @@ const createDependentResources = async (
       displayName: roleName,
       description: `veFaaS execution role for ${serviceName}`,
       trustPolicy: buildDefaultTrustPolicy(trustedServices),
+      executionStatements,
       customStatements: statements as IamStatement[] | undefined,
       managedPolicies,
     });
@@ -638,11 +643,10 @@ export const updateResource = async (
     // External role - skip role management, use TRN directly
     role = { roleName: currentIam.role as string, trn: currentIam.role as string };
   } else if (!hasIamRole && !isTainted) {
-    const deps = await createDependentResources(
-      context,
-      { ...fn, log: false, network: undefined, storage: { disk: undefined, nas: undefined } },
-      serviceName,
-    );
+    // Role creation only: skip TLS so existing log resources are untouched,
+    // but keep network/storage so the derived execution baseline matches the
+    // function's actual VPC/TOS usage.
+    const deps = await createDependentResources(context, { ...fn, log: false }, serviceName);
     role = deps.role;
     newDependentInstances.push(...deps.instances.filter((i) => i.type === 'VOLCENGINE_IAM_ROLE'));
   } else {
@@ -674,10 +678,20 @@ export const updateResource = async (
 
     const desiredIamStatements = desiredRoleConfig?.statements as IamStatement[] | undefined;
     const currentStatementList = currentRoleConfig?.statements as IamStatement[] | undefined;
-    const iamChanged =
+    const customStatementsChanged =
       JSON.stringify(currentStatementList) !== JSON.stringify(desiredIamStatements);
-    if (iamChanged && iamRoleInstance) {
-      await client.iam.updateRolePolicy(iamRoleInstance.id, desiredIamStatements);
+
+    // The derived execution baseline depends only on whether the function
+    // configures a network / TOS mount. The last deployed state records those
+    // as vpcConfig / tosMountConfig, so presence comparison detects drift.
+    const existingDefinition = currentState.definition ?? {};
+    const derivedBaselineChanged =
+      Boolean(fn.network) !== Boolean(existingDefinition.vpcConfig) ||
+      Boolean(fn.storage?.nas?.[0]) !== Boolean(existingDefinition.tosMountConfig);
+
+    if ((derivedBaselineChanged || customStatementsChanged) && iamRoleInstance) {
+      const baseline = deriveVefaasExecutionStatements(fn, context);
+      await client.iam.updateRolePolicy(iamRoleInstance.id, baseline, desiredIamStatements);
     }
 
     // Check managed policy changes

--- a/src/stack/volcengineStack/vefaasTypes.ts
+++ b/src/stack/volcengineStack/vefaasTypes.ts
@@ -1,5 +1,8 @@
-import { FunctionDomain } from '../../types';
+import { Context, FunctionDomain } from '../../types';
 import type { VefaasFunctionConfig, VefaasRuntime } from '../../common/volcengineClient/types';
+import type { IamStatement } from '../../common/iamStatements';
+
+const TEMPLATE_REF_PATTERN = /^\$\{[^}]+\}$/;
 
 export type VefaasFunctionDefinition = {
   functionName: string;
@@ -103,19 +106,41 @@ export type VefaasFunctionInfo = {
 /**
  * Determines which Volcengine services should be trusted to assume the function's IAM role.
  *
- * IMPORTANT: `trigger.backend` is expected to be an *unresolved* YAML reference string in the
- * form `${functions.<functionKey>}` (e.g. `${functions.my_fn}`). This function compares against
- * that raw string — NOT against a resolved function name or ARN. If the backend value has already
- * been resolved to a function name, this check will silently return false and `apigateway` will
- * NOT be added to the trust policy, breaking API Gateway invocation.
+ * Backend semantics (issue #227): `${functions.<key>}` references a template function
+ * by key; a bare value is the function's *deployed name* — either a template function
+ * referenced by name or an external function defined outside this template. External
+ * backends still need apigateway trust: the gateway assumes this managed role as its
+ * invocation identity.
  */
 const getTrustedServicesForFunction = (
   fn: FunctionDomain,
-  context: { iac?: { events?: Array<{ triggers?: Array<{ backend?: string }> }> } },
+  context: {
+    iac?: {
+      events?: Array<{ triggers?: Array<{ backend?: string }> }>;
+      functions?: Array<{ key: string; name?: string }>;
+    };
+  },
 ): string[] => {
+  const templateFunctions = context.iac?.functions ?? [];
+  const templateKeys = new Set(templateFunctions.map((templateFn) => templateFn.key));
+  const templateNames = new Set(
+    templateFunctions
+      .map((templateFn) => templateFn.name)
+      .filter((name): name is string => name !== undefined),
+  );
   const expectedBackendRef = `\${functions.${fn.key}}`;
   const hasApiGateway = context.iac?.events?.some((event) =>
-    event.triggers?.some((trigger) => String(trigger.backend) === expectedBackendRef),
+    event.triggers?.some((trigger) => {
+      const backend = String(trigger.backend);
+      if (backend === expectedBackendRef || backend === fn.name) {
+        return true;
+      }
+      return (
+        !TEMPLATE_REF_PATTERN.test(backend) &&
+        !templateKeys.has(backend) &&
+        !templateNames.has(backend)
+      );
+    }),
   );
   return hasApiGateway ? ['vefaas', 'apigateway'] : ['vefaas'];
 };
@@ -197,6 +222,44 @@ export const buildDefaultTrustPolicy = (
       },
     ],
   };
+};
+
+/**
+ * Derive the least-privilege execution policy statements for a veFaaS function.
+ *
+ * The baseline is always the platform runtime (vefaas) plus the function
+ * logging (tls) statement sets; VPC-describe statements are only added when
+ * the function configures a network, and TOS-object statements only when it
+ * mounts TOS storage. Conditions mirror the truthiness used when mapping the
+ * function into a VefaasFunctionConfig (see vefaasResource).
+ */
+export const deriveVefaasExecutionStatements = (
+  fn: FunctionDomain,
+  _context: Context,
+): IamStatement[] => {
+  const vefaasBaseline: IamStatement[] = [
+    { effect: 'Allow', action: ['vefaas:*'], resource: ['*'] },
+    {
+      effect: 'Allow',
+      action: ['tls:CreateProject', 'tls:CreateTopic', 'tls:PutLogs'],
+      resource: ['*'],
+    },
+  ];
+  const vpcStatement: IamStatement = {
+    effect: 'Allow',
+    action: ['vpc:DescribeVpcs', 'vpc:DescribeSubnets', 'vpc:DescribeSecurityGroups'],
+    resource: ['*'],
+  };
+  const tosStatement: IamStatement = {
+    effect: 'Allow',
+    action: ['tos:GetObject', 'tos:PutObject', 'tos:DeleteObject', 'tos:ListBucket'],
+    resource: ['*'],
+  };
+  return [
+    ...vefaasBaseline,
+    ...(fn.network ? [vpcStatement] : []),
+    ...(fn.storage?.nas?.[0] ? [tosStatement] : []),
+  ];
 };
 
 export { getTrustedServicesForFunction };

--- a/src/validator/semanticValidation.ts
+++ b/src/validator/semanticValidation.ts
@@ -140,6 +140,19 @@ export const validateSemantics = (iacJson: ServerlessIacRaw): Array<ErrorObject>
               eventKey,
             }),
           });
+        } else if (providerName === 'volcengine') {
+          // Volcengine upstreams require a si-managed functionId from state —
+          // external deployed functions cannot be wired as backends there.
+          errors.push({
+            instancePath,
+            schemaPath: '#/semantic/externalBackendUnsupported',
+            keyword: 'externalBackendUnsupported',
+            params: {},
+            message: lang.__('SEMANTIC_EXTERNAL_BACKEND_VOLCENGINE', {
+              backend: bareBackend,
+              eventKey,
+            }),
+          });
         }
       }
 

--- a/src/validator/semanticValidation.ts
+++ b/src/validator/semanticValidation.ts
@@ -1,6 +1,7 @@
 import { ErrorObject } from 'ajv';
 import type { ServerlessIacRaw } from '../types';
 import { lang } from '../lang';
+import { logger } from '../common/logger';
 // Direct leaf import on purpose: routing through the src/common barrel would
 // drag stateManager/lockManager/fs surfaces into the validator graph and
 // recreate an import cycle with src/parser. These helpers are pure.
@@ -17,6 +18,7 @@ type EventTriggerRaw = {
 };
 
 const FUNCTION_BACKEND_PATTERN = /^\$\{functions\.([\w.]+)\}$/;
+const TEMPLATE_REF_PATTERN = /^\$\{[^}]+\}$/;
 
 /**
  * Stage is intentionally empty here: it is identical for every generated name
@@ -37,6 +39,15 @@ export const validateSemantics = (iacJson: ServerlessIacRaw): Array<ErrorObject>
   const functionDefinitions = (iacJson.functions ?? {}) as Record<string, unknown>;
 
   const definedFunctionKeys = new Set(Object.keys(functionDefinitions));
+  const definedFunctionNames = new Set(
+    Object.values(functionDefinitions)
+      .map((fn) =>
+        fn && typeof fn === 'object' && typeof (fn as { name?: unknown }).name === 'string'
+          ? (fn as { name: string }).name
+          : undefined,
+      )
+      .filter((name): name is string => name !== undefined),
+  );
 
   Object.entries(events).forEach(([eventKey, rawEvent]) => {
     const triggers = Array.isArray(rawEvent.triggers)
@@ -89,6 +100,47 @@ export const validateSemantics = (iacJson: ServerlessIacRaw): Array<ErrorObject>
             eventKey,
           }),
         });
+      }
+
+      // Bare backend semantics (issue #227): a bare value must be a function's
+      // deployed name. A value equal to a template function's KEY is the exact
+      // misconfiguration that broke the API Gateway trust policy — reject it;
+      // a value matching a template function's name passes with a preference
+      // warning; anything else is an external function (statically unverifiable).
+      const bareBackend =
+        typeof trigger.backend === 'string' &&
+        !backendRef &&
+        !TEMPLATE_REF_PATTERN.test(trigger.backend)
+          ? trigger.backend
+          : undefined;
+
+      if (bareBackend) {
+        if (definedFunctionNames.has(bareBackend)) {
+          const matchedKey = Object.keys(functionDefinitions).find(
+            (key) =>
+              typeof (functionDefinitions[key] as { name?: unknown })?.name === 'string' &&
+              (functionDefinitions[key] as { name: string }).name === bareBackend,
+          );
+          logger.warn(
+            lang.__('SEMANTIC_BACKEND_BARE_NAME', {
+              backend: bareBackend,
+              key: matchedKey ?? bareBackend,
+              eventKey,
+            }),
+          );
+        } else if (definedFunctionKeys.has(bareBackend)) {
+          errors.push({
+            instancePath,
+            schemaPath: '#/semantic/bareBackendKey',
+            keyword: 'bareBackendKey',
+            params: {},
+            message: lang.__('SEMANTIC_BACKEND_BARE_KEY', {
+              backend: bareBackend,
+              key: bareBackend,
+              eventKey,
+            }),
+          });
+        }
       }
 
       // Generated names derive from method+path, so a duplicate trigger would

--- a/src/validator/semanticValidation.ts
+++ b/src/validator/semanticValidation.ts
@@ -140,19 +140,6 @@ export const validateSemantics = (iacJson: ServerlessIacRaw): Array<ErrorObject>
               eventKey,
             }),
           });
-        } else if (providerName === 'volcengine') {
-          // Volcengine upstreams require a si-managed functionId from state —
-          // external deployed functions cannot be wired as backends there.
-          errors.push({
-            instancePath,
-            schemaPath: '#/semantic/externalBackendUnsupported',
-            keyword: 'externalBackendUnsupported',
-            params: {},
-            message: lang.__('SEMANTIC_EXTERNAL_BACKEND_VOLCENGINE', {
-              backend: bareBackend,
-              eventKey,
-            }),
-          });
         }
       }
 

--- a/tests/fixtures/serverless-insight-deploy-bare-name.yml
+++ b/tests/fixtures/serverless-insight-deploy-bare-name.yml
@@ -1,0 +1,58 @@
+version: 0.0.1
+app: insight-poc-deploy-app
+provider:
+  name: aliyun
+  region: cn-chengdu
+
+vars:
+  region: cn-hangzhou
+  testv: testVarValue
+  handler: index.handler
+
+stages:
+  default:
+    region: ${vars.region}
+    node_env: default
+  dev:
+    region: ${vars.region}
+    node_env: development
+  prod:
+    region: cn-shanghai
+
+service: insight-poc-deploy
+
+backend:
+  state_manager:
+    type: LOCAL
+
+tags:
+  owner: geek-fun
+
+functions:
+  insight_poc_fn:
+    name: insight-poc-fn
+    code:
+      runtime: nodejs18
+      handler: ${vars.handler}
+      path: tests/fixtures/artifacts/artifact.zip
+    memory: 512
+    timeout: 10
+    log: true
+    environment:
+      NODE_ENV: ${stages.node_env}
+      TEST_VAR: ${vars.testv}
+      TEST_VAR_EXTRA: abcds-${vars.testv}-andyou
+
+events:
+  gateway_event:
+    type: API_GATEWAY
+    name: insight-poc-gateway
+    triggers:
+      - method: GET
+        path: /api/hello
+        backend: insight-poc-fn
+#    custom_domain:
+#      domain_name: test.com
+#      certificate_name: test
+#      certificate_private_key: test
+#      certificate_body: test

--- a/tests/service/deploy-flow.spec.test.ts
+++ b/tests/service/deploy-flow.spec.test.ts
@@ -69,6 +69,37 @@ describe('Deploy Flow Service Test', () => {
       expect(mockClient.fc3.createFunction).toHaveBeenCalled();
     });
 
+    it('should deploy a bare function-name backend end to end (issue #227)', async () => {
+      await deploy({
+        location: path.join(fixturesDir, 'serverless-insight-deploy-bare-name.yml'),
+        stage: 'dev',
+        autoApprove: true,
+        region: 'cn-hangzhou',
+        provider: 'aliyun',
+      });
+
+      expect(mockClient.fc3.createFunction).toHaveBeenCalled();
+
+      // The managed role must trust apigateway so the gateway can assume it.
+      expect(mockClient.ram.createRole).toHaveBeenCalled();
+      expect(mockClient.ram.createRole.mock.calls[0][1]).toEqual([
+        'fc.aliyuncs.com',
+        'apigateway.aliyuncs.com',
+      ]);
+
+      // The API must target the resolved function name with the managed role.
+      expect(mockClient.apigw.createApi).toHaveBeenCalledWith(
+        expect.objectContaining({
+          serviceConfig: expect.objectContaining({
+            functionComputeConfig: expect.objectContaining({
+              functionName: 'insight-poc-fn',
+              roleArn: expect.any(String),
+            }),
+          }),
+        }),
+      );
+    });
+
     it('should handle deploy error when cloud SDK fails', async () => {
       mockClient.fc3.createFunction.mockRejectedValueOnce(new Error('FunctionAlreadyExists'));
 

--- a/tests/service/mockCloudClient.ts
+++ b/tests/service/mockCloudClient.ts
@@ -184,8 +184,17 @@ export const createMockAliyunClient = (): MockAliyunClient => {
       applyHttpsRedirect: jest.fn().mockResolvedValue({}),
     },
     ram: {
-      createRole: jest.fn().mockResolvedValue({ body: { Role: { RoleName: 'test-role' } } }),
-      getRole: jest.fn().mockResolvedValue({ body: { Role: { RoleName: 'test-role' } } }),
+      createRole: jest.fn().mockResolvedValue({
+        roleName: 'test-role',
+        roleId: 'role-123',
+        arn: 'acs:ram::123456789012:role/test-role',
+        policyName: 'test-role-policy',
+      }),
+      getRole: jest.fn().mockResolvedValue({
+        roleName: 'test-role',
+        roleId: 'role-123',
+        arn: 'acs:ram::123456789012:role/test-role',
+      }),
       deleteRole: jest.fn().mockResolvedValue({}),
       createPolicy: jest
         .fn()

--- a/tests/service/mockCloudClient.ts
+++ b/tests/service/mockCloudClient.ts
@@ -61,6 +61,7 @@ export type MockAliyunClient = {
     detachPolicyFromRole: jest.Mock;
     updateRolePolicy: jest.Mock;
     updateRoleTrustPolicy: jest.Mock;
+    updateExecutionPolicyDocument: jest.Mock;
   };
   nas: {
     createFileSystem: jest.Mock;
@@ -196,6 +197,7 @@ export const createMockAliyunClient = (): MockAliyunClient => {
       updateRoleTrustPolicy: jest
         .fn()
         .mockResolvedValue({ body: { Role: { RoleName: 'test-role' } } }),
+      updateExecutionPolicyDocument: jest.fn().mockResolvedValue(undefined),
     },
     nas: {
       createFileSystem: jest.fn().mockResolvedValue({ body: { fileSystemId: 'fs-123' } }),
@@ -280,6 +282,13 @@ export type MockTencentClient = {
     DeleteTopic: jest.Mock;
     CreateIndex: jest.Mock;
   };
+  cam: {
+    createRole: jest.Mock;
+    getRole: jest.Mock;
+    deleteRole: jest.Mock;
+    updateRolePolicy: jest.Mock;
+    updateManagedPolicies: jest.Mock;
+  };
   cos: {
     putBucket: jest.Mock;
     getBucket: jest.Mock;
@@ -314,6 +323,22 @@ export const createMockTencentClient = (): MockTencentClient => ({
     ModifyTopic: jest.fn().mockResolvedValue({}),
     DeleteTopic: jest.fn().mockResolvedValue({}),
     CreateIndex: jest.fn().mockResolvedValue({}),
+  },
+  cam: {
+    createRole: jest.fn().mockResolvedValue({
+      roleName: 'test-role',
+      roleId: 'role-123',
+      roleArn: 'test-role',
+      policyName: 'test-role-policy',
+    }),
+    getRole: jest.fn().mockResolvedValue({
+      roleName: 'test-role',
+      roleId: 'role-123',
+      roleArn: 'test-role',
+    }),
+    deleteRole: jest.fn().mockResolvedValue(undefined),
+    updateRolePolicy: jest.fn().mockResolvedValue(undefined),
+    updateManagedPolicies: jest.fn().mockResolvedValue(undefined),
   },
   cos: {
     putBucket: jest.fn().mockResolvedValue({}),

--- a/tests/service/volcengine-deploy-flow.spec.test.ts
+++ b/tests/service/volcengine-deploy-flow.spec.test.ts
@@ -124,7 +124,7 @@ describe('Volcengine Deploy Flow Service Test', () => {
       expect(mockClient.tls.createTopic).toHaveBeenCalledWith(
         expect.objectContaining({
           projectName: 'insight-volc-app-dev-tls',
-          topicName: 'insight-volc-dev-fn-logs',
+          topicName: 'insight-volc-dev-insight_poc_fn-fn-logs',
         }),
       );
       expect(mockClient.tls.addTags).toHaveBeenCalledWith(

--- a/tests/unit/common/aliyunClient/ramOperations.test.ts
+++ b/tests/unit/common/aliyunClient/ramOperations.test.ts
@@ -10,6 +10,11 @@ const mockDetachPolicyFromRole = jest.fn();
 const mockDeletePolicy = jest.fn();
 const mockDeleteRole = jest.fn();
 const mockListPoliciesForRole = jest.fn();
+const mockGetPolicy = jest.fn();
+const mockGetPolicyVersion = jest.fn();
+const mockCreatePolicyVersion = jest.fn();
+const mockListPolicyVersions = jest.fn();
+const mockDeletePolicyVersion = jest.fn();
 
 const mockRamClient = {
   createPolicy: mockCreatePolicy,
@@ -21,6 +26,11 @@ const mockRamClient = {
   deletePolicy: mockDeletePolicy,
   deleteRole: mockDeleteRole,
   listPoliciesForRole: mockListPoliciesForRole,
+  getPolicy: mockGetPolicy,
+  getPolicyVersion: mockGetPolicyVersion,
+  createPolicyVersion: mockCreatePolicyVersion,
+  listPolicyVersions: mockListPolicyVersions,
+  deletePolicyVersion: mockDeletePolicyVersion,
 } as unknown as RamClient;
 
 jest.mock('../../../../src/common/logger', () => ({
@@ -115,7 +125,18 @@ describe('ramOperations', () => {
       });
 
       mockUpdateRole.mockResolvedValue({});
-      mockCreatePolicy.mockResolvedValue({});
+      mockGetPolicy.mockResolvedValue({
+        body: {
+          policy: { policyName: 'fc-execution-role-policy', defaultVersion: 'v1' },
+        },
+      });
+      mockGetPolicyVersion.mockResolvedValue({
+        body: { policyVersion: { versionId: 'v1', policyDocument: '{"stale":true}' } },
+      });
+      mockListPolicyVersions.mockResolvedValue({
+        body: { policyVersions: { policyVersion: [] } },
+      });
+      mockCreatePolicyVersion.mockResolvedValue({});
       mockAttachPolicyToRole.mockResolvedValue({});
 
       const result = await operations.createRole('fc-execution-role', ['fc.aliyuncs.com']);
@@ -123,6 +144,7 @@ describe('ramOperations', () => {
       expect(result.roleName).toBe('fc-execution-role');
       expect(mockGetRole).toHaveBeenCalled();
       expect(mockUpdateRole).toHaveBeenCalled();
+      expect(mockCreatePolicyVersion).toHaveBeenCalled();
     });
 
     it('should throw on role creation failure', async () => {
@@ -538,6 +560,153 @@ describe('ramOperations', () => {
       expect(customStmt.Sid).toBeUndefined();
       expect(customStmt.Effect).toBe('Deny');
       expect(customStmt.Action).toEqual(['ram:DeleteRole']);
+    });
+  });
+
+  describe('createRole with executionStatements', () => {
+    it('should use the provided execution statements as the policy baseline', async () => {
+      mockCreateRole.mockResolvedValue({
+        body: {
+          role: {
+            roleName: 'fc-execution-role',
+            roleId: 'role-123',
+            arn: 'arn:aliyun:ram::123456789:role/fc-execution-role',
+          },
+        },
+      });
+      mockCreatePolicy.mockResolvedValue({});
+      mockAttachPolicyToRole.mockResolvedValue({});
+
+      const baseline = [
+        { effect: 'Allow' as const, action: ['fc:InvokeFunction'], resource: ['*'] },
+      ];
+      const custom = [{ effect: 'Allow' as const, action: ['oss:GetObject'], resource: ['*'] }];
+
+      await operations.createRole(
+        'fc-execution-role',
+        ['fc.aliyuncs.com'],
+        undefined,
+        custom,
+        undefined,
+        baseline,
+      );
+
+      const policyDoc = JSON.parse(mockCreatePolicy.mock.calls[0][0].policyDocument);
+      expect(policyDoc.Statement).toHaveLength(2);
+      expect(policyDoc.Statement[0].Action).toEqual(['fc:InvokeFunction']);
+      expect(policyDoc.Statement[1].Action).toEqual(['oss:GetObject']);
+    });
+  });
+
+  describe('updateExecutionPolicyDocument', () => {
+    const desiredDoc = JSON.stringify({
+      Version: '1',
+      Statement: [
+        { Effect: 'Allow', Action: ['fc:InvokeFunction'], Resource: '*' },
+        { Effect: 'Allow', Action: ['log:GetLogStore'], Resource: '*' },
+      ],
+    });
+    const existingDoc = JSON.stringify({
+      Version: '1',
+      Statement: [{ Effect: 'Allow', Action: ['log:GetLogStore'], Resource: '*' }],
+    });
+
+    beforeEach(() => {
+      mockGetPolicy.mockResolvedValue({
+        body: {
+          policy: { policyName: 'fc-execution-role-policy', defaultVersion: 'v1' },
+        },
+      });
+      mockGetPolicyVersion.mockResolvedValue({
+        body: { policyVersion: { versionId: 'v1', policyDocument: existingDoc } },
+      });
+      mockListPolicyVersions.mockResolvedValue({
+        body: { policyVersions: { policyVersion: [] } },
+      });
+      mockCreatePolicyVersion.mockResolvedValue({});
+      mockDeletePolicyVersion.mockResolvedValue({});
+      mockAttachPolicyToRole.mockResolvedValue({});
+    });
+
+    it('should not create a new version when the document is identical', async () => {
+      await operations.updateExecutionPolicyDocument('fc-execution-role', existingDoc);
+
+      expect(mockGetPolicy).toHaveBeenCalledWith(
+        expect.objectContaining({ policyName: 'fc-execution-role-policy', policyType: 'Custom' }),
+      );
+      expect(mockCreatePolicyVersion).not.toHaveBeenCalled();
+      expect(mockAttachPolicyToRole).not.toHaveBeenCalled();
+    });
+
+    it('should create a new version and ensure attachment when the document changed', async () => {
+      await operations.updateExecutionPolicyDocument('fc-execution-role', desiredDoc);
+
+      expect(mockCreatePolicyVersion).toHaveBeenCalledWith(
+        expect.objectContaining({
+          policyName: 'fc-execution-role-policy',
+          policyDocument: desiredDoc,
+          setAsDefault: true,
+        }),
+      );
+      expect(mockAttachPolicyToRole).toHaveBeenCalledWith(
+        expect.objectContaining({
+          policyType: 'Custom',
+          policyName: 'fc-execution-role-policy',
+          roleName: 'fc-execution-role',
+        }),
+      );
+    });
+
+    it('should create the policy when it does not exist yet', async () => {
+      const notFound = new Error('EntityNotExist.Policy');
+      Object.assign(notFound, { code: 'EntityNotExist.Policy' });
+      mockGetPolicy.mockRejectedValue(notFound);
+
+      await operations.updateExecutionPolicyDocument('fc-execution-role', desiredDoc);
+
+      expect(mockCreatePolicy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          policyName: 'fc-execution-role-policy',
+          policyDocument: desiredDoc,
+        }),
+      );
+      expect(mockCreatePolicyVersion).not.toHaveBeenCalled();
+      expect(mockAttachPolicyToRole).toHaveBeenCalled();
+    });
+
+    it('should prune the oldest non-default version when at the version limit', async () => {
+      mockListPolicyVersions.mockResolvedValue({
+        body: {
+          policyVersions: {
+            policyVersion: [
+              { versionId: 'v1', isDefaultVersion: true, createDate: '2023-01-01T00:00:00Z' },
+              { versionId: 'v2', isDefaultVersion: false, createDate: '2023-01-02T00:00:00Z' },
+              { versionId: 'v3', isDefaultVersion: false, createDate: '2023-01-03T00:00:00Z' },
+              { versionId: 'v4', isDefaultVersion: false, createDate: '2023-01-04T00:00:00Z' },
+              { versionId: 'v5', isDefaultVersion: false, createDate: '2023-01-05T00:00:00Z' },
+            ],
+          },
+        },
+      });
+
+      await operations.updateExecutionPolicyDocument('fc-execution-role', desiredDoc);
+
+      expect(mockDeletePolicyVersion).toHaveBeenCalledWith(
+        expect.objectContaining({ policyName: 'fc-execution-role-policy', versionId: 'v2' }),
+      );
+      expect(mockCreatePolicyVersion).toHaveBeenCalledWith(
+        expect.objectContaining({ policyName: 'fc-execution-role-policy', setAsDefault: true }),
+      );
+    });
+
+    it('should ignore an already-attached error when ensuring attachment', async () => {
+      const alreadyAttached = new Error('EntityAlreadyExists.Role.Policy');
+      Object.assign(alreadyAttached, { code: 'EntityAlreadyExists.Role.Policy' });
+      mockAttachPolicyToRole.mockRejectedValue(alreadyAttached);
+
+      await expect(
+        operations.updateExecutionPolicyDocument('fc-execution-role', desiredDoc),
+      ).resolves.toBeUndefined();
     });
   });
 

--- a/tests/unit/common/iacHelper.test.ts
+++ b/tests/unit/common/iacHelper.test.ts
@@ -1,0 +1,40 @@
+import { getIacDefinition } from '../../../src/common/iacHelper';
+import { ServerlessIac } from '../../../src/types';
+
+describe('getIacDefinition', () => {
+  const buildIac = (functions: Array<{ key: string; name: string }>): ServerlessIac =>
+    ({
+      functions: functions.map((fn) => ({ ...fn })),
+    }) as unknown as ServerlessIac;
+
+  const iac = buildIac([
+    { key: 'console_fn', name: 'console-fn-deployed' },
+    { key: 'api_fn', name: 'api-fn-deployed' },
+  ]);
+
+  it('resolves the template reference form by function key', () => {
+    expect(getIacDefinition(iac, '${functions.console_fn}')).toMatchObject({
+      key: 'console_fn',
+      name: 'console-fn-deployed',
+    });
+  });
+
+  it('resolves a bare value by the function deployed name (issue #227)', () => {
+    expect(getIacDefinition(iac, 'console-fn-deployed')).toMatchObject({
+      key: 'console_fn',
+      name: 'console-fn-deployed',
+    });
+  });
+
+  it('does not resolve a bare value that equals a function key (fallback removed, issue #227)', () => {
+    expect(getIacDefinition(iac, 'console_fn')).toBeUndefined();
+  });
+
+  it('returns undefined for unknown values', () => {
+    expect(getIacDefinition(iac, 'totally-unknown-fn')).toBeUndefined();
+  });
+
+  it('resolves template references against an empty function list as undefined', () => {
+    expect(getIacDefinition(buildIac([]), '${functions.console_fn}')).toBeUndefined();
+  });
+});

--- a/tests/unit/common/tencentClient/camOperations.test.ts
+++ b/tests/unit/common/tencentClient/camOperations.test.ts
@@ -1,4 +1,5 @@
 import { createCamOperations } from '../../../../src/common/tencentClient/camOperations';
+import type { IamStatement } from '../../../../src/common/iamStatements';
 
 jest.mock('../../../../src/common/logger', () => ({
   logger: {
@@ -332,6 +333,62 @@ describe('camOperations', () => {
         expect.arrayContaining([expect.objectContaining({ Sid: 'MyCustomSid' })]),
       );
     });
+
+    it('should use executionStatements as the policy baseline when provided', async () => {
+      mockCamClient.CreateRole.mockResolvedValue({ RoleId: 'role-123' });
+      mockCamClient.GetRole.mockResolvedValue({
+        RoleInfo: { RoleId: 'role-123', RoleName: 'baseline-role', RoleArn: '' },
+      });
+      mockCamClient.CreatePolicy.mockResolvedValue({ PolicyId: 1 });
+      mockCamClient.AttachRolePolicy.mockResolvedValue({});
+
+      const baseline: IamStatement[] = [
+        { effect: 'Allow', action: ['scf:InvokeFunction'], resource: ['*'] },
+      ];
+      await operations.createRole(
+        'baseline-role',
+        ['scf.qcloud.com'],
+        undefined,
+        [{ effect: 'Allow', action: ['cos:PutObject'], resource: ['qcs::cos:::*'] }],
+        undefined,
+        baseline,
+      );
+
+      const policyDocCall = mockCamClient.CreatePolicy.mock.calls[0][0];
+      const parsedDoc = JSON.parse(policyDocCall.PolicyDocument);
+      // Derived baseline first, then custom statements.
+      expect(parsedDoc.Statement).toHaveLength(2);
+      expect(parsedDoc.Statement[0].Action).toEqual(['scf:InvokeFunction']);
+      expect(parsedDoc.Statement[1].Action).toEqual(['cos:PutObject']);
+      // The static SCF default (cls/cos baseline) must NOT leak in.
+      expect(JSON.stringify(parsedDoc)).not.toContain('cls:logset');
+    });
+
+    it('should use executionStatements baseline in RoleAlreadyExist recovery', async () => {
+      const alreadyExists = Object.assign(new Error('RoleAlreadyExist'), {
+        code: 'InvalidParameter.RoleAlreadyExist',
+      });
+      mockCamClient.CreateRole.mockRejectedValueOnce(alreadyExists);
+      mockCamClient.GetRole.mockResolvedValue({
+        RoleInfo: { RoleId: 'role-123', RoleName: 'recover-role', RoleArn: '' },
+      });
+      mockCamClient.CreatePolicy.mockResolvedValue({ PolicyId: 1 });
+      mockCamClient.AttachRolePolicy.mockResolvedValue({});
+
+      await operations.createRole(
+        'recover-role',
+        ['scf.qcloud.com'],
+        undefined,
+        undefined,
+        undefined,
+        [{ effect: 'Allow', action: ['scf:InvokeFunction'], resource: ['*'] }],
+      );
+
+      const policyDocCall = mockCamClient.CreatePolicy.mock.calls[0][0];
+      const parsedDoc = JSON.parse(policyDocCall.PolicyDocument);
+      expect(parsedDoc.Statement).toHaveLength(1);
+      expect(parsedDoc.Statement[0].Action).toEqual(['scf:InvokeFunction']);
+    });
   });
 
   describe('getRole', () => {
@@ -513,6 +570,25 @@ describe('camOperations', () => {
       mockCamClient.CreatePolicy.mockRejectedValue(new Error('CreatePolicyFailed'));
 
       await expect(operations.updateRolePolicy('test-role')).rejects.toThrow('CreatePolicyFailed');
+    });
+
+    it('should use executionStatements baseline in updateRolePolicy', async () => {
+      mockCamClient.DetachRolePolicy.mockResolvedValue({});
+      mockCamClient.ListPolicies.mockResolvedValue({ List: [] });
+      mockCamClient.CreatePolicy.mockResolvedValue({ PolicyId: 2 });
+      mockCamClient.AttachRolePolicy.mockResolvedValue({});
+
+      await operations.updateRolePolicy(
+        'test-role',
+        [{ effect: 'Allow', action: ['cos:DeleteObject'], resource: ['*'] }],
+        [{ effect: 'Allow', action: ['scf:InvokeFunction'], resource: ['*'] }],
+      );
+
+      const policyDocCall = mockCamClient.CreatePolicy.mock.calls[0][0];
+      const parsedDoc = JSON.parse(policyDocCall.PolicyDocument);
+      expect(parsedDoc.Statement).toHaveLength(2);
+      expect(parsedDoc.Statement[0].Action).toEqual(['scf:InvokeFunction']);
+      expect(parsedDoc.Statement[1].Action).toEqual(['cos:DeleteObject']);
     });
   });
 

--- a/tests/unit/common/volcengineClient/iamOperations.test.ts
+++ b/tests/unit/common/volcengineClient/iamOperations.test.ts
@@ -1,5 +1,6 @@
 import { createIamOperations } from '../../../../src/common/volcengineClient/iamOperations';
 import type { IamRoleConfig } from '../../../../src/common/volcengineClient/types';
+import type { IamStatement } from '../../../../src/common/iamStatements';
 
 type MockFetchOpenAPI = jest.Mock;
 
@@ -810,6 +811,121 @@ describe('iamOperations', () => {
           query: expect.objectContaining({ PolicyName: 'arn:policy:b' }),
         }),
       );
+    });
+  });
+
+  describe('createRole - execution statements', () => {
+    it('builds the execution policy from executionStatements when provided', async () => {
+      const configWithBaseline: IamRoleConfig = {
+        ...mockConfig,
+        executionStatements: [
+          { effect: 'Allow', action: ['vefaas:*'], resource: ['*'] },
+          {
+            effect: 'Allow',
+            action: ['vpc:DescribeVpcs', 'vpc:DescribeSubnets', 'vpc:DescribeSecurityGroups'],
+            resource: ['*'],
+          },
+        ],
+        customStatements: [{ effect: 'Allow', action: ['ecs:DescribeInstances'], resource: ['*'] }],
+      };
+
+      mockClient.fetchOpenAPI
+        .mockResolvedValueOnce({
+          Result: { Role: { RoleName: 'test-role', RoleId: 'role-123' } },
+        })
+        .mockResolvedValueOnce({})
+        .mockResolvedValueOnce({});
+
+      await operations.createRole(configWithBaseline);
+
+      const createPolicyCall = mockClient.fetchOpenAPI.mock.calls.find(
+        ([call]) => call.Action === 'CreatePolicy',
+      )?.[0];
+      const policyDocument = JSON.parse(createPolicyCall.query.PolicyDocument as string);
+      expect(policyDocument.Statement.map((s: { Action: string[] }) => s.Action)).toEqual([
+        ['vefaas:*'],
+        ['vpc:DescribeVpcs', 'vpc:DescribeSubnets', 'vpc:DescribeSecurityGroups'],
+        ['ecs:DescribeInstances'],
+      ]);
+    });
+
+    it('uses the static execution policy when no executionStatements are provided', async () => {
+      mockClient.fetchOpenAPI
+        .mockResolvedValueOnce({
+          Result: { Role: { RoleName: 'test-role', RoleId: 'role-123' } },
+        })
+        .mockResolvedValueOnce({})
+        .mockResolvedValueOnce({});
+
+      await operations.createRole(mockConfig);
+
+      const createPolicyCall = mockClient.fetchOpenAPI.mock.calls.find(
+        ([call]) => call.Action === 'CreatePolicy',
+      )?.[0];
+      const policyDocument = JSON.parse(createPolicyCall.query.PolicyDocument as string);
+      expect(policyDocument.Statement).toHaveLength(4);
+    });
+
+    it('uses executionStatements in the RoleAlreadyExists recovery branch', async () => {
+      const configWithBaseline: IamRoleConfig = {
+        ...mockConfig,
+        executionStatements: [{ effect: 'Allow', action: ['vefaas:*'], resource: ['*'] }],
+      };
+
+      const existingError = new Error('Role exists') as Error & { code: string };
+      existingError.code = 'RoleAlreadyExists';
+
+      mockClient.fetchOpenAPI
+        .mockRejectedValueOnce(existingError)
+        .mockResolvedValueOnce({
+          Result: { Role: { RoleName: 'test-role', RoleId: 'role-123' } },
+        })
+        .mockResolvedValueOnce({})
+        .mockResolvedValueOnce({})
+        .mockResolvedValueOnce({});
+
+      await operations.createRole(configWithBaseline);
+
+      const createPolicyCall = mockClient.fetchOpenAPI.mock.calls.find(
+        ([call]) => call.Action === 'CreatePolicy',
+      )?.[0];
+      const policyDocument = JSON.parse(createPolicyCall.query.PolicyDocument as string);
+      expect(policyDocument.Statement).toEqual([expect.objectContaining({ Action: ['vefaas:*'] })]);
+    });
+  });
+
+  describe('updateRolePolicy', () => {
+    it('rebuilds the full policy from baseline and custom statements', async () => {
+      const baseline: IamStatement[] = [
+        { effect: 'Allow', action: ['vefaas:*'], resource: ['*'] },
+        {
+          effect: 'Allow',
+          action: ['vpc:DescribeVpcs', 'vpc:DescribeSubnets', 'vpc:DescribeSecurityGroups'],
+          resource: ['*'],
+        },
+      ];
+      const custom: IamStatement[] = [
+        { effect: 'Allow', action: ['ecs:DescribeInstances'], resource: ['*'] },
+      ];
+
+      mockClient.fetchOpenAPI
+        .mockResolvedValueOnce({})
+        .mockResolvedValueOnce({})
+        .mockResolvedValueOnce({})
+        .mockResolvedValueOnce({});
+
+      await operations.updateRolePolicy('test-role', baseline, custom);
+
+      const createPolicyCall = mockClient.fetchOpenAPI.mock.calls.find(
+        ([call]) => call.Action === 'CreatePolicy',
+      )?.[0];
+      const policyDocument = JSON.parse(createPolicyCall.query.PolicyDocument as string);
+      expect(policyDocument.Statement).toHaveLength(3);
+      expect(policyDocument.Statement.map((s: { Action: string[] }) => s.Action)).toEqual([
+        ['vefaas:*'],
+        ['vpc:DescribeVpcs', 'vpc:DescribeSubnets', 'vpc:DescribeSecurityGroups'],
+        ['ecs:DescribeInstances'],
+      ]);
     });
   });
 

--- a/tests/unit/common/volcengineClient/iamOperations.test.ts
+++ b/tests/unit/common/volcengineClient/iamOperations.test.ts
@@ -101,6 +101,45 @@ describe('iamOperations', () => {
       expect(result.roleName).toBe('test-role');
     });
 
+    it('rebuilds the policy with baseline and custom statements in the RoleAlreadyExists recovery', async () => {
+      const existingError = new Error('Role exists') as Error & { code: string };
+      existingError.code = 'RoleAlreadyExists';
+
+      mockClient.fetchOpenAPI
+        .mockRejectedValueOnce(existingError)
+        .mockResolvedValueOnce({
+          Result: {
+            Role: {
+              RoleName: 'test-role',
+              RoleId: 'role-123',
+              TRN: 'trn:iam::123456:role/test-role',
+            },
+          },
+        })
+        .mockResolvedValue({})
+        .mockResolvedValue({})
+        .mockResolvedValue({});
+
+      await operations.createRole({
+        ...mockConfig,
+        executionStatements: [{ effect: 'Allow', action: ['vefaas:*'], resource: ['*'] }],
+        customStatements: [
+          { effect: 'Allow', action: ['oss:GetObject'], resource: ['trn:tos:::my-bucket/*'] },
+        ],
+      });
+
+      const createPolicyCall = mockClient.fetchOpenAPI.mock.calls.find(
+        (call) => call[0]?.Action === 'CreatePolicy',
+      );
+      expect(createPolicyCall).toBeDefined();
+      const policyDocument = JSON.parse(createPolicyCall![0].query.PolicyDocument) as {
+        Statement: Array<{ Action: string[] }>;
+      };
+      const actions = policyDocument.Statement.flatMap((statement) => statement.Action);
+      expect(actions).toContain('vefaas:*');
+      expect(actions).toContain('oss:GetObject');
+    });
+
     it('should handle existing role with Conflict code', async () => {
       const conflictError = new Error('Conflict') as Error & { code: string };
       conflictError.code = 'Conflict';

--- a/tests/unit/stack/aliyunStack/apigwExecutor.test.ts
+++ b/tests/unit/stack/aliyunStack/apigwExecutor.test.ts
@@ -144,6 +144,54 @@ describe('ApigwExecutor', () => {
       );
     });
 
+    it('should pass a roleArn resolver through to createApigwResource', async () => {
+      const plan: Plan = {
+        items: [
+          {
+            logicalId: 'events.test_api',
+            action: 'create',
+            resourceType: 'ALIYUN_APIGW',
+          },
+        ],
+      };
+
+      const newState = {
+        ...initialState,
+        resources: {
+          'events.test_api': {
+            mode: 'managed',
+            region: 'cn-hangzhou',
+            definition: { groupName: 'test-service-default-test-api-agw-group' },
+            instances: [{ sid: 'si:test:test:default:test', id: 'test-group' }],
+            lastUpdated: new Date().toISOString(),
+          },
+        },
+      };
+
+      const resolver = (backend: string) =>
+        backend === 'userFunction' ? 'arn:fn-a' : 'arn:fallback';
+      (apigwResource.createApigwResource as jest.Mock).mockResolvedValue(newState);
+
+      const result = await executeApigwPlan(
+        mockContext,
+        plan,
+        [testEvent],
+        serviceName,
+        resolver,
+        initialState,
+      );
+
+      expect(result.state).toEqual(newState);
+      expect(result.partialFailure).toBeUndefined();
+      expect(apigwResource.createApigwResource).toHaveBeenCalledWith(
+        mockContext,
+        testEvent,
+        serviceName,
+        resolver,
+        initialState,
+      );
+    });
+
     it('should execute update action successfully', async () => {
       const plan: Plan = {
         items: [

--- a/tests/unit/stack/aliyunStack/apigwResource.test.ts
+++ b/tests/unit/stack/aliyunStack/apigwResource.test.ts
@@ -123,6 +123,12 @@ jest.mock('../../../../src/stack/aliyunStack/apigwTypes', () => ({
   generateApiKey: (...args: unknown[]) => mockedApigwTypes.generateApiKey(...args),
   inferProtocolConfig: (...args: unknown[]) => mockedApigwTypes.inferProtocolConfig(...args),
   buildEventLogSnapshot: (...args: unknown[]) => mockedApigwTypes.buildEventLogSnapshot(...args),
+  normalizeRoleArnResolver: (param: unknown) => {
+    if (typeof param === 'function') {
+      return param;
+    }
+    return () => param;
+  },
 }));
 
 jest.mock('../../../../src/common/stateManager', () => ({
@@ -238,6 +244,67 @@ describe('ApigwResource', () => {
       expect(mockedApigwOperations.createApi).toHaveBeenCalled();
       expect(mockedApigwOperations.deployApi).toHaveBeenCalled();
       expect(mockedStateManager.setResource).toHaveBeenCalled();
+    });
+
+    it('resolves a per-trigger roleArn from the backend via the resolver', async () => {
+      mockedApigwOperations.findApiGroupByName.mockResolvedValue(null);
+      mockedApigwOperations.createApiGroup.mockResolvedValue('group-123');
+      mockedApigwOperations.getApiGroup.mockResolvedValue({
+        groupId: 'group-123',
+        groupName: 'test-api-group',
+        subDomain: 'group-123.apigw.aliyuncs.com',
+      });
+      mockedApigwOperations.createApi.mockResolvedValue('api-456');
+      mockedApigwOperations.getApi.mockResolvedValue({ apiId: 'api-456', apiName: 'test-api' });
+      mockedApigwOperations.deployApi.mockResolvedValue(undefined);
+      mockedApigwTypes.eventToApigwGroupConfig.mockReturnValue({ groupName: 'test-api-group' });
+      mockedApigwTypes.extractApigwGroupDefinition.mockReturnValue({});
+      mockedApigwTypes.triggerToApigwApiConfig.mockReturnValue({ apiName: 'test-api' });
+      mockedApigwTypes.extractEventDomainDefinition.mockReturnValue(null);
+
+      const resolver = (backend: string) =>
+        backend === 'functions.hello_function' ? 'arn:fn-a' : 'arn:fallback';
+
+      await createApigwResource(mockContext, testEvent, 'test-service', resolver, initialState);
+
+      expect(mockedApigwTypes.triggerToApigwApiConfig).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ backend: 'functions.hello_function' }),
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        'arn:fn-a',
+      );
+    });
+
+    it('resolves undefined roleArn when no resolver is provided', async () => {
+      mockedApigwOperations.findApiGroupByName.mockResolvedValue(null);
+      mockedApigwOperations.createApiGroup.mockResolvedValue('group-123');
+      mockedApigwOperations.getApiGroup.mockResolvedValue({
+        groupId: 'group-123',
+        groupName: 'test-api-group',
+        subDomain: 'group-123.apigw.aliyuncs.com',
+      });
+      mockedApigwOperations.createApi.mockResolvedValue('api-456');
+      mockedApigwOperations.getApi.mockResolvedValue({ apiId: 'api-456', apiName: 'test-api' });
+      mockedApigwOperations.deployApi.mockResolvedValue(undefined);
+      mockedApigwTypes.eventToApigwGroupConfig.mockReturnValue({ groupName: 'test-api-group' });
+      mockedApigwTypes.extractApigwGroupDefinition.mockReturnValue({});
+      mockedApigwTypes.triggerToApigwApiConfig.mockReturnValue({ apiName: 'test-api' });
+      mockedApigwTypes.extractEventDomainDefinition.mockReturnValue(null);
+
+      await createApigwResource(mockContext, testEvent, 'test-service', undefined, initialState);
+
+      expect(mockedApigwTypes.triggerToApigwApiConfig).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ backend: 'functions.hello_function' }),
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        undefined,
+      );
     });
 
     it('creates missing PROVIDER gateway log configuration on create', async () => {

--- a/tests/unit/stack/aliyunStack/deployer.test.ts
+++ b/tests/unit/stack/aliyunStack/deployer.test.ts
@@ -269,4 +269,83 @@ describe('Deployer Integration', () => {
       });
     });
   });
+
+  describe('buildRoleArnResolver', () => {
+    const fnA = { key: 'fn_a', name: 'fn-a-name', storage: {} };
+    const fnB = { key: 'fn_b', name: 'fn-b-name', storage: {} };
+
+    const stateWithRoles: StateFile = {
+      ...initialState,
+      resources: {
+        'functions.fn_a': {
+          mode: 'managed',
+          region: 'cn-hangzhou',
+          definition: {},
+          instances: [
+            { sid: 's', id: 'role-fn-a', type: 'ALIYUN_RAM_ROLE', roleArn: 'arn:role-fn-a' },
+          ],
+          lastUpdated: '',
+        },
+        'functions.fn_b': {
+          mode: 'managed',
+          region: 'cn-hangzhou',
+          definition: {},
+          instances: [
+            { sid: 's', id: 'role-fn-b', type: 'ALIYUN_RAM_ROLE', roleArn: 'arn:role-fn-b' },
+          ],
+          lastUpdated: '',
+        },
+      },
+    };
+
+    it('resolves a template reference backend to that function role', () => {
+      const { buildRoleArnResolver } = require('../../../../src/stack/aliyunStack/deployer');
+      const resolver = buildRoleArnResolver(stateWithRoles, [fnA, fnB]);
+
+      expect(resolver('${functions.fn_a}')).toBe('arn:role-fn-a');
+      expect(resolver('${functions.fn_b}')).toBe('arn:role-fn-b');
+    });
+
+    it('resolves a bare backend matching a template function name to that function role', () => {
+      const { buildRoleArnResolver } = require('../../../../src/stack/aliyunStack/deployer');
+      const resolver = buildRoleArnResolver(stateWithRoles, [fnA, fnB]);
+
+      expect(resolver('fn-b-name')).toBe('arn:role-fn-b');
+    });
+
+    it('falls back to the first managed role for an external backend', () => {
+      const { buildRoleArnResolver } = require('../../../../src/stack/aliyunStack/deployer');
+      const resolver = buildRoleArnResolver(stateWithRoles, [fnA, fnB]);
+
+      expect(resolver('external-deployed-fn')).toBe('arn:role-fn-a');
+    });
+
+    it('falls back to the first managed role when the referenced function has no role', () => {
+      const { buildRoleArnResolver } = require('../../../../src/stack/aliyunStack/deployer');
+      const stateWithRolelessFn: StateFile = {
+        ...initialState,
+        resources: {
+          'functions.fn_a': {
+            mode: 'managed',
+            region: 'cn-hangzhou',
+            definition: {},
+            instances: [],
+            lastUpdated: '',
+          },
+          'functions.fn_b': {
+            mode: 'managed',
+            region: 'cn-hangzhou',
+            definition: {},
+            instances: [
+              { sid: 's', id: 'role-fn-b', type: 'ALIYUN_RAM_ROLE', roleArn: 'arn:role-fn-b' },
+            ],
+            lastUpdated: '',
+          },
+        },
+      };
+      const resolver = buildRoleArnResolver(stateWithRolelessFn, [fnA, fnB]);
+
+      expect(resolver('${functions.fn_a}')).toBe('arn:role-fn-b');
+    });
+  });
 });

--- a/tests/unit/stack/aliyunStack/fc3Resource.test.ts
+++ b/tests/unit/stack/aliyunStack/fc3Resource.test.ts
@@ -9,6 +9,7 @@ import {
 import {
   Context,
   CURRENT_STATE_VERSION,
+  FunctionDomain,
   NasStorageClassEnum,
   PartialResourceError,
   StateFile,
@@ -1112,6 +1113,99 @@ describe('Fc3Resource', () => {
         'test-app-test-service-default-fc-role',
         ['fc.aliyuncs.com'],
       );
+    });
+
+    it('unions trust and baseline across functions sharing a legacy role (issue #229 review)', async () => {
+      const peerFunction: FunctionDomain = {
+        ...testFunction,
+        key: 'other_fn',
+        name: 'other-function',
+        network: {
+          vpc_id: 'vpc-123',
+          subnet_ids: ['subnet-1', 'subnet-2'],
+          security_group: { name: 'sg-1', ingress: [], egress: [] },
+        },
+      };
+      const contextWithPeer: Context = {
+        ...mockContext,
+        iac: {
+          version: '0.0.1',
+          app: 'test-app',
+          provider: {
+            name: ProviderEnum.ALIYUN,
+            region: 'cn-hangzhou',
+          },
+          service: 'test-service',
+          functions: [testFunction, peerFunction],
+          events: [
+            {
+              key: 'api_gateway',
+              name: 'test-api',
+              type: 'API_GATEWAY',
+              triggers: [
+                {
+                  method: 'GET',
+                  path: '/api/test',
+                  backend: '${functions.other_fn}',
+                },
+              ],
+            },
+          ],
+        },
+      };
+
+      const legacyRoleInstance = {
+        sid: 'si:aliyun:ram:default:test-app-test-service-default-fc-role',
+        roleArn: 'acs:ram::123456789012:role/test-app-test-service-default-fc-role',
+        id: 'test-app-test-service-default-fc-role',
+        type: 'ALIYUN_RAM_ROLE',
+      };
+      const sharedRoleState: StateFile = {
+        ...initialState,
+        resources: {
+          'functions.test_fn': {
+            mode: 'managed',
+            region: 'cn-hangzhou',
+            definition: mockDefinition,
+            instances: [
+              legacyRoleInstance,
+              {
+                sid: 'si:aliyun:fc3:default:test-function',
+                id: 'test-function',
+                type: 'ALIYUN_FC3_FUNCTION',
+              },
+            ],
+            lastUpdated: '2025-01-01T00:00:00Z',
+          },
+          'functions.other_fn': {
+            mode: 'managed',
+            region: 'cn-hangzhou',
+            definition: mockDefinition,
+            instances: [legacyRoleInstance],
+            lastUpdated: '2025-01-01T00:00:00Z',
+          },
+        },
+      };
+
+      mockedFc3Operations.updateFunctionConfiguration.mockResolvedValue(undefined);
+      mockedFc3Operations.updateFunctionCode.mockResolvedValue(undefined);
+      const newState = { ...sharedRoleState, _updated: true };
+      mockedStateManager.setResource.mockReturnValue(newState);
+
+      await updateResource(contextWithPeer, testFunction, sharedRoleState);
+
+      expect(mockedRamOperations.updateRoleTrustPolicy).toHaveBeenCalledWith(
+        'test-app-test-service-default-fc-role',
+        ['fc.aliyuncs.com', 'apigateway.aliyuncs.com'],
+      );
+
+      const policyDocumentCall = mockedRamOperations.updateExecutionPolicyDocument.mock.calls[0];
+      const policyDocument = JSON.parse(policyDocumentCall[1]) as {
+        Statement: Array<{ Action: string[] }>;
+      };
+      const actions = policyDocument.Statement.flatMap((statement) => statement.Action);
+      expect(actions).toContain('ecs:CreateNetworkInterface');
+      expect(actions).not.toContain('nas:*');
     });
 
     it('should add apigateway trust when a bare backend equals the function deployed name (issue #227)', async () => {

--- a/tests/unit/stack/aliyunStack/fc3Resource.test.ts
+++ b/tests/unit/stack/aliyunStack/fc3Resource.test.ts
@@ -2,6 +2,7 @@ import { ProviderEnum } from '../../../../src/common';
 import {
   createResource,
   deleteResource,
+  deriveFc3ExecutionStatements,
   readResource,
   updateResource,
 } from '../../../../src/stack/aliyunStack/fc3Resource';
@@ -55,6 +56,7 @@ const mockedRamOperations = {
   createRole: jest.fn(),
   updateRoleTrustPolicy: jest.fn(),
   updateRolePolicy: jest.fn(),
+  updateExecutionPolicyDocument: jest.fn(),
   updateManagedPolicies: jest.fn(),
   deleteRole: jest.fn(),
 };
@@ -230,6 +232,7 @@ describe('Fc3Resource', () => {
       arn: 'acs:ram::123456789012:role/test-role',
     });
     mockedRamOperations.updateRolePolicy.mockResolvedValue(undefined);
+    mockedRamOperations.updateExecutionPolicyDocument.mockResolvedValue(undefined);
     mockedRamOperations.updateManagedPolicies.mockResolvedValue(undefined);
     mockedRamOperations.deleteRole.mockResolvedValue(undefined);
     mockedSlsOperations.createProject.mockResolvedValue({ projectName: 'test-sls' });
@@ -1108,6 +1111,138 @@ describe('Fc3Resource', () => {
       expect(mockedRamOperations.updateRoleTrustPolicy).toHaveBeenCalledWith(
         'test-app-test-service-default-fc-role',
         ['fc.aliyuncs.com'],
+      );
+    });
+
+    it('should add apigateway trust when a bare backend equals the function deployed name (issue #227)', async () => {
+      const stateWithRamRole: StateFile = {
+        ...initialState,
+        resources: {
+          'functions.test_fn': {
+            mode: 'managed',
+            region: 'cn-hangzhou',
+            definition: mockDefinition,
+            instances: [
+              {
+                sid: 'si:aliyun:ram:default:test-app-test-service-default-fc-role',
+                roleArn: 'acs:ram::123456789012:role/test-app-test-service-default-fc-role',
+                id: 'test-app-test-service-default-fc-role',
+                type: 'ALIYUN_RAM_ROLE',
+              },
+              {
+                sid: 'si:aliyun:fc3:default:test-function',
+                id: 'test-function',
+                type: 'ALIYUN_FC3_FUNCTION',
+              },
+            ],
+            lastUpdated: '2025-01-01T00:00:00Z',
+          },
+        },
+      };
+
+      const contextWithBareNameBackend: Context = {
+        ...mockContext,
+        iac: {
+          version: '0.0.1',
+          app: 'test-app',
+          provider: {
+            name: ProviderEnum.ALIYUN,
+            region: 'cn-hangzhou',
+          },
+          service: 'test-service',
+          events: [
+            {
+              key: 'api_gateway',
+              name: 'test-api',
+              type: 'API_GATEWAY',
+              triggers: [
+                {
+                  method: 'GET',
+                  path: '/api/test',
+                  backend: 'test-function',
+                },
+              ],
+            },
+          ],
+        },
+      };
+
+      mockedFc3Operations.updateFunctionConfiguration.mockResolvedValue(undefined);
+      mockedFc3Operations.updateFunctionCode.mockResolvedValue(undefined);
+      const newState = { ...stateWithRamRole, _updated: true };
+      mockedStateManager.setResource.mockReturnValue(newState);
+
+      await updateResource(contextWithBareNameBackend, testFunction, stateWithRamRole);
+
+      expect(mockedRamOperations.updateRoleTrustPolicy).toHaveBeenCalledWith(
+        'test-app-test-service-default-fc-role',
+        ['fc.aliyuncs.com', 'apigateway.aliyuncs.com'],
+      );
+    });
+
+    it('should add apigateway trust for an external bare backend (gateway assumes the managed role, issue #227)', async () => {
+      const stateWithRamRole: StateFile = {
+        ...initialState,
+        resources: {
+          'functions.test_fn': {
+            mode: 'managed',
+            region: 'cn-hangzhou',
+            definition: mockDefinition,
+            instances: [
+              {
+                sid: 'si:aliyun:ram:default:test-app-test-service-default-fc-role',
+                roleArn: 'acs:ram::123456789012:role/test-app-test-service-default-fc-role',
+                id: 'test-app-test-service-default-fc-role',
+                type: 'ALIYUN_RAM_ROLE',
+              },
+              {
+                sid: 'si:aliyun:fc3:default:test-function',
+                id: 'test-function',
+                type: 'ALIYUN_FC3_FUNCTION',
+              },
+            ],
+            lastUpdated: '2025-01-01T00:00:00Z',
+          },
+        },
+      };
+
+      const contextWithExternalBackend: Context = {
+        ...mockContext,
+        iac: {
+          version: '0.0.1',
+          app: 'test-app',
+          provider: {
+            name: ProviderEnum.ALIYUN,
+            region: 'cn-hangzhou',
+          },
+          service: 'test-service',
+          events: [
+            {
+              key: 'api_gateway',
+              name: 'test-api',
+              type: 'API_GATEWAY',
+              triggers: [
+                {
+                  method: 'GET',
+                  path: '/api/test',
+                  backend: 'external-deployed-fn',
+                },
+              ],
+            },
+          ],
+        },
+      };
+
+      mockedFc3Operations.updateFunctionConfiguration.mockResolvedValue(undefined);
+      mockedFc3Operations.updateFunctionCode.mockResolvedValue(undefined);
+      const newState = { ...stateWithRamRole, _updated: true };
+      mockedStateManager.setResource.mockReturnValue(newState);
+
+      await updateResource(contextWithExternalBackend, testFunction, stateWithRamRole);
+
+      expect(mockedRamOperations.updateRoleTrustPolicy).toHaveBeenCalledWith(
+        'test-app-test-service-default-fc-role',
+        ['fc.aliyuncs.com', 'apigateway.aliyuncs.com'],
       );
     });
 
@@ -2318,11 +2453,11 @@ describe('Fc3Resource', () => {
       expect(mockedSlsOperations.createProject).toHaveBeenCalledWith('test-app-default-sls');
       expect(mockedSlsOperations.createLogstore).toHaveBeenCalledWith(
         'test-app-default-sls',
-        'test-service-default-fn-logs',
+        'test-service-default-test-fn-fn-logs',
       );
       expect(mockedSlsOperations.createIndex).toHaveBeenCalledWith(
         'test-app-default-sls',
-        'test-service-default-fn-logs',
+        'test-service-default-test-fn-fn-logs',
       );
       expect(mockedSlsOperations.waitForLogstore).toHaveBeenCalled();
       expect(mockedFc3Types.functionToFc3Config).toHaveBeenCalled();
@@ -2379,7 +2514,7 @@ describe('Fc3Resource', () => {
       expect(mockedSlsOperations.createProject).toHaveBeenCalledWith('test-app-default-sls');
       expect(mockedSlsOperations.createLogstore).toHaveBeenCalledWith(
         'test-app-default-sls',
-        'test-service-default-fn-logs',
+        'test-service-default-test-fn-fn-logs',
       );
       const fnResource = result.resources['functions.test_fn'];
       const instanceTypes = fnResource.instances.map((i) => i.type as string);
@@ -3330,6 +3465,7 @@ describe('Fc3Resource', () => {
         undefined,
         fnWithCustomRole.iam.role.statements,
         ['AliyunOSSFullAccess', 'AliyunLogFullAccess'],
+        expect.any(Array),
       );
       expect(mockedFc3Operations.createFunction).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -3357,19 +3493,20 @@ describe('Fc3Resource', () => {
       };
 
       mockedRamOperations.createRole.mockResolvedValueOnce({
-        roleName: 'test-app-test-service-default-fc-role',
-        arn: 'acs:ram::123456789012:role/test-app-test-service-default-fc-role',
-        policyName: 'test-app-test-service-default-fc-role-policy',
+        roleName: 'test-app-test-service-default-test-fn-role',
+        arn: 'acs:ram::123456789012:role/test-app-test-service-default-test-fn-role',
+        policyName: 'test-app-test-service-default-test-fn-role-policy',
       });
 
       await createResource(mockContext, fnWithDefaultRole, initialState);
 
       expect(mockedRamOperations.createRole).toHaveBeenCalledWith(
-        'test-app-test-service-default-fc-role',
+        'test-app-test-service-default-test-fn-role',
         ['fc.aliyuncs.com'],
         undefined,
         fnWithDefaultRole.iam.role.statements,
         undefined,
+        expect.any(Array),
       );
     });
 
@@ -3514,6 +3651,7 @@ describe('Fc3Resource', () => {
       expect(mockedRamOperations.updateRolePolicy).toHaveBeenCalledWith(
         'test-app-test-service-default-fc-role',
         fnWithUpdatedStatements.iam.role.statements,
+        expect.any(Array),
       );
     });
 
@@ -3620,6 +3758,217 @@ describe('Fc3Resource', () => {
       // External role should NOT be deleted
       expect(mockedRamOperations.deleteRole).not.toHaveBeenCalled();
       expect(result).toEqual(initialState);
+    });
+  });
+
+  describe('deriveFc3ExecutionStatements', () => {
+    it('yields only fc+log statements for a bare function', () => {
+      const statements = deriveFc3ExecutionStatements(testFunction, mockContext);
+
+      expect(statements).toHaveLength(2);
+      expect(statements[0]).toEqual({
+        effect: 'Allow',
+        action: ['fc:InvokeFunction'],
+        resource: ['*'],
+      });
+      expect(statements[1].effect).toBe('Allow');
+      expect(statements[1].action).toEqual([
+        'log:PostLogStoreLogs',
+        'log:CreateLogStore',
+        'log:GetLogStore',
+        'log:ListShards',
+        'log:GetCursorOrData',
+      ]);
+      expect(statements[1].resource).toEqual(['*']);
+    });
+
+    it('scopes the log resource when logConfig and accountId are known', () => {
+      const statements = deriveFc3ExecutionStatements(testFunction, mockContext, {
+        project: 'test-sls',
+        logstore: 'test-logstore',
+      });
+
+      expect(statements[1].resource).toEqual([
+        'acs:log:cn-hangzhou:123456789012:project/test-sls/logstore/test-logstore',
+      ]);
+    });
+
+    it('adds ecs/vpc statements when fn.network is present', () => {
+      const fnWithNetwork = {
+        ...testFunction,
+        network: {
+          vpc_id: 'vpc-123',
+          subnet_ids: ['vsw-123'],
+          security_group: { name: 'sg', ingress: [] as string[], egress: [] as string[] },
+        },
+      };
+
+      const statements = deriveFc3ExecutionStatements(fnWithNetwork, mockContext);
+      const actions = statements.flatMap((s) => s.action);
+
+      expect(actions).toContain('ecs:CreateNetworkInterface');
+      expect(actions).toContain('ecs:DeleteNetworkInterface');
+      expect(actions).toContain('ecs:DescribeNetworkInterfaces');
+      expect(actions).toContain('ecs:CreateNetworkInterfacePermission');
+      expect(actions).toContain('ecs:DescribeNetworkInterfacePermissions');
+      expect(actions).toContain('ecs:DeleteNetworkInterfacePermission');
+      expect(actions).toContain('vpc:DescribeVSwitchAttributes');
+    });
+
+    it('adds nas statements when fn.storage.nas is present', () => {
+      const fnWithNas = {
+        ...testFunction,
+        network: {
+          vpc_id: 'vpc-123',
+          subnet_ids: ['vsw-123'],
+          security_group: { name: 'sg', ingress: [] as string[], egress: [] as string[] },
+        },
+        storage: {
+          nas: [
+            {
+              storage_class: NasStorageClassEnum.STANDARD_CAPACITY,
+              mount_path: '/mnt/data',
+            },
+          ],
+        },
+      };
+
+      const statements = deriveFc3ExecutionStatements(fnWithNas, mockContext);
+
+      expect(statements.some((s) => s.action.includes('nas:*'))).toBe(true);
+    });
+  });
+
+  describe('per-function execution role naming', () => {
+    it('creates a per-function role named with the function key on new deployment', async () => {
+      mockedFc3Operations.getFunction.mockResolvedValueOnce(mockFunctionInfo);
+      mockedFc3Operations.createFunction.mockResolvedValue(undefined);
+      const readyState = { ...initialState, _ready: true };
+      mockedStateManager.setResource.mockReturnValue(readyState);
+      mockedRamOperations.createRole.mockResolvedValue({
+        roleName: 'test-app-test-service-default-test-fn-role',
+        arn: 'acs:ram::123456789012:role/test-app-test-service-default-test-fn-role',
+      });
+
+      await createResource(mockContext, testFunction, initialState);
+
+      expect(mockedRamOperations.createRole).toHaveBeenCalledWith(
+        'test-app-test-service-default-test-fn-role',
+        ['fc.aliyuncs.com'],
+        undefined,
+        undefined,
+        undefined,
+        expect.any(Array),
+      );
+      expect(mockedFc3Operations.createFunction).toHaveBeenCalledWith(
+        expect.objectContaining({
+          role: 'acs:ram::123456789012:role/test-app-test-service-default-test-fn-role',
+        }),
+        'test.zip',
+        undefined,
+      );
+    });
+
+    it('reuses the existing role id on redeploy without recreating the role', async () => {
+      const taintedStateWithLegacyRole: StateFile = {
+        ...initialState,
+        resources: {
+          'functions.test_fn': {
+            mode: 'managed',
+            region: 'cn-hangzhou',
+            definition: mockDefinition,
+            instances: [
+              {
+                sid: 'si:aliyun:ram:default:test-app-test-service-default-fc-role',
+                roleArn: 'acs:ram::123456789012:role/test-app-test-service-default-fc-role',
+                id: 'test-app-test-service-default-fc-role',
+                type: 'ALIYUN_RAM_ROLE',
+                roleName: 'test-app-test-service-default-fc-role',
+              },
+            ],
+            lastUpdated: '2025-01-01T00:00:00Z',
+            status: 'tainted',
+          },
+        },
+      };
+      mockedFc3Operations.createFunction.mockResolvedValue(undefined);
+      mockedStateManager.setResource.mockReturnValue(taintedStateWithLegacyRole);
+
+      await createResource(mockContext, testFunction, taintedStateWithLegacyRole);
+
+      expect(mockedRamOperations.createRole).not.toHaveBeenCalled();
+      expect(mockedRamOperations.updateRoleTrustPolicy).toHaveBeenCalledWith(
+        'test-app-test-service-default-fc-role',
+        ['fc.aliyuncs.com'],
+      );
+      expect(mockedRamOperations.updateExecutionPolicyDocument).toHaveBeenCalledWith(
+        'test-app-test-service-default-fc-role',
+        expect.stringContaining('fc:InvokeFunction'),
+      );
+    });
+  });
+
+  describe('updateResource policy propagation', () => {
+    const stateWithRamRole = (): StateFile => ({
+      ...initialState,
+      resources: {
+        'functions.test_fn': {
+          mode: 'managed',
+          region: 'cn-hangzhou',
+          definition: mockDefinition,
+          instances: [
+            {
+              sid: 'si:aliyun:ram:default:test-app-test-service-default-fc-role',
+              roleArn: 'acs:ram::123456789012:role/test-app-test-service-default-fc-role',
+              id: 'test-app-test-service-default-fc-role',
+              type: 'ALIYUN_RAM_ROLE',
+            },
+            {
+              sid: 'si:aliyun:fc3:default:test-function',
+              id: 'test-function',
+              type: 'ALIYUN_FC3_FUNCTION',
+            },
+          ],
+          lastUpdated: '2025-01-01T00:00:00Z',
+        },
+      },
+    });
+
+    it('propagates the derived execution policy document on redeploy', async () => {
+      mockedFc3Operations.updateFunctionConfiguration.mockResolvedValue(undefined);
+      mockedFc3Operations.updateFunctionCode.mockResolvedValue(undefined);
+      mockedStateManager.setResource.mockReturnValue({ ...stateWithRamRole(), _updated: true });
+
+      await updateResource(mockContext, testFunction, stateWithRamRole());
+
+      expect(mockedRamOperations.updateRoleTrustPolicy).toHaveBeenCalledWith(
+        'test-app-test-service-default-fc-role',
+        ['fc.aliyuncs.com'],
+      );
+      expect(mockedRamOperations.updateExecutionPolicyDocument).toHaveBeenCalledWith(
+        'test-app-test-service-default-fc-role',
+        expect.stringContaining('fc:InvokeFunction'),
+      );
+    });
+
+    it('merges custom statements after the derived baseline in the propagated document', async () => {
+      const fnWithCustomStatements = {
+        ...testFunction,
+        iam: {
+          role: {
+            statements: [{ effect: 'Allow' as const, action: ['oss:GetObject'], resource: ['*'] }],
+          },
+        },
+      };
+      mockedFc3Operations.updateFunctionConfiguration.mockResolvedValue(undefined);
+      mockedFc3Operations.updateFunctionCode.mockResolvedValue(undefined);
+      mockedStateManager.setResource.mockReturnValue({ ...stateWithRamRole(), _updated: true });
+
+      await updateResource(mockContext, fnWithCustomStatements, stateWithRamRole());
+
+      const docArg = mockedRamOperations.updateExecutionPolicyDocument.mock.calls[0][1] as string;
+      const parsed = JSON.parse(docArg) as { Statement: Array<{ Action: string[] }> };
+      expect(parsed.Statement.some((s) => s.Action.includes('oss:GetObject'))).toBe(true);
     });
   });
 });

--- a/tests/unit/stack/aliyunStack/sharedLogProject.test.ts
+++ b/tests/unit/stack/aliyunStack/sharedLogProject.test.ts
@@ -339,35 +339,36 @@ describe('sharedLogProject (aliyun)', () => {
   });
 
   describe('ensureFunctionLogstore', () => {
-    it('creates service-scoped function logstore in shared project', async () => {
+    it('creates a per-function logstore in the shared project', async () => {
       const result = await ensureFunctionLogstore(
         mockContext,
         mockClient as never,
         'test-app-dev-sls',
+        'test_fn',
       );
 
-      expect(result).toEqual({ logstoreName: 'test-service-dev-fn-logs' });
+      expect(result).toEqual({ logstoreName: 'test-service-dev-test-fn-fn-logs' });
       expect(mockClient.sls.getLogstore).toHaveBeenCalledWith(
         'test-app-dev-sls',
-        'test-service-dev-fn-logs',
+        'test-service-dev-test-fn-fn-logs',
       );
       expect(mockClient.sls.createLogstore).toHaveBeenCalledWith(
         'test-app-dev-sls',
-        'test-service-dev-fn-logs',
+        'test-service-dev-test-fn-fn-logs',
       );
       expect(mockClient.sls.createIndex).toHaveBeenCalledWith(
         'test-app-dev-sls',
-        'test-service-dev-fn-logs',
+        'test-service-dev-test-fn-fn-logs',
       );
       expect(mockClient.sls.waitForLogstore).toHaveBeenCalledWith(
         'test-app-dev-sls',
-        'test-service-dev-fn-logs',
+        'test-service-dev-test-fn-fn-logs',
       );
     });
 
     it('reuses an existing function logstore without re-creating it', async () => {
       mockClient.sls.getLogstore.mockResolvedValue({
-        logstoreName: 'test-service-dev-fn-logs',
+        logstoreName: 'test-service-dev-test-fn-fn-logs',
         projectName: 'test-app-dev-sls',
       });
 
@@ -375,9 +376,10 @@ describe('sharedLogProject (aliyun)', () => {
         mockContext,
         mockClient as never,
         'test-app-dev-sls',
+        'test_fn',
       );
 
-      expect(result).toEqual({ logstoreName: 'test-service-dev-fn-logs' });
+      expect(result).toEqual({ logstoreName: 'test-service-dev-test-fn-fn-logs' });
       expect(mockClient.sls.createLogstore).not.toHaveBeenCalled();
       expect(mockClient.sls.createIndex).not.toHaveBeenCalled();
     });

--- a/tests/unit/stack/localStack/aliyunFc.test.ts
+++ b/tests/unit/stack/localStack/aliyunFc.test.ts
@@ -38,12 +38,12 @@ describe('Aliyun FC LocalStack', () => {
           {
             method: 'GET',
             path: '/api/v1/hello',
-            backend: 'aliyun_fc_fn',
+            backend: 'aliyun-fc-function',
           },
           {
             method: 'POST',
             path: '/api/v1/hello',
-            backend: 'aliyun_fc_fn',
+            backend: 'aliyun-fc-function',
           },
         ],
       },
@@ -165,12 +165,12 @@ describe('Aliyun FC LocalStack - HTML serving', () => {
           {
             method: 'GET',
             path: '/map/map.html',
-            backend: 'html_fn',
+            backend: 'html-serving-function',
           },
           {
             method: 'GET',
             path: '/static/style.css',
-            backend: 'css_fn',
+            backend: 'css-serving-function',
           },
         ],
       },

--- a/tests/unit/stack/scfStack/scfPlanner.test.ts
+++ b/tests/unit/stack/scfStack/scfPlanner.test.ts
@@ -328,7 +328,10 @@ describe('SCF Planner', () => {
       });
       expect(plan.items[0].changes?.after).toEqual(
         expect.objectContaining({
-          logConfig: { logset: 'test-app-default-cls', topic: 'test-service-default-fn-logs' },
+          logConfig: {
+            logset: 'test-app-default-cls',
+            topic: 'test-service-default-test_fn-fn-logs',
+          },
         }),
       );
     });

--- a/tests/unit/stack/scfStack/scfResource.test.ts
+++ b/tests/unit/stack/scfStack/scfResource.test.ts
@@ -3,6 +3,7 @@ import {
   readResource,
   updateResource,
   deleteResource,
+  deriveScfExecutionStatements,
 } from '../../../../src/stack/scfStack/scfResource';
 import * as scfTypes from '../../../../src/stack/scfStack/scfTypes';
 import * as stateManager from '../../../../src/common/stateManager';
@@ -52,7 +53,10 @@ const mockClsOperations = {
 
 jest.mock('../../../../src/stack/scfStack/scfTypes');
 jest.mock('../../../../src/common/stateManager');
-jest.mock('../../../../src/common/hashUtils');
+jest.mock('../../../../src/common/hashUtils', () => ({
+  ...jest.requireActual('../../../../src/common/hashUtils'),
+  computeZipContentHash: jest.fn(),
+}));
 
 jest.mock('../../../../src/common/tencentClient', () => ({
   createTencentClient: () => ({
@@ -267,6 +271,7 @@ describe('ScfResource', () => {
         expect.any(String),
         expect.arrayContaining([expect.objectContaining({ effect: 'Allow' })]),
         undefined,
+        deriveScfExecutionStatements(fnWithIam, mockContext),
       );
 
       // Should pass role to SCF config
@@ -364,6 +369,262 @@ describe('ScfResource', () => {
       expect(mockScfOperations.createFunction).toHaveBeenCalledWith(
         expectedConfig,
         'base64encodedcontent',
+      );
+    });
+
+    it('should create a per-function CAM role with derived name and baseline on new deploy', async () => {
+      jest.useFakeTimers();
+
+      const fnWithIam = {
+        ...testFunction,
+        iam: { role: {} },
+      };
+
+      const derivedName = 'test-app-test-service-default-test-fn-role';
+      (mockCamOperations.createRole as jest.Mock).mockResolvedValue({
+        roleName: derivedName,
+        roleId: 'role-id',
+        roleArn: derivedName,
+        policyName: `${derivedName}-policy`,
+      });
+      (mockScfOperations.createFunction as jest.Mock).mockResolvedValue(undefined);
+      (stateManager.setResource as jest.Mock).mockReturnValue(initialState);
+
+      const createPromise = createResource(mockContext, fnWithIam, initialState);
+      await jest.advanceTimersByTimeAsync(5000);
+      await createPromise;
+
+      expect(mockCamOperations.createRole).toHaveBeenCalledWith(
+        derivedName,
+        ['scf.qcloud.com'],
+        expect.any(String),
+        undefined,
+        undefined,
+        deriveScfExecutionStatements(fnWithIam, mockContext),
+      );
+      expect(mockScfOperations.createFunction).toHaveBeenCalledWith(
+        expect.objectContaining({ Role: derivedName }),
+        'base64encodedcontent',
+      );
+    });
+
+    it('should prefer custom iam.role.name over the derived per-function name', async () => {
+      jest.useFakeTimers();
+
+      const fnWithIam = {
+        ...testFunction,
+        iam: { role: { name: 'my-custom-role' } },
+      };
+
+      (mockCamOperations.createRole as jest.Mock).mockResolvedValue({
+        roleName: 'my-custom-role',
+        roleId: 'role-id',
+        roleArn: 'my-custom-role',
+        policyName: 'my-custom-role-policy',
+      });
+      (mockScfOperations.createFunction as jest.Mock).mockResolvedValue(undefined);
+      (stateManager.setResource as jest.Mock).mockReturnValue(initialState);
+
+      const createPromise = createResource(mockContext, fnWithIam, initialState);
+      await jest.advanceTimersByTimeAsync(5000);
+      await createPromise;
+
+      expect(mockCamOperations.createRole).toHaveBeenCalledWith(
+        'my-custom-role',
+        expect.any(Array),
+        expect.any(String),
+        undefined,
+        undefined,
+        deriveScfExecutionStatements(fnWithIam, mockContext),
+      );
+    });
+
+    it('should reuse the existing role id (migration) instead of the derived per-function name', async () => {
+      const legacyRoleId = 'test-app-test-service-default-scf-role';
+      const stateWithLegacyRole: StateFile = {
+        ...initialState,
+        resources: {
+          'functions.test_fn': {
+            mode: 'managed',
+            region: 'ap-guangzhou',
+            definition: mockDefinition,
+            instances: [
+              {
+                sid: 'si:tencent:scf:default:test-function',
+                id: 'test-function',
+                functionName: 'test-function',
+              },
+              {
+                sid: `si:tencent:scf-role:default:${legacyRoleId}`,
+                type: ResourceTypeEnum.TENCENT_SCF_ROLE,
+                id: legacyRoleId,
+                roleArn: legacyRoleId,
+              },
+            ],
+            lastUpdated: '2025-01-01T00:00:00Z',
+          },
+        },
+      };
+
+      const fnWithIam = { ...testFunction, iam: { role: {} } };
+
+      (stateManager.getResource as jest.Mock).mockReturnValue(
+        stateWithLegacyRole.resources['functions.test_fn'],
+      );
+      (mockScfOperations.createFunction as jest.Mock).mockResolvedValue(undefined);
+      (stateManager.setResource as jest.Mock).mockReturnValue(initialState);
+
+      await createResource(mockContext, fnWithIam, stateWithLegacyRole);
+
+      expect(mockCamOperations.createRole).not.toHaveBeenCalled();
+      expect(mockScfOperations.createFunction).toHaveBeenCalledWith(
+        expect.objectContaining({ Role: legacyRoleId }),
+        'base64encodedcontent',
+      );
+    });
+
+    it('derives the least-privilege execution baseline for a bare function', () => {
+      expect(deriveScfExecutionStatements(testFunction, mockContext)).toEqual([
+        { effect: 'Allow', action: ['scf:InvokeFunction'], resource: ['*'] },
+        {
+          effect: 'Allow',
+          action: ['cls:logset:putlog', 'cls:logset:create*', 'cls:logset:get*'],
+          resource: ['*'],
+        },
+        {
+          effect: 'Allow',
+          action: ['cos:GetObject', 'cos:PutObject', 'cos:DeleteObject', 'cos:ListBucket'],
+          resource: ['*'],
+        },
+      ]);
+    });
+
+    it('does not re-propagate the policy when iam statements are unchanged on reuse', async () => {
+      const stateWithRole: StateFile = {
+        ...initialState,
+        resources: {
+          'functions.test_fn': {
+            mode: 'managed',
+            region: 'ap-guangzhou',
+            definition: {
+              ...mockDefinition,
+              iam: {
+                role: {
+                  name: 'existing-role',
+                  statements: [
+                    { effect: 'Allow', action: ['scf:InvokeFunction'], resource: ['*'] },
+                  ],
+                },
+              },
+            },
+            instances: [
+              {
+                sid: 'si:tencent:scf:default:test-function',
+                id: 'test-function',
+                functionName: 'test-function',
+              },
+              {
+                sid: 'si:tencent:scf-role:default:existing-role',
+                type: ResourceTypeEnum.TENCENT_SCF_ROLE,
+                id: 'existing-role',
+                roleArn: 'existing-role',
+              },
+            ],
+            lastUpdated: '2025-01-01T00:00:00Z',
+          },
+        },
+      };
+
+      const fnWithIam = {
+        ...testFunction,
+        iam: {
+          role: {
+            name: 'existing-role',
+            statements: [
+              { effect: 'Allow' as const, action: ['scf:InvokeFunction'], resource: ['*'] },
+            ],
+          },
+        },
+      };
+
+      (stateManager.getResource as jest.Mock).mockReturnValue(
+        stateWithRole.resources['functions.test_fn'],
+      );
+      (mockScfOperations.createFunction as jest.Mock).mockResolvedValue(undefined);
+      (stateManager.setResource as jest.Mock).mockReturnValue(initialState);
+
+      await createResource(mockContext, fnWithIam, stateWithRole);
+
+      expect(mockCamOperations.createRole).not.toHaveBeenCalled();
+      expect(mockCamOperations.updateRolePolicy).not.toHaveBeenCalled();
+      expect(mockScfOperations.createFunction).toHaveBeenCalledWith(
+        expect.objectContaining({ Role: 'existing-role' }),
+        'base64encodedcontent',
+      );
+    });
+
+    it('propagates the policy with derived baseline when iam statements change on reuse', async () => {
+      const stateWithRole: StateFile = {
+        ...initialState,
+        resources: {
+          'functions.test_fn': {
+            mode: 'managed',
+            region: 'ap-guangzhou',
+            definition: {
+              ...mockDefinition,
+              iam: {
+                role: {
+                  name: 'existing-role',
+                  statements: [
+                    { effect: 'Allow', action: ['scf:InvokeFunction'], resource: ['*'] },
+                  ],
+                },
+              },
+            },
+            instances: [
+              {
+                sid: 'si:tencent:scf:default:test-function',
+                id: 'test-function',
+                functionName: 'test-function',
+              },
+              {
+                sid: 'si:tencent:scf-role:default:existing-role',
+                type: ResourceTypeEnum.TENCENT_SCF_ROLE,
+                id: 'existing-role',
+                roleArn: 'existing-role',
+              },
+            ],
+            lastUpdated: '2025-01-01T00:00:00Z',
+          },
+        },
+      };
+
+      const fnWithChangedStatements = {
+        ...testFunction,
+        iam: {
+          role: {
+            name: 'existing-role',
+            statements: [
+              { effect: 'Allow' as const, action: ['scf:InvokeFunction'], resource: ['*'] },
+              { effect: 'Allow' as const, action: ['cos:PutObject'], resource: ['*'] },
+            ],
+          },
+        },
+      };
+
+      (stateManager.getResource as jest.Mock).mockReturnValue(
+        stateWithRole.resources['functions.test_fn'],
+      );
+      (mockCamOperations.updateRolePolicy as jest.Mock).mockResolvedValue(undefined);
+      (mockScfOperations.createFunction as jest.Mock).mockResolvedValue(undefined);
+      (stateManager.setResource as jest.Mock).mockReturnValue(initialState);
+
+      await createResource(mockContext, fnWithChangedStatements, stateWithRole);
+
+      expect(mockCamOperations.updateRolePolicy).toHaveBeenCalledWith(
+        'existing-role',
+        fnWithChangedStatements.iam.role.statements,
+        deriveScfExecutionStatements(fnWithChangedStatements, mockContext),
       );
     });
 
@@ -1076,7 +1337,7 @@ describe('ScfResource', () => {
       ]);
       expect(mockClsOperations.createTopic).toHaveBeenCalledWith(
         'logset-1',
-        'test-service-default-fn-logs',
+        'test-service-default-test_fn-fn-logs',
         expect.objectContaining({
           period: 30,
           storageType: 'hot',
@@ -1659,6 +1920,7 @@ describe('ScfResource', () => {
             name: 'existing-role',
             statements: [
               { effect: 'Allow' as const, action: ['scf:InvokeFunction'], resource: ['*'] },
+              { effect: 'Allow' as const, action: ['cos:GetObject'], resource: ['*'] },
             ],
             managed_policies: ['QcloudSCFFullAccess'],
           },

--- a/tests/unit/stack/scfStack/sharedLogset.test.ts
+++ b/tests/unit/stack/scfStack/sharedLogset.test.ts
@@ -95,7 +95,13 @@ describe('sharedLogset', () => {
   });
 
   describe('buildFunctionTopicName', () => {
-    it('builds the canonical function topic name', () => {
+    it('builds the canonical per-function topic name', () => {
+      expect(buildFunctionTopicName(mockContext, 'test_fn')).toBe(
+        'test-service-dev-test_fn-fn-logs',
+      );
+    });
+
+    it('builds the legacy service-scoped shape when no function key is given', () => {
       expect(buildFunctionTopicName(mockContext)).toBe('test-service-dev-fn-logs');
     });
   });

--- a/tests/unit/stack/volcengineStack/apigwResource.test.ts
+++ b/tests/unit/stack/volcengineStack/apigwResource.test.ts
@@ -394,7 +394,7 @@ describe('apigwResource', () => {
       });
       mockClient.tls.createTopic.mockResolvedValue({
         topicId: 'topic-1',
-        topicName: 'test-service-dev-apigw-logs',
+        topicName: 'test-service-dev-api_gateway-apigw-logs',
       });
       mockClient.tls.getTopic.mockResolvedValue(null);
 
@@ -412,7 +412,7 @@ describe('apigwResource', () => {
       expect(mockClient.tls.createTopic).toHaveBeenCalledWith(
         expect.objectContaining({
           projectName: 'test-app-dev-tls',
-          topicName: 'test-service-dev-apigw-logs',
+          topicName: 'test-service-dev-api_gateway-apigw-logs',
         }),
       );
       expect(mockClient.apigw.updateGatewayLog).toHaveBeenCalledWith('gw-1', {
@@ -485,7 +485,7 @@ describe('apigwResource', () => {
       });
       mockClient.tls.createTopic.mockResolvedValue({
         topicId: 'topic-1',
-        topicName: 'test-service-dev-apigw-logs',
+        topicName: 'test-service-dev-api_gateway-apigw-logs',
       });
 
       await createApigwResource(mockContext, eventWithLog, 'test-service', stateWithExistingLogs);
@@ -508,7 +508,7 @@ describe('apigwResource', () => {
       });
       mockClient.tls.createTopic.mockResolvedValue({
         topicId: 'topic-1',
-        topicName: 'test-service-dev-apigw-logs',
+        topicName: 'test-service-dev-api_gateway-apigw-logs',
       });
       mockClient.tls.getTopic.mockResolvedValue(null);
 
@@ -523,7 +523,7 @@ describe('apigwResource', () => {
       expect(mockClient.tls.createTopic).toHaveBeenCalledWith(
         expect.objectContaining({
           projectName: 'test-app-dev-tls',
-          topicName: 'test-service-dev-apigw-logs',
+          topicName: 'test-service-dev-api_gateway-apigw-logs',
         }),
       );
       expect(mockClient.tls.addTags).toHaveBeenCalledWith(
@@ -536,7 +536,7 @@ describe('apigwResource', () => {
       const saved = result.resources['events.api_gateway'];
       const topic = saved.instances.find((i) => (i.type as string) === 'VOLCENGINE_TLS_TOPIC');
       expect(topic).toMatchObject({
-        id: 'test-app-dev-tls/test-service-dev-apigw-logs',
+        id: 'test-app-dev-tls/test-service-dev-api_gateway-apigw-logs',
         topicId: 'topic-1',
         projectId: 'proj-1',
       });
@@ -736,7 +736,7 @@ describe('apigwResource', () => {
               {
                 type: 'VOLCENGINE_TLS_TOPIC',
                 sid: 's',
-                id: 'test-service-dev-apigw-tls/test-service-dev-apigw-logs',
+                id: 'test-service-dev-apigw-tls/test-service-dev-api_gateway-apigw-logs',
                 topicId: 'topic-existing',
               },
             ],
@@ -791,13 +791,13 @@ describe('apigwResource', () => {
               {
                 type: 'VOLCENGINE_TLS_TOPIC',
                 sid: 's',
-                id: 'test-service-dev-apigw-tls/test-service-dev-apigw-logs',
+                id: 'test-service-dev-apigw-tls/test-service-dev-api_gateway-apigw-logs',
                 topicId: 'topic-existing',
               },
               {
                 type: 'VOLCENGINE_TLS_INDEX',
                 sid: 's',
-                id: 'test-service-dev-apigw-tls/test-service-dev-apigw-logs/index',
+                id: 'test-service-dev-apigw-tls/test-service-dev-api_gateway-apigw-logs/index',
               },
             ],
           },
@@ -827,11 +827,11 @@ describe('apigwResource', () => {
       // Index deleted before topic; the legacy own-project after its children.
       expect(mockClient.tls.deleteIndex).toHaveBeenCalledWith(
         'test-service-dev-apigw-tls',
-        'test-service-dev-apigw-logs',
+        'test-service-dev-api_gateway-apigw-logs',
       );
       expect(mockClient.tls.deleteTopic).toHaveBeenCalledWith(
         'test-service-dev-apigw-tls',
-        'test-service-dev-apigw-logs',
+        'test-service-dev-api_gateway-apigw-logs',
       );
       expect(mockClient.tls.deleteProject).toHaveBeenCalledWith('test-service-dev-apigw-tls');
       // Stale TLS instances are removed from the resource state.
@@ -875,13 +875,13 @@ describe('apigwResource', () => {
               {
                 type: 'VOLCENGINE_TLS_TOPIC',
                 sid: 's',
-                id: 'test-app-dev-tls/test-service-dev-apigw-logs',
+                id: 'test-app-dev-tls/test-service-dev-api_gateway-apigw-logs',
                 topicId: 'topic-1',
               },
               {
                 type: 'VOLCENGINE_TLS_INDEX',
                 sid: 's',
-                id: 'test-app-dev-tls/test-service-dev-apigw-logs/index',
+                id: 'test-app-dev-tls/test-service-dev-api_gateway-apigw-logs/index',
               },
             ],
           },
@@ -951,13 +951,13 @@ describe('apigwResource', () => {
               {
                 type: 'VOLCENGINE_TLS_TOPIC',
                 sid: 's',
-                id: 'test-app-dev-tls/test-service-dev-apigw-logs',
+                id: 'test-app-dev-tls/test-service-dev-api_gateway-apigw-logs',
                 topicId: 'topic-1',
               },
               {
                 type: 'VOLCENGINE_TLS_INDEX',
                 sid: 's',
-                id: 'test-app-dev-tls/test-service-dev-apigw-logs/index',
+                id: 'test-app-dev-tls/test-service-dev-api_gateway-apigw-logs/index',
               },
             ],
           },
@@ -1097,13 +1097,13 @@ describe('apigwResource', () => {
               {
                 type: 'VOLCENGINE_TLS_TOPIC',
                 sid: 's',
-                id: 'test-app-dev-tls/test-service-dev-apigw-logs',
+                id: 'test-app-dev-tls/test-service-dev-api_gateway-apigw-logs',
                 topicId: 'topic-1',
               },
               {
                 type: 'VOLCENGINE_TLS_INDEX',
                 sid: 's',
-                id: 'test-app-dev-tls/test-service-dev-apigw-logs/index',
+                id: 'test-app-dev-tls/test-service-dev-api_gateway-apigw-logs/index',
               },
               {
                 type: 'VOLCENGINE_TLS_PROJECT',
@@ -1129,11 +1129,11 @@ describe('apigwResource', () => {
       });
       expect(mockClient.tls.deleteIndex).toHaveBeenCalledWith(
         'test-app-dev-tls',
-        'test-service-dev-apigw-logs',
+        'test-service-dev-api_gateway-apigw-logs',
       );
       expect(mockClient.tls.deleteTopic).toHaveBeenCalledWith(
         'test-app-dev-tls',
-        'test-service-dev-apigw-logs',
+        'test-service-dev-api_gateway-apigw-logs',
       );
       // The stage-shared project is destroyer-owned — never deleted at resource level.
       expect(mockClient.tls.deleteProject).not.toHaveBeenCalled();

--- a/tests/unit/stack/volcengineStack/apigwResource.test.ts
+++ b/tests/unit/stack/volcengineStack/apigwResource.test.ts
@@ -54,6 +54,10 @@ const mockClient = {
     deleteCustomDomain: jest.fn(),
     updateGatewayLog: jest.fn(),
   },
+  vefaas: {
+    getFunction: jest.fn(),
+    getFunctionById: jest.fn(),
+  },
   tls: {
     createProject: jest.fn(),
     getProject: jest.fn(),
@@ -247,6 +251,39 @@ describe('apigwResource', () => {
       expect(types).toContain('VOLCENGINE_APIGW_SERVICE');
       expect(types).toContain('VOLCENGINE_APIGW_UPSTREAM');
       expect(types).toContain('VOLCENGINE_APIGW_ROUTE');
+    });
+
+    it('resolves an external bare backend function Id from the provider (issue #227)', async () => {
+      const externalEvent: EventDomain = {
+        ...mockEvent,
+        triggers: [
+          { method: 'POST', path: '/graphql', backend: 'external-deployed-fn' },
+          { method: 'GET', path: '/health', backend: 'external-deployed-fn' },
+        ],
+      };
+      mockClient.vefaas.getFunction.mockResolvedValue({
+        functionId: 'ext-fn-1',
+        functionName: 'external-deployed-fn',
+      });
+
+      const result = await createApigwResource(
+        mockContext,
+        externalEvent,
+        'test-service',
+        stateWithFunction,
+      );
+
+      expect(mockClient.vefaas.getFunction).toHaveBeenCalledWith('external-deployed-fn');
+      expect(mockClient.apigw.createUpstream).toHaveBeenCalledWith(
+        expect.objectContaining({
+          gatewayId: 'gw-1',
+          sourceType: 'VeFaas',
+          functionId: 'ext-fn-1',
+        }),
+      );
+      const saved = result.resources['events.api_gateway'];
+      const types = saved.instances.map((i) => (i as unknown as { type: string }).type);
+      expect(types).toContain('VOLCENGINE_APIGW_UPSTREAM');
     });
 
     it('retains the full provider detail set on gateway/service/upstream/route instances', async () => {

--- a/tests/unit/stack/volcengineStack/apigwTypes.test.ts
+++ b/tests/unit/stack/volcengineStack/apigwTypes.test.ts
@@ -143,7 +143,7 @@ describe('apigwTypes', () => {
     expect(def.logEnabled).toBe(true);
     expect(def.logConfig).toEqual({
       project: 'test-app-dev-tls',
-      topic: 'test-service-dev-apigw-logs',
+      topic: 'test-service-dev-api_gateway-apigw-logs',
     });
   });
 

--- a/tests/unit/stack/volcengineStack/vefaasPlanner.test.ts
+++ b/tests/unit/stack/volcengineStack/vefaasPlanner.test.ts
@@ -573,7 +573,7 @@ describe('vefaasPlanner', () => {
           after: {
             logConfig: {
               project: 'test-app-dev-tls',
-              topic: 'test-service-dev-fn-logs',
+              topic: 'test-service-dev-test_fn-fn-logs',
             },
           },
         },
@@ -670,7 +670,7 @@ describe('vefaasPlanner', () => {
         action: 'create',
         changes: {
           after: {
-            logConfig: { project: 'test-app-dev-tls', topic: 'test-service-dev-fn-logs' },
+            logConfig: { project: 'test-app-dev-tls', topic: 'test-service-dev-test_fn-fn-logs' },
           },
         },
       });

--- a/tests/unit/stack/volcengineStack/vefaasResource.test.ts
+++ b/tests/unit/stack/volcengineStack/vefaasResource.test.ts
@@ -51,6 +51,9 @@ jest.mock('../../../../src/common', () => {
       ),
     })),
     getResource: jest.fn(),
+    getAllResources: jest.fn(
+      (state?: { resources?: Record<string, unknown> }) => state?.resources ?? {},
+    ),
     setSharedResource: jest.fn((state, stage, key, resourceState) => ({
       ...state,
       stages: {
@@ -1922,6 +1925,98 @@ describe('vefaasResource', () => {
       await updateResource(mockContext, mockFunction, stateWithRole);
 
       expect(mockVefaasClient.iam.updateRolePolicy).not.toHaveBeenCalled();
+    });
+
+    it('unions trust and baseline across functions sharing a legacy role (issue #229 review)', async () => {
+      const peerFn: FunctionDomain = {
+        ...mockFunction,
+        key: 'other_fn',
+        name: 'other-function',
+        network: {
+          vpc_id: 'vpc-123',
+          subnet_ids: ['subnet-1', 'subnet-2'],
+          security_group: { name: 'sg-1', ingress: [], egress: [] },
+        },
+      };
+      const contextWithIac = {
+        ...mockContext,
+        iac: {
+          functions: [mockFunction, peerFn],
+          events: [
+            {
+              key: 'gateway_event',
+              triggers: [{ backend: '${functions.other_fn}' }],
+            },
+          ],
+        },
+      } as unknown as Context;
+
+      const legacyRoleInstances = [
+        {
+          type: 'VOLCENGINE_VEFAAS_FUNCTION',
+          sid: 'volcengine-test-service-dev-test-function',
+          id: 'test-function',
+          functionName: 'test-function',
+          functionId: 'func-123',
+        },
+        {
+          type: 'VOLCENGINE_IAM_ROLE',
+          sid: 'volcengine-iam_role-dev-role',
+          id: 'test-app-test-service-dev-role',
+          trn: 'trn:iam::123456:role/test-app-test-service-dev-role',
+        },
+      ];
+      const sharedRoleState: StateFile = {
+        ...mockState,
+        resources: {
+          'functions.test_fn': {
+            mode: 'managed',
+            region: 'cn-beijing',
+            definition: { functionName: 'test-function', codeHash: 'test-hash-123' },
+            instances: legacyRoleInstances,
+            lastUpdated: '2024-01-01T00:00:00Z',
+          },
+          'functions.other_fn': {
+            mode: 'managed',
+            region: 'cn-beijing',
+            definition: { functionName: 'other-function', codeHash: 'test-hash-123' },
+            instances: legacyRoleInstances,
+            lastUpdated: '2024-01-01T00:00:00Z',
+          },
+        },
+      };
+
+      (getResource as jest.Mock).mockReturnValue(sharedRoleState.resources['functions.test_fn']);
+      (attributesEqual as jest.Mock).mockReturnValue(true);
+
+      mockVefaasClient.vefaas.getFunctionById.mockResolvedValue({
+        functionName: 'test-function',
+        functionId: 'func-123',
+        runtime: 'nodejs16',
+        handler: 'index.handler',
+        memoryMb: 128,
+        requestTimeout: 30,
+      });
+
+      await updateResource(contextWithIac, mockFunction, sharedRoleState);
+
+      expect(mockVefaasClient.iam.updateRoleTrustPolicy).toHaveBeenCalledWith(
+        'test-app-test-service-dev-role',
+        expect.objectContaining({
+          Statement: [
+            expect.objectContaining({
+              Principal: { Service: ['vefaas', 'apigateway'] },
+            }),
+          ],
+        }),
+      );
+      expect(mockVefaasClient.iam.updateRolePolicy).toHaveBeenCalledWith(
+        'test-app-test-service-dev-role',
+        expect.arrayContaining([
+          expect.objectContaining({ action: expect.arrayContaining(['vpc:DescribeVpcs']) }),
+        ]),
+        undefined,
+      );
     });
 
     it('calls updateRolePolicy with the derived baseline when network is added', async () => {

--- a/tests/unit/stack/volcengineStack/vefaasResource.test.ts
+++ b/tests/unit/stack/volcengineStack/vefaasResource.test.ts
@@ -20,46 +20,76 @@ jest.mock('../../../../src/common/volcengineClient', () => ({
   createVolcengineClient: jest.fn(),
 }));
 
-jest.mock('../../../../src/common', () => ({
-  setResource: jest.fn((state, logicalId, resourceState) => ({
-    ...state,
-    resources: { ...state.resources, [logicalId]: resourceState },
-  })),
-  removeResource: jest.fn((state, logicalId) => ({
-    ...state,
-    resources: Object.fromEntries(
-      Object.entries(state.resources).filter(([key]) => key !== logicalId),
+jest.mock('../../../../src/common', () => {
+  const constrainedName = ({
+    parts,
+    maxLength,
+    charset,
+  }: {
+    parts: string[];
+    maxLength: number;
+    charset: string;
+  }) => {
+    const separator = charset === 'underscore' ? '_' : '-';
+    const invalid = charset === 'underscore' ? /[^A-Za-z0-9_]/g : /[^A-Za-z0-9-]/g;
+    const joined = parts
+      .map((part) => part.replace(invalid, separator))
+      .filter((part) => part.length > 0)
+      .join(separator);
+    return joined.length <= maxLength ? joined : joined.slice(0, maxLength);
+  };
+
+  return {
+    setResource: jest.fn((state, logicalId, resourceState) => ({
+      ...state,
+      resources: { ...state.resources, [logicalId]: resourceState },
+    })),
+    removeResource: jest.fn((state, logicalId) => ({
+      ...state,
+      resources: Object.fromEntries(
+        Object.entries(state.resources).filter(([key]) => key !== logicalId),
+      ),
+    })),
+    getResource: jest.fn(),
+    setSharedResource: jest.fn((state, stage, key, resourceState) => ({
+      ...state,
+      stages: {
+        ...state.stages,
+        [stage]: {
+          ...state.stages?.[stage],
+          resources: state.stages?.[stage]?.resources ?? {},
+          shared: { ...state.stages?.[stage]?.shared, [key]: resourceState },
+        },
+      },
+    })),
+    getSharedResource: jest.fn((state, stage, key) => state.stages?.[stage]?.shared?.[key]),
+    removeSharedResource: jest.fn((state, stage, key) => ({
+      ...state,
+      stages: {
+        ...state.stages,
+        [stage]: {
+          ...state.stages?.[stage],
+          shared: Object.fromEntries(
+            Object.entries(state.stages?.[stage]?.shared ?? {}).filter(([k]) => k !== key),
+          ),
+        },
+      },
+    })),
+    computeZipContentHash: jest.fn().mockResolvedValue('test-hash-123'),
+    buildSid: jest.fn(
+      (provider, service, stage, name) => `${provider}-${service}-${stage}-${name}`,
     ),
-  })),
-  getResource: jest.fn(),
-  setSharedResource: jest.fn((state, stage, key, resourceState) => ({
-    ...state,
-    stages: {
-      ...state.stages,
-      [stage]: {
-        ...state.stages?.[stage],
-        resources: state.stages?.[stage]?.resources ?? {},
-        shared: { ...state.stages?.[stage]?.shared, [key]: resourceState },
-      },
-    },
-  })),
-  getSharedResource: jest.fn((state, stage, key) => state.stages?.[stage]?.shared?.[key]),
-  removeSharedResource: jest.fn((state, stage, key) => ({
-    ...state,
-    stages: {
-      ...state.stages,
-      [stage]: {
-        ...state.stages?.[stage],
-        shared: Object.fromEntries(
-          Object.entries(state.stages?.[stage]?.shared ?? {}).filter(([k]) => k !== key),
-        ),
-      },
-    },
-  })),
-  computeZipContentHash: jest.fn().mockResolvedValue('test-hash-123'),
-  buildSid: jest.fn((provider, service, stage, name) => `${provider}-${service}-${stage}-${name}`),
-  attributesEqual: jest.fn((a, b) => JSON.stringify(a) === JSON.stringify(b)),
-}));
+    attributesEqual: jest.fn((a, b) => JSON.stringify(a) === JSON.stringify(b)),
+    buildConstrainedName: jest.fn(constrainedName),
+    buildFunctionRoleName: jest.fn((serviceName: string, stage: string, fnKey: string) =>
+      constrainedName({
+        parts: [serviceName, stage, fnKey, 'role'],
+        maxLength: 64,
+        charset: 'hyphen',
+      }),
+    ),
+  };
+});
 
 jest.mock('../../../../src/common/logger', () => ({
   logger: {
@@ -406,7 +436,7 @@ describe('vefaasResource', () => {
       });
       mockVefaasClient.tls.createTopic.mockResolvedValue({
         topicId: 'topic-1',
-        topicName: 'test-service-dev-fn-logs',
+        topicName: 'test-service-dev-test_fn-fn-logs',
       });
       mockVefaasClient.tls.getTopic.mockResolvedValue(null);
       mockVefaasClient.vefaas.createFunction.mockResolvedValueOnce({ functionId: 'func-123' });
@@ -427,7 +457,7 @@ describe('vefaasResource', () => {
       expect(mockVefaasClient.tls.createTopic).toHaveBeenCalledWith(
         expect.objectContaining({
           projectName: 'test-app-dev-tls',
-          topicName: 'test-service-dev-fn-logs',
+          topicName: 'test-service-dev-test_fn-fn-logs',
         }),
       );
       expect(mockVefaasClient.tls.addTags).toHaveBeenCalledWith(
@@ -458,7 +488,7 @@ describe('vefaasResource', () => {
       expect(saved.instances.some((i) => i.type === 'VOLCENGINE_TLS_TOPIC')).toBe(true);
       expect(mockVefaasClient.vefaas.createFunction).toHaveBeenCalledWith(
         expect.objectContaining({
-          logConfig: { project: 'test-app-dev-tls', topic: 'test-service-dev-fn-logs' },
+          logConfig: { project: 'test-app-dev-tls', topic: 'test-service-dev-test_fn-fn-logs' },
         }),
         expect.any(String),
       );
@@ -993,8 +1023,60 @@ describe('vefaasResource', () => {
 
       expect(mockVefaasClient.iam.createRole).toHaveBeenCalledWith(
         expect.objectContaining({
-          roleName: 'test-app-test-service-dev-role',
+          roleName: 'test-app-test-service-dev-test-fn-role',
           managedPolicies: ['AdministratorAccess', 'ReadOnlyAccess'],
+        }),
+      );
+    });
+
+    it('creates a per-function role name including fn.key for new deployments', async () => {
+      mockVefaasClient.vefaas.createFunction.mockResolvedValueOnce({ functionId: 'func-123' });
+      mockVefaasClient.vefaas.getFunction.mockResolvedValueOnce({
+        functionName: 'test-function',
+        functionId: 'func-123',
+        runtime: 'nodejs16',
+        handler: 'index.handler',
+        memoryMb: 128,
+        requestTimeout: 30,
+      });
+
+      await createResource(mockContext, mockFunction, mockState);
+
+      expect(mockVefaasClient.iam.createRole).toHaveBeenCalledWith(
+        expect.objectContaining({ roleName: 'test-app-test-service-dev-test-fn-role' }),
+      );
+    });
+
+    it('passes the derived execution baseline to createRole', async () => {
+      const fnWithNetwork: FunctionDomain = {
+        ...mockFunction,
+        network: {
+          vpc_id: 'vpc-123',
+          subnet_ids: ['subnet-1'],
+          security_group: { name: 'sg-1', ingress: [], egress: [] },
+        },
+      };
+
+      mockVefaasClient.vefaas.createFunction.mockResolvedValueOnce({ functionId: 'func-123' });
+      mockVefaasClient.vefaas.getFunction.mockResolvedValueOnce({
+        functionName: 'test-function',
+        functionId: 'func-123',
+        runtime: 'nodejs16',
+        handler: 'index.handler',
+        memoryMb: 128,
+        requestTimeout: 30,
+      });
+
+      await createResource(mockContext, fnWithNetwork, mockState);
+
+      expect(mockVefaasClient.iam.createRole).toHaveBeenCalledWith(
+        expect.objectContaining({
+          roleName: 'test-app-test-service-dev-test-fn-role',
+          executionStatements: expect.arrayContaining([
+            expect.objectContaining({
+              action: ['vpc:DescribeVpcs', 'vpc:DescribeSubnets', 'vpc:DescribeSecurityGroups'],
+            }),
+          ]),
         }),
       );
     });
@@ -1788,6 +1870,207 @@ describe('vefaasResource', () => {
       expect(mockVefaasClient.iam.updateRolePolicy).not.toHaveBeenCalled();
       expect(mockVefaasClient.iam.updateManagedPolicies).not.toHaveBeenCalled();
       expect(mockVefaasClient.iam.createRole).not.toHaveBeenCalled();
+    });
+
+    it('skips updateRolePolicy when neither derived inputs nor custom statements changed', async () => {
+      const stateWithRole: StateFile = {
+        ...mockState,
+        resources: {
+          'functions.test_fn': {
+            mode: 'managed',
+            region: 'cn-beijing',
+            definition: {
+              functionName: 'test-function',
+              codeHash: 'test-hash-123',
+              runtime: 'nodejs16',
+              handler: 'index.handler',
+              memorySize: 128,
+              timeout: 30,
+            },
+            instances: [
+              {
+                type: 'VOLCENGINE_VEFAAS_FUNCTION',
+                sid: 'volcengine-test-service-dev-test-function',
+                id: 'test-function',
+                functionName: 'test-function',
+                functionId: 'func-123',
+              },
+              {
+                type: 'VOLCENGINE_IAM_ROLE',
+                sid: 'volcengine-iam_role-dev-role',
+                id: 'test-app-test-service-dev-role',
+                trn: 'trn:iam::123456:role/test-app-test-service-dev-role',
+              },
+            ],
+            lastUpdated: '2024-01-01T00:00:00Z',
+          },
+        },
+      };
+
+      (getResource as jest.Mock).mockReturnValue(stateWithRole.resources['functions.test_fn']);
+      (attributesEqual as jest.Mock).mockReturnValue(true);
+
+      mockVefaasClient.vefaas.getFunctionById.mockResolvedValue({
+        functionName: 'test-function',
+        functionId: 'func-123',
+        runtime: 'nodejs16',
+        handler: 'index.handler',
+        memoryMb: 128,
+        requestTimeout: 30,
+      });
+
+      await updateResource(mockContext, mockFunction, stateWithRole);
+
+      expect(mockVefaasClient.iam.updateRolePolicy).not.toHaveBeenCalled();
+    });
+
+    it('calls updateRolePolicy with the derived baseline when network is added', async () => {
+      const fnWithNetwork: FunctionDomain = {
+        ...mockFunction,
+        network: {
+          vpc_id: 'vpc-123',
+          subnet_ids: ['subnet-1'],
+          security_group: { name: 'sg-1', ingress: [], egress: [] },
+        },
+      };
+
+      const stateWithoutVpc: StateFile = {
+        ...mockState,
+        resources: {
+          'functions.test_fn': {
+            mode: 'managed',
+            region: 'cn-beijing',
+            definition: {
+              functionName: 'test-function',
+              codeHash: 'test-hash-123',
+              runtime: 'nodejs16',
+              handler: 'index.handler',
+              memorySize: 128,
+              timeout: 30,
+            },
+            instances: [
+              {
+                type: 'VOLCENGINE_VEFAAS_FUNCTION',
+                sid: 'volcengine-test-service-dev-test-function',
+                id: 'test-function',
+                functionName: 'test-function',
+                functionId: 'func-123',
+              },
+              {
+                type: 'VOLCENGINE_IAM_ROLE',
+                sid: 'volcengine-iam_role-dev-role',
+                id: 'test-app-test-service-dev-role',
+                trn: 'trn:iam::123456:role/test-app-test-service-dev-role',
+              },
+            ],
+            lastUpdated: '2024-01-01T00:00:00Z',
+          },
+        },
+      };
+
+      (getResource as jest.Mock).mockReturnValue(stateWithoutVpc.resources['functions.test_fn']);
+      (attributesEqual as jest.Mock).mockReturnValue(true);
+
+      mockVefaasClient.vefaas.getFunctionById.mockResolvedValue({
+        functionName: 'test-function',
+        functionId: 'func-123',
+        runtime: 'nodejs16',
+        handler: 'index.handler',
+        memoryMb: 128,
+        requestTimeout: 30,
+      });
+
+      await updateResource(mockContext, fnWithNetwork, stateWithoutVpc);
+
+      expect(mockVefaasClient.iam.updateRolePolicy).toHaveBeenCalledWith(
+        'test-app-test-service-dev-role',
+        expect.arrayContaining([
+          expect.objectContaining({
+            action: ['vpc:DescribeVpcs', 'vpc:DescribeSubnets', 'vpc:DescribeSecurityGroups'],
+          }),
+        ]),
+        undefined,
+      );
+    });
+
+    it('calls updateRolePolicy when custom statements change', async () => {
+      const fnWithCustomStatements: FunctionDomain = {
+        ...mockFunction,
+        iam: {
+          role: {
+            statements: [
+              { effect: 'Allow', action: ['ecs:DescribeInstances'], resource: ['*'] },
+              { effect: 'Allow', action: ['oss:ListBuckets'], resource: ['*'] },
+            ],
+          },
+        },
+      };
+
+      const stateWithOldStatements: StateFile = {
+        ...mockState,
+        resources: {
+          'functions.test_fn': {
+            mode: 'managed',
+            region: 'cn-beijing',
+            definition: {
+              functionName: 'test-function',
+              codeHash: 'test-hash-123',
+              runtime: 'nodejs16',
+              handler: 'index.handler',
+              memorySize: 128,
+              timeout: 30,
+              iam: {
+                role: {
+                  statements: [
+                    { effect: 'Allow', action: ['ecs:DescribeInstances'], resource: ['*'] },
+                  ],
+                },
+              },
+            },
+            instances: [
+              {
+                type: 'VOLCENGINE_VEFAAS_FUNCTION',
+                sid: 'volcengine-test-service-dev-test-function',
+                id: 'test-function',
+                functionName: 'test-function',
+                functionId: 'func-123',
+              },
+              {
+                type: 'VOLCENGINE_IAM_ROLE',
+                sid: 'volcengine-iam_role-dev-role',
+                id: 'test-app-test-service-dev-role',
+                trn: 'trn:iam::123456:role/test-app-test-service-dev-role',
+              },
+            ],
+            lastUpdated: '2024-01-01T00:00:00Z',
+          },
+        },
+      };
+
+      (getResource as jest.Mock).mockReturnValue(
+        stateWithOldStatements.resources['functions.test_fn'],
+      );
+      (attributesEqual as jest.Mock).mockReturnValue(true);
+
+      mockVefaasClient.vefaas.getFunctionById.mockResolvedValue({
+        functionName: 'test-function',
+        functionId: 'func-123',
+        runtime: 'nodejs16',
+        handler: 'index.handler',
+        memoryMb: 128,
+        requestTimeout: 30,
+      });
+
+      await updateResource(mockContext, fnWithCustomStatements, stateWithOldStatements);
+
+      expect(mockVefaasClient.iam.updateRolePolicy).toHaveBeenCalledWith(
+        'test-app-test-service-dev-role',
+        expect.arrayContaining([expect.objectContaining({ action: ['vefaas:*'] })]),
+        [
+          { effect: 'Allow', action: ['ecs:DescribeInstances'], resource: ['*'] },
+          { effect: 'Allow', action: ['oss:ListBuckets'], resource: ['*'] },
+        ],
+      );
     });
   });
 

--- a/tests/unit/stack/volcengineStack/vefaasTypes.test.ts
+++ b/tests/unit/stack/volcengineStack/vefaasTypes.test.ts
@@ -3,8 +3,10 @@ import {
   functionToVefaasConfig,
   extractVefaasDefinition,
   buildDefaultTrustPolicy,
+  deriveVefaasExecutionStatements,
 } from '../../../../src/stack/volcengineStack/vefaasTypes';
 import type { FunctionDomain } from '../../../../src/types';
+import { NasStorageClassEnum } from '../../../../src/types';
 
 describe('vefaasTypes', () => {
   const mockFn: FunctionDomain = {
@@ -59,6 +61,56 @@ describe('vefaasTypes', () => {
           events: [
             {
               triggers: [{ backend: '${functions.other_fn}' }],
+            },
+          ],
+        },
+      };
+
+      const result = getTrustedServicesForFunction(mockFn, context as never);
+
+      expect(result).toEqual(['vefaas']);
+    });
+
+    it('should include apigateway when a bare backend equals the function deployed name (issue #227)', () => {
+      const context = {
+        iac: {
+          events: [
+            {
+              triggers: [{ backend: 'test-function' }],
+            },
+          ],
+        },
+      };
+
+      const result = getTrustedServicesForFunction(mockFn, context as never);
+
+      expect(result).toEqual(['vefaas', 'apigateway']);
+    });
+
+    it('should include apigateway for an external bare backend that matches no template function (issue #227)', () => {
+      const context = {
+        iac: {
+          functions: [{ key: 'other_fn', name: 'other-function' }],
+          events: [
+            {
+              triggers: [{ backend: 'external-deployed-fn' }],
+            },
+          ],
+        },
+      };
+
+      const result = getTrustedServicesForFunction(mockFn, context as never);
+
+      expect(result).toEqual(['vefaas', 'apigateway']);
+    });
+
+    it('should not treat a bare value matching another template function key as this function trigger', () => {
+      const context = {
+        iac: {
+          functions: [{ key: 'other_fn', name: 'other-function' }],
+          events: [
+            {
+              triggers: [{ backend: 'other_fn' }],
             },
           ],
         },
@@ -172,6 +224,112 @@ describe('vefaasTypes', () => {
       expect(result.Statement[0].Effect).toBe('Allow');
       expect(result.Statement[0].Principal.Service).toEqual(services);
       expect(result.Statement[0].Action).toContain('sts:AssumeRole');
+    });
+  });
+
+  describe('deriveVefaasExecutionStatements', () => {
+    const context = {} as never;
+
+    it('returns only vefaas and tls baseline for a bare function', () => {
+      const result = deriveVefaasExecutionStatements(mockFn, context);
+
+      expect(result).toEqual([
+        { effect: 'Allow', action: ['vefaas:*'], resource: ['*'] },
+        {
+          effect: 'Allow',
+          action: ['tls:CreateProject', 'tls:CreateTopic', 'tls:PutLogs'],
+          resource: ['*'],
+        },
+      ]);
+    });
+
+    it('adds vpc describe statements when network is configured', () => {
+      const fnWithNetwork: FunctionDomain = {
+        ...mockFn,
+        network: {
+          vpc_id: 'vpc-123',
+          subnet_ids: ['subnet-1'],
+          security_group: { name: 'sg-1', ingress: [], egress: [] },
+        },
+      };
+
+      const result = deriveVefaasExecutionStatements(fnWithNetwork, context);
+
+      expect(result).toHaveLength(3);
+      expect(result).toEqual(
+        expect.arrayContaining([
+          {
+            effect: 'Allow',
+            action: ['vpc:DescribeVpcs', 'vpc:DescribeSubnets', 'vpc:DescribeSecurityGroups'],
+            resource: ['*'],
+          },
+        ]),
+      );
+    });
+
+    it('adds tos object statements when a TOS mount is configured', () => {
+      const fnWithTos: FunctionDomain = {
+        ...mockFn,
+        storage: {
+          nas: [
+            { mount_path: '/mnt/tos', storage_class: NasStorageClassEnum.STANDARD_PERFORMANCE },
+          ],
+        },
+      };
+
+      const result = deriveVefaasExecutionStatements(fnWithTos, context);
+
+      expect(result).toHaveLength(3);
+      expect(result).toEqual(
+        expect.arrayContaining([
+          {
+            effect: 'Allow',
+            action: ['tos:GetObject', 'tos:PutObject', 'tos:DeleteObject', 'tos:ListBucket'],
+            resource: ['*'],
+          },
+        ]),
+      );
+    });
+
+    it('includes vpc and tos statements when both are configured', () => {
+      const fnWithBoth: FunctionDomain = {
+        ...mockFn,
+        network: {
+          vpc_id: 'vpc-123',
+          subnet_ids: ['subnet-1'],
+          security_group: { name: 'sg-1', ingress: [], egress: [] },
+        },
+        storage: {
+          nas: [
+            { mount_path: '/mnt/tos', storage_class: NasStorageClassEnum.STANDARD_PERFORMANCE },
+          ],
+        },
+      };
+
+      const result = deriveVefaasExecutionStatements(fnWithBoth, context);
+
+      expect(result).toHaveLength(4);
+      expect(result.map((s) => s.action[0])).toEqual([
+        'vefaas:*',
+        'tls:CreateProject',
+        'vpc:DescribeVpcs',
+        'tos:GetObject',
+      ]);
+    });
+
+    it('does not include custom iam statements in the derived baseline', () => {
+      const fnWithIam: FunctionDomain = {
+        ...mockFn,
+        iam: {
+          role: {
+            statements: [{ effect: 'Allow', action: ['ecs:DescribeInstances'], resource: ['*'] }],
+          },
+        },
+      };
+
+      const result = deriveVefaasExecutionStatements(fnWithIam, context);
+
+      expect(result).toHaveLength(2);
     });
   });
 });

--- a/tests/unit/validator/semanticValidation.test.ts
+++ b/tests/unit/validator/semanticValidation.test.ts
@@ -172,6 +172,36 @@ describe('validateSemantics', () => {
       expect(errors).toHaveLength(0);
       expect(logger.warn).not.toHaveBeenCalled();
     });
+
+    it('rejects external bare backends on volcengine (upstreams need a managed function)', () => {
+      const errors = validateSemantics({
+        ...buildIac({
+          gateway: {
+            ...baseEvent,
+            triggers: [{ method: 'GET', path: '/api', backend: 'external-fn' }],
+          },
+        }),
+        provider: { name: ProviderEnum.VOLCENGINE, region: 'cn-beijing' },
+      } as unknown as ServerlessIacRaw);
+
+      const external = errors.filter((error) => error.keyword === 'externalBackendUnsupported');
+      expect(external).toHaveLength(1);
+      expect(external[0].instancePath).toBe('/events/gateway/triggers/0');
+    });
+
+    it('allows external bare backends on aliyun (gateway assumes the managed role)', () => {
+      const errors = validateSemantics({
+        ...buildIac({
+          gateway: {
+            ...baseEvent,
+            triggers: [{ method: 'GET', path: '/api', backend: 'external-fn' }],
+          },
+        }),
+        provider: { name: ProviderEnum.ALIYUN, region: 'cn-hangzhou' },
+      } as unknown as ServerlessIacRaw);
+
+      expect(errors).toHaveLength(0);
+    });
   });
 
   describe('generated gateway names', () => {
@@ -217,15 +247,15 @@ describe('validateSemantics', () => {
       const volcEvents = {
         first_gateway: {
           ...baseEvent,
-          triggers: [{ method: 'GET', path: '/shared', backend: 'fn' }],
+          triggers: [{ method: 'GET', path: '/shared', backend: '${functions.fn}' }],
         },
         second_gateway: {
           ...baseEvent,
-          triggers: [{ method: 'GET', path: '/shared', backend: 'fn' }],
+          triggers: [{ method: 'GET', path: '/shared', backend: '${functions.fn}' }],
         },
       };
       const volcIac = {
-        ...buildIac(volcEvents),
+        ...buildIac(volcEvents, { fn: { name: 'fn' } }),
         provider: { name: ProviderEnum.VOLCENGINE, region: 'cn-beijing' },
       } as ServerlessIacRaw;
 

--- a/tests/unit/validator/semanticValidation.test.ts
+++ b/tests/unit/validator/semanticValidation.test.ts
@@ -173,7 +173,7 @@ describe('validateSemantics', () => {
       expect(logger.warn).not.toHaveBeenCalled();
     });
 
-    it('rejects external bare backends on volcengine (upstreams need a managed function)', () => {
+    it('allows external bare backends on volcengine (provider lookup resolves the function Id)', () => {
       const errors = validateSemantics({
         ...buildIac({
           gateway: {
@@ -184,9 +184,7 @@ describe('validateSemantics', () => {
         provider: { name: ProviderEnum.VOLCENGINE, region: 'cn-beijing' },
       } as unknown as ServerlessIacRaw);
 
-      const external = errors.filter((error) => error.keyword === 'externalBackendUnsupported');
-      expect(external).toHaveLength(1);
-      expect(external[0].instancePath).toBe('/events/gateway/triggers/0');
+      expect(errors).toHaveLength(0);
     });
 
     it('allows external bare backends on aliyun (gateway assumes the managed role)', () => {

--- a/tests/unit/validator/semanticValidation.test.ts
+++ b/tests/unit/validator/semanticValidation.test.ts
@@ -2,12 +2,21 @@ import { validateSemantics } from '../../../src/validator/semanticValidation';
 import { validateYaml } from '../../../src/validator/iacSchema';
 import { ServerlessIacRaw } from '../../../src/types';
 import { ProviderEnum } from '../../../src/common';
+import { logger } from '../../../src/common/logger';
+
+jest.mock('../../../src/common/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+}));
 
 jest.mock('../../../src/lang', () => ({
   lang: { __: (key: string) => key },
 }));
 
 describe('validateSemantics', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   const baseEvent = {
     type: 'API_GATEWAY',
     name: 'test-gateway',
@@ -108,6 +117,60 @@ describe('validateSemantics', () => {
       );
 
       expect(errors).toHaveLength(0);
+    });
+
+    it('rejects a bare value that equals a template function key (issue #227)', () => {
+      const errors = validateSemantics(
+        buildIac(
+          {
+            gateway: {
+              ...baseEvent,
+              triggers: [{ method: 'GET', path: '/api', backend: 'known_fn' }],
+            },
+          },
+          { known_fn: { name: 'known-function' } },
+        ) as ServerlessIacRaw,
+      );
+
+      const bareKeyErrors = errors.filter((error) => error.keyword === 'bareBackendKey');
+      expect(bareKeyErrors).toHaveLength(1);
+      expect(bareKeyErrors[0].instancePath).toBe('/events/gateway/triggers/0');
+    });
+
+    it('passes a bare value that equals a template function name and warns to prefer the reference form', () => {
+      const errors = validateSemantics(
+        buildIac(
+          {
+            gateway: {
+              ...baseEvent,
+              triggers: [{ method: 'GET', path: '/api', backend: 'known-function' }],
+            },
+          },
+          { known_fn: { name: 'known-function' } },
+        ) as ServerlessIacRaw,
+      );
+
+      expect(errors).toHaveLength(0);
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('SEMANTIC_BACKEND_BARE_NAME'),
+      );
+    });
+
+    it('skips backend values that are non-functions template refs (e.g. ${vars.x})', () => {
+      const errors = validateSemantics(
+        buildIac(
+          {
+            gateway: {
+              ...baseEvent,
+              triggers: [{ method: 'GET', path: '/api', backend: '${vars.backend_fn}' }],
+            },
+          },
+          { known_fn: { name: 'known-function' } },
+        ) as ServerlessIacRaw,
+      );
+
+      expect(errors).toHaveLength(0);
+      expect(logger.warn).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## Summary

Fixes #227 — the RAM role trust policy missed `apigateway.aliyuncs.com` when `trigger.backend` used bare values, so every API Gateway request 403'd with `A403FC` (0 FC invocations). Implements the maintainer design decision from the issue (4-case backend semantics) and lands the per-function execution role model directed in #228, across **aliyun fc3, volcengine vefaas and tencent scf**.

## Trigger backend semantics (#227) — identical on every provider

| User writes | Resolves to | Behavior |
|---|---|---|
| `${functions.key}` | template function (by key) | unchanged; dangling refs still error |
| bare value == a function's **name** | that template function | passes; warns to prefer the reference form |
| bare value == a function's **key** | ❌ | new `bareBackendKey` validation error suggesting `${functions.key}` |
| anything else | **external deployed function** | passes on aliyun **and** volcengine; deploy-time resolution details below |

- `getIacDefinition`: bare values resolve by deployed **name**; the bare-key fallback that masked the incident is removed (shared by aliyun, volcengine and the local stack).
- Trust policies (aliyun fc3 + volcengine vefaas) grant `apigateway` for template refs, bare-name refs **and** external bare backends. Trust is rewritten on every deploy, so existing broken deployments self-heal.
- **External backends per provider**: aliyun invokes by name (functionName passed through, gateway assumes the managed role). Volcengine invokes by Id — external function Ids are resolved via a **provider lookup by name** (`vefaas.getFunction`); if the lookup finds nothing, a clear i18n error names the missing function. Template refs with a missing state Id still fail with "deploy the function first" — a stale/failed deploy must not adopt a same-named foreign function.

## Per-function execution roles + dynamic policies (#228)

- **Role naming** (platform-consistent): `buildFunctionRoleName` → `${app}-${service}-${stage}-${fnKey}-role` on every provider (64 chars, hyphen). Custom `iam.role.name` overrides; external string roles untouched.
- **Dynamic derivation per function**: fc/log baseline always; aliyun ecs/vpc gated on `fn.network`, `nas:*` on `fn.storage.nas` (log statements scoped to the managed logstore ARN when known); volcengine vpc gated on network, tos gated on TOS mount; tencent cls + cos baseline. Custom statements/managed policies still merge after the baseline.
- **Policy propagation**: aliyun `GetPolicy` → document compare → `CreatePolicyVersion` (5-version prune) only on change; volcengine/tencent reuse `updateRolePolicy` gated on derived-input drift. `EntityAlreadyExists` recovery paths use the same derived baseline.
- **Legacy shared roles (review hardening)**: for pre-existing deployments where several functions share one role, trust **and** the derived policy baseline are the **union across all functions sharing that role** — a single function's update can no longer strip another function's apigateway trust or ecs/vpc permissions. Per-function roles (new deployments) are unaffected; the union naturally reduces to self.
- **API Gateway identity (aliyun)**: each trigger resolves `functionComputeConfig.roleArn` from **its own backend function's** role in state (`buildRoleArnResolver`); external backends fall back to the first managed role.
- **Volcengine recovery fix**: the `RoleAlreadyExists` recovery rebuilds the policy with the derived baseline **and** custom statements (custom statements were previously dropped).

## Naming consistency

- `buildRolePolicyName` replaces 15 raw `${roleName}-policy` sites across the three IAM clients (formula unchanged — byte-identical names, no migration impact).
- **Per-function fn-log containers on all providers** (topic/logstore names include `fn.key`; legacy service-scoped shape preserved for legacy-state paths and delete fallbacks) — closes the teardown hazard where removing one function deleted the log container other functions still used.
- **Per-event apigw-logs topics on volcengine** (`${service}-${stage}-${event.key}-apigw-logs`, stored-first so legacy events don't drift). Aliyun's apigw-logs stays service-scoped by design: it is a provider-level log-config singleton (`${region}:PROVIDER`) and cannot be per-event; its deletion is already guarded against active references.
- Aliyun SLS project/logstore names constrained to 63 chars (only over-limit inputs change — they previously failed with opaque cloud errors).
- `OWNERSHIP_TAG_KEY` imported instead of hardcoded; duplicate name templates (upstream ×3, TLS project, fn/apigw log topics, fc3 cert ×3, gateway logstore ×3) collapsed onto single helpers.
- SIDs intentionally left per-provider (lifecycle-bound to physical resources; no cross-provider value) — codified in AGENTS.md.

## Docs

- `AGENTS.md` gains a **Resource Naming (Cross-Platform) - MANDATORY** section: canonical builders, per-owner teardown, stored-first renames, in-place role migration, and the per-provider SID policy.

## Verification

| Check | Result |
|---|---|
| Full unit suite | 156/156 suites, 3290/3290 tests |
| Provider suites (aliyun/volcengine/scf) | 59/59 suites, 1242/1242 tests |
| Service tests (mocked cloud SDKs) | 7/7 suites, 24/24 tests |
| Lint (`eslint ./`) | clean |
| Build (`tsc --build`) | exit 0 |

TDD throughout. A dedicated end-to-end service test deploys a fixture whose `backend:` is the bare function **name** and asserts the role trusts apigateway and the API targets the resolved name with a wired roleArn (this exposed and fixed a latent mock-shape bug: the aliyun `ram.createRole` mock omitted `RamRoleInfo.arn`). Live-cloud deploy was not run in this environment (no credentials) — service tests exercise parser → planner → executor with mocked cloud SDKs as the real-surface substitute.

## Migration notes for existing deployments

- Role/policy/log-container names apply to **newly created** resources only; reuse branches key on instance type, so current deployments keep their recorded names and get trust/policy updated in place.
- Bare-key backend configs (the incident pattern) now fail validation — change them to `${functions.key}` or the deployed function name.
- Derived policies narrow to what each function declares; a function calling NAS/ECS APIs without declaring `network`/`storage.nas` will lose those permissions on the next deploy (intended least-privilege, #228).
- Design decisions documented on #228: [comment](https://github.com/geek-fun/serverlessinsight/issues/228#issuecomment-5461436612).
