### PR TITLE
ci(release): check version before running build/tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,38 +25,46 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         with:
           fetch-depth: 0 # Fetch all history including tags for version checking
+      - name: Check for version change
+        id: version_check
+        run: ./scripts/check-version.sh . v
       - name: Use Node.js ${{ matrix.node-version }}
+        if: steps.version_check.outputs.should_release == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           registry-url: 'https://registry.npmjs.org'
       - name: Install dependencies
+        if: steps.version_check.outputs.should_release == 'true'
         run: npm ci
-      - run: npm run lint:check
-      - run: npm audit --audit-level=critical
-      - run: npm run build
-      - run: npm run test:ci
+      - name: Lint
+        if: steps.version_check.outputs.should_release == 'true'
+        run: npm run lint:check
+      - name: Audit dependencies
+        if: steps.version_check.outputs.should_release == 'true'
+        run: npm audit --audit-level=critical
+      - name: build 🔧
+        if: steps.version_check.outputs.should_release == 'true'
+        run: npm run build
+      - name: Test
+        if: steps.version_check.outputs.should_release == 'true'
+        run: npm run test:ci
       - name: Upload coverage reports to Codecov
+        if: steps.version_check.outputs.should_release == 'true'
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true
           fail_ci_if_error: true
-      - name: build 🔧
-        run: npm run build
       - name: Generate changelog
+        if: steps.version_check.outputs.should_release == 'true'
         uses: jaywcjlove/changelog-generator@main
         id: changelog
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Check for version change
-        id: version_check
-        run: ./scripts/check-version.sh . v
-
       - name: Publish package on NPM 📦
         if: steps.version_check.outputs.should_release == 'true'
         run: npm publish
-
       - name: Create GitHub Release
         if: steps.version_check.outputs.should_release == 'true'
         uses: softprops/action-gh-release@v1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@geek-fun/serverlessinsight",
-  "version": "0.8.6",
+  "version": "0.8.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@geek-fun/serverlessinsight",
-      "version": "0.8.6",
+      "version": "0.8.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@alicloud/alidns20150109": "^4.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geek-fun/serverlessinsight",
-  "version": "0.8.6",
+  "version": "0.8.7",
   "description": "Full life cycle cross providers serverless application management for your fast-growing business.",
   "homepage": "https://serverlessinsight.com",
   "main": "dist/src/index.js",


### PR DESCRIPTION
## Problem

The release workflow (triggered on **every** master push) ran `npm ci`, lint, `npm audit`, build (twice), the full test suite and codecov upload — and only checked whether the version actually changed **afterwards**. Non-release pushes (docs, fixes, refactors) paid ~10 minutes of runner time to conclude `should_release: false` and do nothing. Routine lint/build/test coverage is already the job of the `node.yml` CI workflow (PRs + master pushes).

## Change

- `scripts/check-version.sh` now runs **immediately after checkout** — it only needs git + the runner's built-in node (no `npm ci`).
- Every heavy step (install, lint, audit, build, test, codecov, changelog, npm publish, GitHub release) is gated on `should_release == 'true'`.
- Dropped the duplicated second build step.
- Version-bumped pushes still run the full validation pipeline before publishing (publish is irreversible).

## Effect

- Non-release master pushes: ~10 min → **~15 seconds** (checkout + version check).
- Release pushes: unchanged behavior, minus the duplicated build.

## Note: includes the 0.8.7 version bump

The working tree had an uncommitted `package.json` bump (0.8.6 → 0.8.7) that got swept into this commit. That's actually convenient: merging this PR will trigger the first real release through the new early-check pipeline (version changed → full gated path → publish 0.8.7), validating the true path end to end. Happy to split the bump out if you'd rather release separately.