### PR TITLE
fix(fc3): union custom statements and attach managed policies on legacy shared roles (issue #228)

### DIFF
--- a/src/stack/aliyunStack/fc3Resource.ts
+++ b/src/stack/aliyunStack/fc3Resource.ts
@@ -140,9 +140,10 @@ const unionTrustedServices = (serviceLists: string[][]): string[] => [
 ];
 
 /**
- * Legacy shared roles serve every function that recorded them, so their trust
- * and derived policy must be the union across those functions — a single
- * function's update would otherwise strip another function's requirements.
+ * Legacy shared roles serve every function that recorded them, so their trust,
+ * derived policy and CUSTOM statements must be the union across those
+ * functions — a single function's update would otherwise strip another
+ * function's requirements.
  */
 const resolveRoleGrant = (
   context: Context,
@@ -150,16 +151,37 @@ const resolveRoleGrant = (
   fn: FunctionDomain,
   logConfig: { project: string; logstore: string } | undefined,
   roleId: string,
-): { trustedServices: string[]; executionStatements: IamStatement[] } => {
+): {
+  trustedServices: string[];
+  executionStatements: IamStatement[];
+  customStatements: IamStatement[] | undefined;
+} => {
   const storedPeers = state ? collectRolePeers(state, context, roleId) : [];
   const currentStored = storedPeers.find((peer) => peer.fn.key === fn.key);
   const peers: RolePeer[] = currentStored
     ? [...storedPeers]
     : [{ fn, ...(logConfig ? { logConfig } : {}) }, ...storedPeers];
-  if (peers.length <= 1) {
+
+  const ownCustoms =
+    fn.iam?.role && typeof fn.iam.role !== 'string' ? fn.iam.role.statements : undefined;
+  const peerCustoms = peers
+    .filter((peer) => peer.fn.key !== fn.key)
+    .map((peer) =>
+      peer.fn.iam?.role && typeof peer.fn.iam.role !== 'string'
+        ? peer.fn.iam.role.statements
+        : undefined,
+    )
+    .filter((statements): statements is IamStatement[] => Boolean(statements?.length));
+  const sharedRole = peers.length > 1;
+  const customStatements = sharedRole
+    ? unionPolicyStatements([ownCustoms ?? [], ...peerCustoms])
+    : ownCustoms;
+
+  if (!sharedRole) {
     return {
       trustedServices: getTrustedServicesForFunction(context, fn),
       executionStatements: deriveFc3ExecutionStatements(fn, context, logConfig),
+      customStatements,
     };
   }
   return {
@@ -169,6 +191,7 @@ const resolveRoleGrant = (
     executionStatements: unionPolicyStatements(
       peers.map((peer) => deriveFc3ExecutionStatements(peer.fn, context, peer.logConfig)),
     ),
+    customStatements,
   };
 };
 
@@ -453,8 +476,11 @@ const createDependentResources = async (
       await client.ram.updateRoleTrustPolicy(ramRoleInstance.id, roleGrant.trustedServices);
       await client.ram.updateExecutionPolicyDocument(
         ramRoleInstance.id,
-        buildFc3ExecutionPolicyDocument(roleGrant.executionStatements, statements),
+        buildFc3ExecutionPolicyDocument(roleGrant.executionStatements, roleGrant.customStatements),
       );
+      if (managedPolicies?.length) {
+        await client.ram.attachManagedPolicies(ramRoleInstance.id, managedPolicies);
+      }
     }
   } else {
     const roleName = customRoleName ?? defaultRoleName;
@@ -1053,8 +1079,6 @@ export const updateResource = async (
 
   const newIamRole = fn.iam?.role;
   const executionStatements = deriveFc3ExecutionStatements(fn, context, logConfig);
-  const customStatements =
-    newIamRole && typeof newIamRole !== 'string' ? newIamRole.statements : undefined;
 
   if (typeof newIamRole === 'string') {
     // External role - use ARN directly, skip management
@@ -1082,7 +1106,7 @@ export const updateResource = async (
       await client.ram.updateRoleTrustPolicy(ramRoleInstance.id, roleGrant.trustedServices);
       await client.ram.updateExecutionPolicyDocument(
         ramRoleInstance.id,
-        buildFc3ExecutionPolicyDocument(roleGrant.executionStatements, customStatements),
+        buildFc3ExecutionPolicyDocument(roleGrant.executionStatements, roleGrant.customStatements),
       );
 
       const existingIam = existingState?.definition?.iam as Record<string, unknown> | undefined;

--- a/tests/unit/stack/aliyunStack/fc3Resource.test.ts
+++ b/tests/unit/stack/aliyunStack/fc3Resource.test.ts
@@ -59,6 +59,7 @@ const mockedRamOperations = {
   updateRolePolicy: jest.fn(),
   updateExecutionPolicyDocument: jest.fn(),
   updateManagedPolicies: jest.fn(),
+  attachManagedPolicies: jest.fn(),
   deleteRole: jest.fn(),
 };
 const mockedEcsOperations = {
@@ -1125,6 +1126,11 @@ describe('Fc3Resource', () => {
           subnet_ids: ['subnet-1', 'subnet-2'],
           security_group: { name: 'sg-1', ingress: [], egress: [] },
         },
+        iam: {
+          role: {
+            statements: [{ effect: 'Allow' as const, action: ['kafka:GetTopic'], resource: ['*'] }],
+          },
+        },
       };
       const contextWithPeer: Context = {
         ...mockContext,
@@ -1205,7 +1211,56 @@ describe('Fc3Resource', () => {
       };
       const actions = policyDocument.Statement.flatMap((statement) => statement.Action);
       expect(actions).toContain('ecs:CreateNetworkInterface');
+      expect(actions).toContain('kafka:GetTopic');
       expect(actions).not.toContain('nas:*');
+    });
+
+    it('attaches managed policies when a new function joins an existing legacy role', async () => {
+      const stateWithLegacyRole: StateFile = {
+        ...initialState,
+        resources: {
+          'functions.test_fn': {
+            mode: 'managed',
+            region: 'cn-hangzhou',
+            definition: mockDefinition,
+            instances: [
+              {
+                sid: 'si:aliyun:ram:default:test-app-test-service-default-fc-role',
+                roleArn: 'acs:ram::123456789012:role/test-app-test-service-default-fc-role',
+                id: 'test-app-test-service-default-fc-role',
+                type: 'ALIYUN_RAM_ROLE',
+              },
+              {
+                sid: 'si:aliyun:fc3:default:test-function',
+                id: 'test-function',
+                type: 'ALIYUN_FC3_FUNCTION',
+              },
+            ],
+            lastUpdated: '2025-01-01T00:00:00Z',
+          },
+        },
+      };
+      const fnWithManagedPolicies: FunctionDomain = {
+        ...testFunction,
+        iam: {
+          role: {
+            managed_policies: ['AliyunOSSFullAccess'],
+          },
+        },
+      };
+
+      mockedFc3Operations.createFunction.mockResolvedValue({
+        body: { functionName: 'test-function', functionArn: 'arn:test' },
+      });
+      const newState = { ...stateWithLegacyRole, _updated: true };
+      mockedStateManager.setResource.mockReturnValue(newState);
+
+      await createResource(mockContext, fnWithManagedPolicies, stateWithLegacyRole);
+
+      expect(mockedRamOperations.attachManagedPolicies).toHaveBeenCalledWith(
+        'test-app-test-service-default-fc-role',
+        ['AliyunOSSFullAccess'],
+      );
     });
 
     it('should add apigateway trust when a bare backend equals the function deployed name (issue #227)', async () => {


### PR DESCRIPTION
Resolves the last two actionable items from the [#228 status update](https://github.com/geekfun/serverlessinsight/issues/228#issuecomment-5463853219).

## What

- **Custom `iam.role.statements` are now unioned across legacy shared roles** (item 4): previously last-writer-wins — the last deployed function's update stripped earlier functions' custom permissions on the shared role. `resolveRoleGrant` now unions the current function's custom statements with every peer's stored custom statements before building the policy document.
- **Managed policies attach when a new function joins an existing legacy role** (item 5): the create-reuse branch previously skipped the incoming function's `managed_policies` entirely; they are now attached to the reused role (attach is idempotent).

Per maintainer direction, volcengine is unaffected (no deployed vefaas usage → no legacy shared roles exist there).

## Verification

- Full suite 156/156 suites, 3291/3291 tests; lint clean; build exit 0
- New tests: peer custom statements appear in the propagated policy document; managed policies attach on the create-reuse branch