### PR TITLE
feat(fc3): scope fc:InvokeFunction to the function ARN (strict, issue #228)

### DIFF
--- a/src/stack/aliyunStack/fc3Resource.ts
+++ b/src/stack/aliyunStack/fc3Resource.ts
@@ -172,14 +172,51 @@ const resolveRoleGrant = (
   };
 };
 
+const buildFcFunctionArn = (context: Context, functionName: string): string | undefined =>
+  context.accountId
+    ? `acs:fc:${context.region}:${context.accountId}:functions/${functionName}`
+    : undefined;
+
+const isTemplateFunctionBackend = (context: Context, backend: string): boolean => {
+  if (/^\$\{functions\./.test(backend)) return true;
+  return (context.iac?.functions ?? []).some(
+    (candidate) => candidate.key === backend || candidate.name === backend,
+  );
+};
+
+/**
+ * Strict invoke scope (issue #228): this role may invoke its own function plus
+ * the service's external backend functions (the gateway may assume any managed
+ * role as the fallback identity for external APIs). Falls back to '*' only
+ * when the account Id is unknown — never wrong-permissions.
+ */
+const resolveFc3InvokeResources = (fn: FunctionDomain, context: Context): string[] => {
+  const ownArn = buildFcFunctionArn(context, fn.name);
+  if (!ownArn) return ['*'];
+
+  const resources = new Set<string>([ownArn]);
+  for (const event of context.iac?.events ?? []) {
+    for (const trigger of event.triggers ?? []) {
+      const backend = String(trigger.backend ?? '');
+      if (!backend || isTemplateFunctionBackend(context, backend)) continue;
+      const externalArn = buildFcFunctionArn(context, backend);
+      if (externalArn) resources.add(externalArn);
+    }
+  }
+  return [...resources];
+};
+
 export const deriveFc3ExecutionStatements = (
   fn: FunctionDomain,
   context: Context,
   logConfig?: { project: string; logstore: string },
 ): IamStatement[] => {
   const statements: IamStatement[] = [
-    // Broad on purpose: the API gateway assumes this role as its invocation identity.
-    { effect: 'Allow', action: ['fc:InvokeFunction'], resource: ['*'] },
+    {
+      effect: 'Allow',
+      action: ['fc:InvokeFunction'],
+      resource: resolveFc3InvokeResources(fn, context),
+    },
     {
       effect: 'Allow',
       action: FC3_LOG_ACTIONS,

--- a/tests/unit/stack/aliyunStack/fc3Resource.test.ts
+++ b/tests/unit/stack/aliyunStack/fc3Resource.test.ts
@@ -3863,7 +3863,7 @@ describe('Fc3Resource', () => {
       expect(statements[0]).toEqual({
         effect: 'Allow',
         action: ['fc:InvokeFunction'],
-        resource: ['*'],
+        resource: ['acs:fc:cn-hangzhou:123456789012:functions/test-function'],
       });
       expect(statements[1].effect).toBe('Allow');
       expect(statements[1].action).toEqual([
@@ -3885,6 +3885,44 @@ describe('Fc3Resource', () => {
       expect(statements[1].resource).toEqual([
         'acs:log:cn-hangzhou:123456789012:project/test-sls/logstore/test-logstore',
       ]);
+    });
+
+    it('scopes fc:InvokeFunction to the function ARN plus external backend ARNs (issue #228)', () => {
+      const contextWithExternals: Context = {
+        ...mockContext,
+        iac: {
+          ...(mockContext.iac ?? {}),
+          functions: [testFunction],
+          events: [
+            {
+              key: 'api_gateway',
+              name: 'test-api',
+              type: 'API_GATEWAY',
+              triggers: [
+                { method: 'GET', path: '/own', backend: '${functions.test_fn}' },
+                { method: 'POST', path: '/ext1', backend: 'external-deployed-fn' },
+                { method: 'PUT', path: '/ext2', backend: 'another-external-fn' },
+              ],
+            },
+          ],
+        },
+      } as Context;
+
+      const statements = deriveFc3ExecutionStatements(testFunction, contextWithExternals);
+
+      expect(statements[0].resource).toEqual([
+        'acs:fc:cn-hangzhou:123456789012:functions/test-function',
+        'acs:fc:cn-hangzhou:123456789012:functions/external-deployed-fn',
+        'acs:fc:cn-hangzhou:123456789012:functions/another-external-fn',
+      ]);
+    });
+
+    it('falls back to resource * for fc:InvokeFunction when accountId is unknown', () => {
+      const contextWithoutAccount: Context = { ...mockContext, accountId: undefined };
+
+      const statements = deriveFc3ExecutionStatements(testFunction, contextWithoutAccount);
+
+      expect(statements[0].resource).toEqual(['*']);
     });
 
     it('adds ecs/vpc statements when fn.network is present', () => {


### PR DESCRIPTION
Implements #228 remaining item 1 (strict invoke scoping) — maintainer decision: strict mode, no implicit fn-to-function invocation.

## What

The derived aliyun FC3 execution baseline no longer grants `fc:InvokeFunction` on `Resource: "*"`:

- **Template functions**: scoped to their own ARN — `acs:fc:<region>:<account>:functions/<name>`
- **External bare backends**: their ARNs are added to every managed role's invoke resources (the gateway may assume any managed role as the fallback identity for external APIs); the backend value is the function name, so the ARN is deterministic — no manual specification needed
- **Fallback**: `*` only when the account Id is unknown at policy-build time (never wrong-permissions)
- **fn-to-fn invocation**: no longer implicit — declare it via `iam.role.statements` (maintainer decision: strict)

## Verification

- Full suite 156/156 suites, 3292/3292 tests; lint clean; build exit 0
- New derivation tests: scoped ARN, external ARN inclusion, accountId-missing fallback

> Housekeeping note: this change was briefly committed directly to master and reverted there (2145794); this PR re-applies it for proper review.