### PR TITLE
feat: Phase 0 — FC3 RAM role drift reconciliation + refresh read dedup & rate-limit guards (#234)

### DIFF
--- a/src/common/concurrency.ts
+++ b/src/common/concurrency.ts
@@ -1,0 +1,31 @@
+/**
+ * Bounded-concurrency map for planner read fan-outs (issue #234 rate-limit
+ * mitigation): each planner probes resources concurrently, and a naive
+ * Promise.all burst can exceed provider management-API QPS (e.g. Tencent CAM
+ * GetRole at 20/s). The limit is deliberately provider-neutral and coarse —
+ * ~10 in-flight reads per planner group — since provider quota tables are
+ * partially unpublished (Volcengine, Aliyun OSS management plane).
+ */
+export const PLAN_READ_CONCURRENCY = 10;
+
+export const mapWithConcurrency = async <T, R>(
+  items: Array<T>,
+  limit: number,
+  fn: (item: T, index: number) => Promise<R>,
+): Promise<Array<R>> => {
+  const results = new Array<R>(items.length);
+  let nextIndex = 0;
+  const workerCount = Math.min(limit, items.length);
+  const workers = Array.from({ length: workerCount }, async () => {
+    while (true) {
+      const index = nextIndex;
+      nextIndex += 1;
+      if (index >= items.length) {
+        return;
+      }
+      results[index] = await fn(items[index], index);
+    }
+  });
+  await Promise.all(workers);
+  return results;
+};

--- a/src/common/context.ts
+++ b/src/common/context.ts
@@ -4,6 +4,7 @@ import { Context, ServerlessIac } from '../types';
 import { getCredentials } from './credentials';
 import { getIamInfo } from './imsClient';
 import { ProviderEnum } from './providerEnum';
+import { createRefreshCache } from './refreshCache';
 
 let context: Context | undefined;
 
@@ -119,6 +120,7 @@ export const setContext = async (
       }),
       {},
     ),
+    refreshCache: createRefreshCache(),
   };
 
   if (reaValToken) {

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -22,3 +22,6 @@ export * from './apiClient';
 export * from './triggerMapper';
 export * from './nameBuilder';
 export * from './providerNames';
+export * from './refreshCache';
+export * from './concurrency';
+export * from './throttleRetry';

--- a/src/common/refreshCache.ts
+++ b/src/common/refreshCache.ts
@@ -1,0 +1,55 @@
+import { logger } from './logger';
+import { lang } from '../lang';
+import { withThrottleRetry } from './throttleRetry';
+
+/**
+ * Command-lifecycle scoped read-through cache for provider state reads issued
+ * by planning/refresh (issue #234 rate-limit mitigation). `si deploy` computes
+ * the plan twice (display pass in commands/deploy.ts + executor pass in each
+ * provider deployer), and planners probe the same resources in both passes.
+ * Reads issued through this cache execute at most once per command run.
+ *
+ * Scope rules:
+ * - Planning/refresh reads ONLY. Executor reads (post-mutation or
+ *   mutation-time freshness checks) must never go through this cache.
+ * - Single-flight: concurrent callers asking for the same key share one
+ *   in-flight promise.
+ * - Failures are not cached: a rejected read evicts its key so later callers
+ *   retry against the provider.
+ * - One instance per Context: `setContext` creates it, so every command
+ *   lifecycle starts empty and caches never leak across commands or tests.
+ */
+export type RefreshCache = {
+  read: <T>(key: string, load: () => Promise<T>) => Promise<T>;
+};
+
+export const createRefreshCache = (): RefreshCache => {
+  const inflight = new Map<string, Promise<unknown>>();
+
+  return {
+    read: <T>(key: string, load: () => Promise<T>): Promise<T> => {
+      const existing = inflight.get(key);
+      if (existing) {
+        logger.debug(lang.__('REFRESH_CACHE_HIT', { key }));
+        return existing as Promise<T>;
+      }
+      const promise = withThrottleRetry(load).catch((error: unknown) => {
+        inflight.delete(key);
+        throw error;
+      });
+      inflight.set(key, promise);
+      return promise;
+    },
+  };
+};
+
+/**
+ * Read-through helper for planner call sites: uses the context-scoped cache
+ * when present, otherwise loads directly. Planners receive the context as a
+ * parameter, so tests can decide whether caching applies.
+ */
+export const cachedRefreshRead = <T>(
+  context: { refreshCache?: RefreshCache },
+  key: string,
+  load: () => Promise<T>,
+): Promise<T> => (context.refreshCache ? context.refreshCache.read(key, load) : load());

--- a/src/common/throttleRetry.ts
+++ b/src/common/throttleRetry.ts
@@ -1,0 +1,61 @@
+import { sleep } from './retryUtils';
+
+/**
+ * Provider management-API throttling recognition (issue #234). Error shapes
+ * differ across SDKs: Alibaba/Volcengine/Tencent expose `code`, Volcengine TLS
+ * nests it under `response.data.Error.Code`, and Tencent scopes the frequency
+ * limit as `RequestLimitExceeded.UinLimitExceeded` etc. All three families map
+ * onto one recognizer because none of the SDKs retry throttling by default.
+ */
+const isThrottlingCode = (code: unknown): boolean => {
+  if (typeof code === 'string') {
+    return (
+      code.startsWith('Throttling') ||
+      code.startsWith('RequestLimitExceeded') ||
+      code === 'FlowLimitExceeded' ||
+      code === 'SlowDown' ||
+      code === 'TooManyRequests'
+    );
+  }
+  return code === 100018; // Volcengine FlowLimitExceeded numeric code
+};
+
+export const isThrottlingError = (error: unknown): boolean => {
+  if (!error || typeof error !== 'object') {
+    return false;
+  }
+  const candidate = error as {
+    code?: unknown;
+    response?: { data?: { Error?: { Code?: unknown } } };
+  };
+  if (isThrottlingCode(candidate.code)) {
+    return true;
+  }
+  return isThrottlingCode(candidate.response?.data?.Error?.Code);
+};
+
+const RETRY_DELAY_BASE_MS = 250;
+const RETRY_JITTER_MAX_MS = 150;
+
+const jitteredBackoff = (attempt: number): number =>
+  RETRY_DELAY_BASE_MS * 2 ** attempt + Math.floor(Math.random() * RETRY_JITTER_MAX_MS);
+
+/**
+ * Retries a load only on recognized throttling errors with exponential backoff
+ * + jitter. Used on the refresh/plan read path; write operations must not be
+ * auto-retried through this helper (idempotency is their caller's concern).
+ */
+export const withThrottleRetry = async <T>(load: () => Promise<T>, maxAttempts = 3): Promise<T> => {
+  let attempt = 0;
+  for (;;) {
+    try {
+      return await load();
+    } catch (error: unknown) {
+      attempt += 1;
+      if (!isThrottlingError(error) || attempt >= maxAttempts) {
+        throw error;
+      }
+      await sleep(jitteredBackoff(attempt - 1));
+    }
+  }
+};

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -274,6 +274,11 @@ export const en = {
     '{{count}} logstore(s) still reference shared SLS project {{projectName}}; retaining it',
   SHARED_SLS_PROJECT_ADOPTED:
     'Adopting existing shared SLS project {{projectName}} owned by this app',
+  REFRESH_CACHE_HIT: 'Refresh read cache hit: {{key}}',
+  PLAN_FUNCTION_ROLE_MISSING:
+    'Function {{functionName}} role {{roleName}} is missing in the provider; it will be recreated and rebound on deploy',
+  RAM_ROLE_MISSING_RECREATE:
+    'RAM role {{roleName}} is missing in the provider; recreating it with the union of all functions that share it',
   SLS_PROJECT_FOREIGN_OWNED:
     'SLS project {{projectName}} exists but is not owned by this app; refusing to adopt',
   APIGW_LOG_CONFIG_STILL_REFERENCES_STORE:

--- a/src/lang/zh-CN.ts
+++ b/src/lang/zh-CN.ts
@@ -254,6 +254,11 @@ export const zhCN = {
   SLS_LOGSTORE_WAITING: '等待 SLS 日志库 {{project}}/{{logstore}} 就绪...',
   SHARED_SLS_PROJECT_IN_USE: '仍有 {{count}} 个日志库引用共享 SLS 项目 {{projectName}}，予以保留',
   SHARED_SLS_PROJECT_ADOPTED: '采用当前应用已有的共享 SLS 项目 {{projectName}}',
+  REFRESH_CACHE_HIT: '刷新读缓存命中：{{key}}',
+  PLAN_FUNCTION_ROLE_MISSING:
+    '函数 {{functionName}} 的角色 {{roleName}} 在云端不存在；部署时将重建并重新绑定',
+  RAM_ROLE_MISSING_RECREATE:
+    'RAM 角色 {{roleName}} 在云端不存在；将以共享该角色的所有函数的并集权限重建',
   SLS_PROJECT_FOREIGN_OWNED: 'SLS 项目 {{projectName}} 已存在但不属于当前应用，拒绝采用',
   APIGW_LOG_CONFIG_STILL_REFERENCES_STORE:
     '区域级 PROVIDER 网关日志配置仍引用 {{slsLogStore}}，保留该日志库',

--- a/src/stack/aliyunStack/apigwPlanner.ts
+++ b/src/stack/aliyunStack/apigwPlanner.ts
@@ -8,6 +8,8 @@ import {
 } from './apigwTypes';
 import { getAllResources, getResource } from '../../common/stateManager';
 import { attributesEqual } from '../../common/hashUtils';
+import { cachedRefreshRead } from '../../common/refreshCache';
+import { PLAN_READ_CONCURRENCY, mapWithConcurrency } from '../../common/concurrency';
 import { OWNERSHIP_TAG_KEY, isOwnedByStack } from '../ownershipTag';
 
 const DNS_SUB_RESOURCE_SUFFIXES = ['.dns_verification', '.dns_txt_verification'];
@@ -42,8 +44,10 @@ export const generateApigwPlan = async (
 
   const desiredLogicalIds = new Set(events.map((e) => `events.${e.key}`));
 
-  const eventItems = await Promise.all(
-    events.map(async (event): Promise<PlanItem> => {
+  const eventItems = await mapWithConcurrency(
+    events,
+    PLAN_READ_CONCURRENCY,
+    async (event): Promise<PlanItem> => {
       const logicalId = `events.${event.key}`;
       const currentState = getResource(state, logicalId);
       const groupConfig = eventToApigwGroupConfig(event, serviceName, context.stage);
@@ -68,7 +72,11 @@ export const generateApigwPlan = async (
         // If a same-named group already exists WITHOUT our ownership tag it
         // may belong to another project — fail fast in the plan instead of
         // letting the executor discover it mid-deploy.
-        const remoteGroup = await client.apigw.findApiGroupByName(groupConfig.groupName);
+        const remoteGroup = await cachedRefreshRead(
+          context,
+          `apigw.findApiGroupByName:${groupConfig.groupName}`,
+          () => client.apigw.findApiGroupByName(groupConfig.groupName),
+        );
         if (remoteGroup?.groupId) {
           if (!isOwnedByStack(context, logicalId, remoteGroup.tags)) {
             throw new Error(
@@ -101,7 +109,11 @@ export const generateApigwPlan = async (
         const groupInstance = currentState.instances.find((i) => i.type === 'ALIYUN_APIGW_GROUP');
 
         if (groupInstance) {
-          const remoteGroup = await client.apigw.getApiGroup(groupInstance.id);
+          const remoteGroup = await cachedRefreshRead(
+            context,
+            `apigw.getApiGroup:${groupInstance.id}`,
+            () => client.apigw.getApiGroup(groupInstance.id),
+          );
 
           if (!remoteGroup) {
             // Resource in state but not remotely - needs recreate
@@ -136,7 +148,7 @@ export const generateApigwPlan = async (
           changes: { before: currentState.definition, after: desiredDefinition },
         };
       }
-    }),
+    },
   );
 
   // Find resources in state that are no longer in config

--- a/src/stack/aliyunStack/databasePlanner.ts
+++ b/src/stack/aliyunStack/databasePlanner.ts
@@ -8,6 +8,8 @@ import {
   ResourceAttributes,
 } from '../../types';
 import { createAliyunClient } from '../../common/aliyunClient';
+import { cachedRefreshRead } from '../../common/refreshCache';
+import { PLAN_READ_CONCURRENCY, mapWithConcurrency } from '../../common/concurrency';
 import { databaseToRdsConfig, extractRdsDefinition } from './rdsTypes';
 import { databaseToEsConfig, extractEsDefinition } from './esServerlessTypes';
 import { getAllResources, getResource } from '../../common/stateManager';
@@ -100,8 +102,10 @@ export const generateDatabasePlan = async (
 
   const client = createAliyunClient(context);
 
-  const databaseItems = await Promise.all(
-    aliyunDatabases.map(async (database): Promise<PlanItem> => {
+  const databaseItems = await mapWithConcurrency(
+    aliyunDatabases,
+    PLAN_READ_CONCURRENCY,
+    async (database): Promise<PlanItem> => {
       const logicalId = `databases.${database.key}`;
       const currentState = getResource(state, logicalId);
       const resourceType = getResourceType(database);
@@ -114,8 +118,12 @@ export const generateDatabasePlan = async (
         // letting the executor discover it mid-deploy.
         const remote =
           resourceType === 'ALIYUN_ES_SERVERLESS'
-            ? await client.es.getApp(database.name)
-            : await client.rds.getInstanceByName(database.name);
+            ? await cachedRefreshRead(context, `es.getApp:${database.name}`, () =>
+                client.es.getApp(database.name),
+              )
+            : await cachedRefreshRead(context, `rds.getInstanceByName:${database.name}`, () =>
+                client.rds.getInstanceByName(database.name),
+              );
         if (remote && !isOwnedByStack(context, logicalId, toOwnershipTagShape(remote.tags))) {
           throw new Error(
             `${resourceType} ${database.name} already exists in provider but is not owned by this stack (missing ${OWNERSHIP_TAG_KEY} tag). Refusing to create — resolve manually.`,
@@ -139,9 +147,17 @@ export const generateDatabasePlan = async (
         let remoteInstance: any = null;
 
         if (resourceType === 'ALIYUN_ES_SERVERLESS') {
-          remoteInstance = instanceId ? await client.es.getApp(instanceId) : null;
+          remoteInstance = instanceId
+            ? await cachedRefreshRead(context, `es.getApp:${instanceId}`, () =>
+                client.es.getApp(instanceId),
+              )
+            : null;
         } else if (resourceType === 'ALIYUN_RDS_SERVERLESS') {
-          remoteInstance = instanceId ? await client.rds.getInstance(instanceId) : null;
+          remoteInstance = instanceId
+            ? await cachedRefreshRead(context, `rds.getInstance:${instanceId}`, () =>
+                client.rds.getInstance(instanceId),
+              )
+            : null;
         }
 
         if (!remoteInstance) {
@@ -176,7 +192,7 @@ export const generateDatabasePlan = async (
           changes: { before: currentState.definition, after: desiredDefinition },
         };
       }
-    }),
+    },
   );
 
   const allStates = getAllResources(state);

--- a/src/stack/aliyunStack/fc3Planner.ts
+++ b/src/stack/aliyunStack/fc3Planner.ts
@@ -1,11 +1,21 @@
-import { attributesEqual, computeZipContentHash, getAllResources, getResource } from '../../common';
+import {
+  attributesEqual,
+  buildFunctionRoleName,
+  computeZipContentHash,
+  getAllResources,
+  getResource,
+  logger,
+} from '../../common';
 import { createAliyunClient } from '../../common/aliyunClient';
+import { cachedRefreshRead } from '../../common/refreshCache';
+import { PLAN_READ_CONCURRENCY, mapWithConcurrency } from '../../common/concurrency';
 import {
   Context,
   FunctionDomain,
   Plan,
   PlanItem,
   ResourceAttributes,
+  ResourceState,
   StateFile,
 } from '../../types';
 import { extractFc3Definition, Fc3FunctionConfig, functionToFc3Config } from './fc3Types';
@@ -59,7 +69,11 @@ const resolveSecurityGroupId = async (
   }
 
   const client = createAliyunClient(context);
-  const sg = await client.ecs.getSecurityGroupByName(securityGroupName, vpcId);
+  const sg = await cachedRefreshRead(
+    context,
+    `ecs.getSecurityGroupByName:${securityGroupName}:${vpcId ?? ''}`,
+    () => client.ecs.getSecurityGroupByName(securityGroupName, vpcId),
+  );
   if (!sg) {
     throw new Error(
       lang.__('SECURITY_GROUP_NOT_FOUND', { sgName: securityGroupName, vpcId: vpcId ?? 'default' }),
@@ -98,6 +112,35 @@ const planFunctionDeletion = (logicalId: string, definition: ResourceAttributes)
   changes: { before: normalizeDefinitionForComparison(definition) },
 });
 
+type ManagedRoleProbe = { roleName: string };
+
+// Issue #234: recorded role instance governs (stored-first); explicit managed
+// iam.role derives the executor's name. External (string) roles and functions
+// without role config are deliberately not probed.
+const resolveManagedRoleProbe = (
+  context: Context,
+  fn: FunctionDomain,
+  currentState: ResourceState | undefined,
+): ManagedRoleProbe | undefined => {
+  const iamRole = fn.iam?.role;
+  if (typeof iamRole === 'string') {
+    return undefined;
+  }
+  const roleInstance = currentState?.instances?.find(
+    (i) => (i as { type?: string }).type === 'ALIYUN_RAM_ROLE',
+  ) as { id?: string } | undefined;
+  if (roleInstance?.id) {
+    return { roleName: roleInstance.id };
+  }
+  if (iamRole && typeof iamRole === 'object') {
+    const serviceName = `${context.app}-${context.service}`;
+    return {
+      roleName: iamRole.name ?? buildFunctionRoleName(serviceName, context.stage, fn.key),
+    };
+  }
+  return undefined;
+};
+
 export const generateFunctionPlan = async (
   context: Context,
   state: StateFile,
@@ -115,8 +158,10 @@ export const generateFunctionPlan = async (
 
   const desiredLogicalIds = new Set(functions.map((fn) => `functions.${fn.key}`));
 
-  const functionItems = await Promise.all(
-    functions.map(async (fn): Promise<PlanItem> => {
+  const functionItems = await mapWithConcurrency(
+    functions,
+    PLAN_READ_CONCURRENCY,
+    async (fn): Promise<PlanItem> => {
       const logicalId = `functions.${fn.key}`;
       const currentState = getResource(state, logicalId);
       const rawConfig = functionToFc3Config(fn);
@@ -132,7 +177,9 @@ export const generateFunctionPlan = async (
         // may belong to another project — fail fast in the plan instead of
         // letting the executor discover it mid-deploy.
         const client = createAliyunClient(context);
-        const remoteFunction = await client.fc3.getFunction(fn.name);
+        const remoteFunction = await cachedRefreshRead(context, `fc3.getFunction:${fn.name}`, () =>
+          client.fc3.getFunction(fn.name),
+        );
         if (remoteFunction && !isOwnedByStack(context, logicalId, remoteFunction.tags)) {
           throw new Error(
             `Function ${fn.name} already exists in provider but is not owned by this stack (missing ${OWNERSHIP_TAG_KEY} tag). Refusing to create — resolve manually.`,
@@ -149,7 +196,9 @@ export const generateFunctionPlan = async (
 
       try {
         const client = createAliyunClient(context);
-        const remoteFunction = await client.fc3.getFunction(fn.name);
+        const remoteFunction = await cachedRefreshRead(context, `fc3.getFunction:${fn.name}`, () =>
+          client.fc3.getFunction(fn.name),
+        );
 
         if (!remoteFunction) {
           return {
@@ -179,6 +228,30 @@ export const generateFunctionPlan = async (
           };
         }
 
+        const roleProbe = resolveManagedRoleProbe(context, fn, currentState);
+        if (roleProbe) {
+          const cloudRole = await cachedRefreshRead(
+            context,
+            `ram.getRole:${roleProbe.roleName}`,
+            () => client.ram.getRole(roleProbe.roleName),
+          );
+          if (!cloudRole) {
+            logger.warn(
+              lang.__('PLAN_FUNCTION_ROLE_MISSING', {
+                roleName: roleProbe.roleName,
+                functionName: fn.name,
+              }),
+            );
+            return {
+              logicalId,
+              action: 'update',
+              resourceType: 'ALIYUN_FC3',
+              changes: { before: normalizedCurrent, after: normalizedDesired },
+              drifted: true,
+            };
+          }
+        }
+
         return { logicalId, action: 'noop', resourceType: 'ALIYUN_FC3' };
       } catch {
         return {
@@ -191,7 +264,7 @@ export const generateFunctionPlan = async (
           },
         };
       }
-    }),
+    },
   );
 
   const allStates = getAllResources(state);

--- a/src/stack/aliyunStack/fc3Resource.ts
+++ b/src/stack/aliyunStack/fc3Resource.ts
@@ -416,6 +416,7 @@ const createDependentResources = async (
   serviceName: string,
   existingInstances: Array<DependentInstance> = [],
   state?: StateFile,
+  options?: { skipRole?: boolean },
 ): Promise<{
   logConfig?: { project: string; logstore: string };
   role?: { roleName: string; arn: string };
@@ -453,6 +454,10 @@ const createDependentResources = async (
   const hasRamRole = existingInstances.some((i) => i.type === 'ALIYUN_RAM_ROLE');
   const hasSecurityGroup = existingInstances.some((i) => i.type === 'ALIYUN_ECS_SECURITY_GROUP');
   const hasNasResources = existingInstances.some((i) => i.type === 'ALIYUN_NAS_FILE_SYSTEM');
+  // Callers that reconcile the role themselves (updateResource) opt out so the
+  // helper neither re-creates a just-repaired role nor rewrites the execution
+  // policy from a grant derived without the caller's logConfig.
+  const skipRole = options?.skipRole === true;
 
   if (fn.log) {
     if (hasSlsProject) {
@@ -490,7 +495,7 @@ const createDependentResources = async (
 
   const isExternalRole = typeof iamConfig === 'string';
 
-  if (isExternalRole) {
+  if (isExternalRole && !skipRole) {
     // External role - use ARN directly, skip creation and management
     instances.push({
       type: 'ALIYUN_RAM_ROLE',
@@ -499,7 +504,7 @@ const createDependentResources = async (
       external: true,
       attributes: {} as Record<string, unknown>,
     });
-  } else if (hasRamRole) {
+  } else if (!skipRole && hasRamRole) {
     const ramRoleInstance = existingInstances.find((i) => i.type === 'ALIYUN_RAM_ROLE');
     if (ramRoleInstance) {
       const cloudRole = await client.ram.getRole(ramRoleInstance.id);
@@ -539,7 +544,7 @@ const createDependentResources = async (
         }
       }
     }
-  } else {
+  } else if (!skipRole) {
     const roleName = customRoleName ?? defaultRoleName;
     const roleGrant = resolveRoleGrant(context, state, fn, logConfig, roleName);
     logger.info(lang.__('CREATING_RAM_ROLE', { roleName }));
@@ -561,14 +566,17 @@ const createDependentResources = async (
   }
 
   const ramRoleInstance = instances.find((i) => i.type === 'ALIYUN_RAM_ROLE');
-  const role = isExternalRole
-    ? { roleName: '', arn: iamConfig }
-    : {
-        roleName: customRoleName ?? defaultRoleName,
-        arn:
-          ramRoleInstance?.roleArn ??
-          `acs:ram::${context.accountId}:role/${customRoleName ?? defaultRoleName}`,
-      };
+  let role: { roleName: string; arn: string } | undefined;
+  if (isExternalRole) {
+    role = { roleName: '', arn: iamConfig };
+  } else if (!skipRole) {
+    role = {
+      roleName: customRoleName ?? defaultRoleName,
+      arn:
+        ramRoleInstance?.roleArn ??
+        `acs:ram::${context.accountId}:role/${customRoleName ?? defaultRoleName}`,
+    };
+  }
 
   if (fn.network) {
     if (hasSecurityGroup) {
@@ -1108,6 +1116,7 @@ export const updateResource = async (
       serviceName,
       undefined,
       state,
+      { skipRole: true },
     );
     logConfig = deps.logConfig;
     newDependentInstances.push(...deps.instances.filter((i) => i.type.startsWith('ALIYUN_SLS_')));
@@ -1144,21 +1153,25 @@ export const updateResource = async (
   let roleBindingChanged = false;
   const droppedRamRoleIds = new Set<string>();
 
-  const ramRoleInstance = existingInstances.find((i) => i.type === 'ALIYUN_RAM_ROLE') as
-    { id: string; roleArn?: string } | undefined;
+  const ramRoleInstance = existingInstances.find((i) => i.type === 'ALIYUN_RAM_ROLE');
   // Issue #234 dual check: a recorded instance is not trusted on its own — when
   // the provider role is gone, the create path below rebuilds it with
   // peer-union grants and drops the stale instance from the resulting state.
-  const cloudRoleExists = ramRoleInstance
-    ? Boolean(await client.ram.getRole(ramRoleInstance.id))
-    : false;
+  // External roles are recorded with the ARN as the instance id, which is not a
+  // valid GetRole roleName input, and the external branch below never consults
+  // the probe — so only recorded managed roles are probed.
+  const isRecordedRoleExternal = Boolean(ramRoleInstance?.external);
+  const cloudRoleExists =
+    ramRoleInstance && !isRecordedRoleExternal && typeof newIamRole !== 'string'
+      ? Boolean(await client.ram.getRole(ramRoleInstance.id))
+      : false;
 
   if (typeof newIamRole === 'string') {
     // External role - use ARN directly, skip management
     role = { roleName: '', arn: newIamRole };
-  } else if (!ramRoleInstance || !cloudRoleExists) {
+  } else if (!ramRoleInstance || isRecordedRoleExternal || !cloudRoleExists) {
     const roleName =
-      ramRoleInstance?.id ??
+      (isRecordedRoleExternal ? undefined : ramRoleInstance?.id) ??
       customRoleName ??
       buildDefaultRoleName(serviceName, context.stage, fn.key);
     const roleGrant = resolveRoleGrant(context, state, fn, logConfig, roleName);
@@ -1256,6 +1269,7 @@ export const updateResource = async (
       serviceName,
       undefined,
       state,
+      { skipRole: true },
     );
     securityGroup = deps.securityGroup;
     newDependentInstances.push(
@@ -1269,12 +1283,24 @@ export const updateResource = async (
   }
 
   if (fn.storage?.nas && fn.storage.nas.length > 0 && fn.network && !hasNasResources) {
+    // The SG branch above already created/reused the security group — pass it
+    // so the helper reuses it instead of creating an untracked duplicate.
+    const sgExistingInstances = securityGroup
+      ? [
+          {
+            type: 'ALIYUN_ECS_SECURITY_GROUP',
+            id: securityGroup.securityGroupId,
+            attributes: {} as Record<string, unknown>,
+          },
+        ]
+      : [];
     const deps = await createDependentResources(
       context,
       { ...fn, log: false },
       serviceName,
-      undefined,
+      sgExistingInstances,
       state,
+      { skipRole: true },
     );
     nasConfig = deps.nasConfig;
     newDependentInstances.push(...deps.instances.filter((i) => i.type.startsWith('ALIYUN_NAS_')));

--- a/src/stack/aliyunStack/fc3Resource.ts
+++ b/src/stack/aliyunStack/fc3Resource.ts
@@ -416,7 +416,6 @@ const createDependentResources = async (
   serviceName: string,
   existingInstances: Array<DependentInstance> = [],
   state?: StateFile,
-  executionStatementsOverride?: IamStatement[],
 ): Promise<{
   logConfig?: { project: string; logstore: string };
   role?: { roleName: string; arn: string };
@@ -484,15 +483,10 @@ const createDependentResources = async (
   }
 
   const iamConfig = fn.iam?.role;
-  const statements = iamConfig && typeof iamConfig !== 'string' ? iamConfig.statements : undefined;
   const managedPolicies =
     iamConfig && typeof iamConfig !== 'string' ? iamConfig.managed_policies : undefined;
   const customRoleName = iamConfig && typeof iamConfig !== 'string' ? iamConfig.name : undefined;
   const defaultRoleName = buildDefaultRoleName(serviceName, context.stage, fn.key);
-
-  const trustedServices = getTrustedServicesForFunction(context, fn);
-  const executionStatements =
-    executionStatementsOverride ?? deriveFc3ExecutionStatements(fn, context, logConfig);
 
   const isExternalRole = typeof iamConfig === 'string';
 
@@ -508,27 +502,54 @@ const createDependentResources = async (
   } else if (hasRamRole) {
     const ramRoleInstance = existingInstances.find((i) => i.type === 'ALIYUN_RAM_ROLE');
     if (ramRoleInstance) {
-      instances.push(ramRoleInstance);
-      const roleGrant = resolveRoleGrant(context, state, fn, logConfig, ramRoleInstance.id);
-      await client.ram.updateRoleTrustPolicy(ramRoleInstance.id, roleGrant.trustedServices);
-      await client.ram.updateExecutionPolicyDocument(
-        ramRoleInstance.id,
-        buildFc3ExecutionPolicyDocument(roleGrant.executionStatements, roleGrant.customStatements),
-      );
-      if (managedPolicies?.length) {
-        await client.ram.attachManagedPolicies(ramRoleInstance.id, managedPolicies);
+      const cloudRole = await client.ram.getRole(ramRoleInstance.id);
+      if (!cloudRole) {
+        // Issue #234: recorded instance but provider role gone — rebuild with
+        // peer-union grants instead of failing on the trust-policy update.
+        logger.warn(lang.__('RAM_ROLE_MISSING_RECREATE', { roleName: ramRoleInstance.id }));
+        const roleGrant = resolveRoleGrant(context, state, fn, logConfig, ramRoleInstance.id);
+        const ramRole = await client.ram.createRole(
+          ramRoleInstance.id,
+          roleGrant.trustedServices,
+          undefined,
+          roleGrant.customStatements,
+          managedPolicies,
+          roleGrant.executionStatements,
+        );
+        instances.push({
+          type: 'ALIYUN_RAM_ROLE',
+          id: ramRoleInstance.id,
+          roleArn: ramRole.arn,
+          attributes: { ...ramRole },
+        });
+        await delay(RAM_ROLE_PROPAGATION_DELAY_MS);
+      } else {
+        instances.push(ramRoleInstance);
+        const roleGrant = resolveRoleGrant(context, state, fn, logConfig, ramRoleInstance.id);
+        await client.ram.updateRoleTrustPolicy(ramRoleInstance.id, roleGrant.trustedServices);
+        await client.ram.updateExecutionPolicyDocument(
+          ramRoleInstance.id,
+          buildFc3ExecutionPolicyDocument(
+            roleGrant.executionStatements,
+            roleGrant.customStatements,
+          ),
+        );
+        if (managedPolicies?.length) {
+          await client.ram.attachManagedPolicies(ramRoleInstance.id, managedPolicies);
+        }
       }
     }
   } else {
     const roleName = customRoleName ?? defaultRoleName;
+    const roleGrant = resolveRoleGrant(context, state, fn, logConfig, roleName);
     logger.info(lang.__('CREATING_RAM_ROLE', { roleName }));
     const ramRole = await client.ram.createRole(
       roleName,
-      trustedServices,
+      roleGrant.trustedServices,
       undefined,
-      statements,
+      roleGrant.customStatements,
       managedPolicies,
-      executionStatements,
+      roleGrant.executionStatements,
     );
     instances.push({
       type: 'ALIYUN_RAM_ROLE',
@@ -1055,7 +1076,6 @@ export const updateResource = async (
       i.type === 'ALIYUN_SLS_LOGSTORE' ||
       i.type === 'ALIYUN_SLS_INDEX',
   );
-  const hasRamRole = existingInstances.some((i) => i.type === 'ALIYUN_RAM_ROLE');
   const hasSecurityGroup = existingInstances.some((i) => i.type === 'ALIYUN_ECS_SECURITY_GROUP');
   const hasNasResources = existingInstances.some((i) => i.type === 'ALIYUN_NAS_FILE_SYSTEM');
 
@@ -1116,23 +1136,57 @@ export const updateResource = async (
 
   const newIamRole = fn.iam?.role;
   const executionStatements = deriveFc3ExecutionStatements(fn, context, logConfig);
+  const iamRoleConfig = newIamRole && typeof newIamRole !== 'string' ? newIamRole : undefined;
+  const customRoleName = iamRoleConfig?.name;
+  const desiredManagedPolicies = iamRoleConfig?.managed_policies;
+  // A role created/recreated in this run must rebind the function even when the
+  // compared definition is unchanged — role is not part of extractFc3Definition.
+  let roleBindingChanged = false;
+  const droppedRamRoleIds = new Set<string>();
+
+  const ramRoleInstance = existingInstances.find((i) => i.type === 'ALIYUN_RAM_ROLE') as
+    { id: string; roleArn?: string } | undefined;
+  // Issue #234 dual check: a recorded instance is not trusted on its own — when
+  // the provider role is gone, the create path below rebuilds it with
+  // peer-union grants and drops the stale instance from the resulting state.
+  const cloudRoleExists = ramRoleInstance
+    ? Boolean(await client.ram.getRole(ramRoleInstance.id))
+    : false;
 
   if (typeof newIamRole === 'string') {
     // External role - use ARN directly, skip management
     role = { roleName: '', arn: newIamRole };
-  } else if (!hasRamRole) {
-    const deps = await createDependentResources(
-      context,
-      { ...fn, log: false, network: undefined, storage: { ...fn.storage, nas: undefined } },
-      serviceName,
+  } else if (!ramRoleInstance || !cloudRoleExists) {
+    const roleName =
+      ramRoleInstance?.id ??
+      customRoleName ??
+      buildDefaultRoleName(serviceName, context.stage, fn.key);
+    const roleGrant = resolveRoleGrant(context, state, fn, logConfig, roleName);
+    logger.info(lang.__('CREATING_RAM_ROLE', { roleName }));
+    const ramRole = await client.ram.createRole(
+      roleName,
+      roleGrant.trustedServices,
       undefined,
-      state,
-      executionStatements,
+      roleGrant.customStatements,
+      desiredManagedPolicies,
+      roleGrant.executionStatements,
     );
-    role = deps.role;
-    newDependentInstances.push(...deps.instances.filter((i) => i.type === 'ALIYUN_RAM_ROLE'));
+    role = {
+      roleName,
+      arn: ramRole.arn ?? `acs:ram::${context.accountId}:role/${roleName}`,
+    };
+    if (ramRoleInstance) {
+      droppedRamRoleIds.add(ramRoleInstance.id);
+    }
+    newDependentInstances.push({
+      type: 'ALIYUN_RAM_ROLE',
+      id: roleName,
+      roleArn: role.arn,
+      attributes: { ...ramRole },
+    });
+    await delay(RAM_ROLE_PROPAGATION_DELAY_MS);
+    roleBindingChanged = true;
   } else {
-    const ramRoleInstance = existingInstances.find((i) => i.type === 'ALIYUN_RAM_ROLE');
     if (ramRoleInstance) {
       role = {
         roleName: ramRoleInstance.id,
@@ -1202,7 +1256,6 @@ export const updateResource = async (
       serviceName,
       undefined,
       state,
-      executionStatements,
     );
     securityGroup = deps.securityGroup;
     newDependentInstances.push(
@@ -1222,7 +1275,6 @@ export const updateResource = async (
       serviceName,
       undefined,
       state,
-      executionStatements,
     );
     nasConfig = deps.nasConfig;
     newDependentInstances.push(...deps.instances.filter((i) => i.type.startsWith('ALIYUN_NAS_')));
@@ -1300,7 +1352,7 @@ export const updateResource = async (
   const { codeHash: _desiredCodeHash, ...desiredConfigOnly } = desiredDefinition;
   const configChanged = !attributesEqual(existingConfigOnly, desiredConfigOnly);
 
-  if (configChanged) {
+  if (configChanged || roleBindingChanged) {
     await client.fc3.updateFunctionConfiguration(config);
   }
 
@@ -1506,6 +1558,7 @@ export const updateResource = async (
     .filter((i) => i.type !== 'ALIYUN_FC3_HTTP_TRIGGER')
     .filter((i) => i.type !== 'ALIYUN_FC3_CUSTOM_DOMAIN')
     .filter((i) => !(typeof fn.iam?.role === 'string' && i.type === 'ALIYUN_RAM_ROLE'))
+    .filter((i) => !(i.type === 'ALIYUN_RAM_ROLE' && droppedRamRoleIds.has(i.id)))
     .filter((i) => !droppedSlsDependentTypes.includes(i.type))
     .map((i) => {
       const { sid: existingSid, id: existingId, ...rest } = i;

--- a/src/stack/aliyunStack/ossPlanner.ts
+++ b/src/stack/aliyunStack/ossPlanner.ts
@@ -1,6 +1,8 @@
 import path from 'node:path';
 import { Context, BucketDomain, Plan, PlanItem, StateFile, ResourceAttributes } from '../../types';
 import { createAliyunClient } from '../../common/aliyunClient';
+import { cachedRefreshRead } from '../../common/refreshCache';
+import { PLAN_READ_CONCURRENCY, mapWithConcurrency } from '../../common/concurrency';
 import { bucketToOssBucketConfig, extractOssBucketDefinition } from './ossTypes';
 import { getAllResources, getResource } from '../../common/stateManager';
 import { attributesEqual, computeDirectoryHash } from '../../common/hashUtils';
@@ -40,8 +42,10 @@ export const generateBucketPlan = async (
 
   const desiredLogicalIds = new Set(buckets.map((bucket) => `buckets.${bucket.key}`));
 
-  const bucketItems = await Promise.all(
-    buckets.map(async (bucket): Promise<PlanItem> => {
+  const bucketItems = await mapWithConcurrency(
+    buckets,
+    PLAN_READ_CONCURRENCY,
+    async (bucket): Promise<PlanItem> => {
       const logicalId = `buckets.${bucket.key}`;
       const currentState = getResource(state, logicalId);
       const config = bucketToOssBucketConfig(bucket);
@@ -61,7 +65,9 @@ export const generateBucketPlan = async (
         // may belong to another project — fail fast in the plan instead of
         // letting the executor discover it mid-deploy.
         const client = createAliyunClient(context);
-        const remoteBucket = await client.oss.getBucket(bucket.name);
+        const remoteBucket = await cachedRefreshRead(context, `oss.getBucket:${bucket.name}`, () =>
+          client.oss.getBucket(bucket.name),
+        );
         if (
           remoteBucket &&
           !isOwnedByStack(context, logicalId, toOwnershipTags(remoteBucket.tags))
@@ -81,7 +87,9 @@ export const generateBucketPlan = async (
 
       try {
         const client = createAliyunClient(context);
-        const remoteBucket = await client.oss.getBucket(bucket.name);
+        const remoteBucket = await cachedRefreshRead(context, `oss.getBucket:${bucket.name}`, () =>
+          client.oss.getBucket(bucket.name),
+        );
 
         if (!remoteBucket) {
           return {
@@ -125,7 +133,7 @@ export const generateBucketPlan = async (
           },
         };
       }
-    }),
+    },
   );
 
   const allStates = getAllResources(state);

--- a/src/stack/aliyunStack/tablestorePlanner.ts
+++ b/src/stack/aliyunStack/tablestorePlanner.ts
@@ -1,5 +1,7 @@
 import { Context, TableDomain, Plan, PlanItem, StateFile, ResourceAttributes } from '../../types';
 import { createAliyunClient } from '../../common/aliyunClient';
+import { cachedRefreshRead } from '../../common/refreshCache';
+import { PLAN_READ_CONCURRENCY, mapWithConcurrency } from '../../common/concurrency';
 import { tableToTableStoreConfig, extractTableStoreDefinition } from './tablestoreTypes';
 import { getAllResources, getResource } from '../../common/stateManager';
 import { attributesEqual } from '../../common/hashUtils';
@@ -26,8 +28,10 @@ export const generateTablePlan = async (
 
   const desiredLogicalIds = new Set(tables.map((table) => `tables.${table.key}`));
 
-  const tableItems = await Promise.all(
-    tables.map(async (table): Promise<PlanItem> => {
+  const tableItems = await mapWithConcurrency(
+    tables,
+    PLAN_READ_CONCURRENCY,
+    async (table): Promise<PlanItem> => {
       const logicalId = `tables.${table.key}`;
       const currentState = getResource(state, logicalId);
       const config = tableToTableStoreConfig(table);
@@ -42,7 +46,11 @@ export const generateTablePlan = async (
         // discover the collision mid-deploy.
         const client = createAliyunClient(context);
         const tablestoreClient = client.tablestore(config.instanceName);
-        const remoteTable = await tablestoreClient.getTable(config.tableName);
+        const remoteTable = await cachedRefreshRead(
+          context,
+          `tablestore.getTable:${config.instanceName}:${config.tableName}`,
+          () => tablestoreClient.getTable(config.tableName),
+        );
         if (remoteTable) {
           throw new Error(
             `Table ${config.tableName} already exists in provider but ownership cannot be verified (no table-level tags). Refusing to adopt — resolve manually.`,
@@ -60,7 +68,11 @@ export const generateTablePlan = async (
       try {
         const client = createAliyunClient(context);
         const tablestoreClient = client.tablestore(config.instanceName);
-        const remoteTable = await tablestoreClient.getTable(config.tableName);
+        const remoteTable = await cachedRefreshRead(
+          context,
+          `tablestore.getTable:${config.instanceName}:${config.tableName}`,
+          () => tablestoreClient.getTable(config.tableName),
+        );
 
         if (!remoteTable) {
           return {
@@ -113,7 +125,7 @@ export const generateTablePlan = async (
           changes: { before: currentState.definition, after: desiredDefinition },
         };
       }
-    }),
+    },
   );
 
   const allStates = getAllResources(state);

--- a/src/stack/scfStack/cosPlanner.ts
+++ b/src/stack/scfStack/cosPlanner.ts
@@ -1,5 +1,7 @@
 import { Context, BucketDomain, Plan, PlanItem, StateFile, ResourceAttributes } from '../../types';
 import { createTencentClient } from '../../common/tencentClient';
+import { cachedRefreshRead } from '../../common/refreshCache';
+import { PLAN_READ_CONCURRENCY, mapWithConcurrency } from '../../common/concurrency';
 import { bucketToCosBucketConfig, extractCosBucketDefinition } from './cosTypes';
 import { getAllResources, getResource } from '../../common/stateManager';
 import { attributesEqual } from '../../common/hashUtils';
@@ -27,8 +29,10 @@ export const generateBucketPlan = async (
 
   const desiredLogicalIds = new Set(buckets.map((bucket) => `buckets.${bucket.key}`));
 
-  const bucketItems = await Promise.all(
-    buckets.map(async (bucket): Promise<PlanItem> => {
+  const bucketItems = await mapWithConcurrency(
+    buckets,
+    PLAN_READ_CONCURRENCY,
+    async (bucket): Promise<PlanItem> => {
       const logicalId = `buckets.${bucket.key}`;
       const currentState = getResource(state, logicalId);
       const config = bucketToCosBucketConfig(bucket, context.region);
@@ -40,7 +44,11 @@ export const generateBucketPlan = async (
         // may belong to another project — fail fast in the plan instead of
         // letting the executor discover it mid-deploy.
         const client = createTencentClient(context);
-        const remoteBucket = await client.cos.getBucket(bucket.name, context.region);
+        const remoteBucket = await cachedRefreshRead(
+          context,
+          `cos.getBucket:${context.region}:${bucket.name}`,
+          () => client.cos.getBucket(bucket.name, context.region),
+        );
         if (remoteBucket && !isOwnedByStack(context, logicalId, remoteBucket.Tags)) {
           throw new Error(
             `Bucket ${bucket.name} already exists in provider but is not owned by this stack (missing ${OWNERSHIP_TAG_KEY} tag). Refusing to create — resolve manually.`,
@@ -57,7 +65,11 @@ export const generateBucketPlan = async (
 
       try {
         const client = createTencentClient(context);
-        const remoteBucket = await client.cos.getBucket(bucket.name, context.region);
+        const remoteBucket = await cachedRefreshRead(
+          context,
+          `cos.getBucket:${context.region}:${bucket.name}`,
+          () => client.cos.getBucket(bucket.name, context.region),
+        );
 
         if (!remoteBucket) {
           return {
@@ -91,7 +103,7 @@ export const generateBucketPlan = async (
           changes: { before: currentState.definition, after: desiredDefinition },
         };
       }
-    }),
+    },
   );
 
   const allStates = getAllResources(state);

--- a/src/stack/scfStack/esServerlessPlanner.ts
+++ b/src/stack/scfStack/esServerlessPlanner.ts
@@ -8,6 +8,8 @@ import {
   ResourceAttributes,
 } from '../../types';
 import { createTencentClient } from '../../common/tencentClient';
+import { cachedRefreshRead } from '../../common/refreshCache';
+import { PLAN_READ_CONCURRENCY, mapWithConcurrency } from '../../common/concurrency';
 import { databaseToTencentEsConfig, extractTencentEsDefinition } from './esServerlessTypes';
 import { getAllResources, getResource } from '../../common/stateManager';
 import { attributesEqual } from '../../common/hashUtils';
@@ -40,8 +42,10 @@ export const generateEsPlan = async (
 
   const desiredLogicalIds = new Set(esDatabases.map((db) => `databases.${db.key}`));
 
-  const databaseItems = await Promise.all(
-    esDatabases.map(async (database): Promise<PlanItem> => {
+  const databaseItems = await mapWithConcurrency(
+    esDatabases,
+    PLAN_READ_CONCURRENCY,
+    async (database): Promise<PlanItem> => {
       const logicalId = `databases.${database.key}`;
       const currentState = getResource(state, logicalId);
       const config = databaseToTencentEsConfig(database);
@@ -53,7 +57,11 @@ export const generateEsPlan = async (
         // belong to another project — fail fast in the plan instead of letting
         // the executor discover it mid-deploy.
         const client = createTencentClient(context);
-        const remoteSpace = await client.es.getSpaceByName(config.SpaceName);
+        const remoteSpace = await cachedRefreshRead(
+          context,
+          `es.getSpaceByName:${config.SpaceName}`,
+          () => client.es.getSpaceByName(config.SpaceName),
+        );
         if (remoteSpace && !isOwnedByStack(context, logicalId, remoteSpace.Tags)) {
           throw new Error(
             `ES space ${config.SpaceName} already exists in provider but is not owned by this stack (missing ${OWNERSHIP_TAG_KEY} tag). Refusing to create — resolve manually.`,
@@ -73,7 +81,11 @@ export const generateEsPlan = async (
 
       try {
         const client = createTencentClient(context);
-        const remoteSpace = spaceId ? await client.es.getSpace(spaceId) : null;
+        const remoteSpace = spaceId
+          ? await cachedRefreshRead(context, `es.getSpace:${spaceId}`, () =>
+              client.es.getSpace(spaceId),
+            )
+          : null;
 
         if (!remoteSpace) {
           return {
@@ -107,7 +119,7 @@ export const generateEsPlan = async (
           changes: { before: currentState.definition, after: desiredDefinition },
         };
       }
-    }),
+    },
   );
 
   const allStates = getAllResources(state);

--- a/src/stack/scfStack/scfPlanner.ts
+++ b/src/stack/scfStack/scfPlanner.ts
@@ -7,6 +7,8 @@ import {
   ResourceAttributes,
 } from '../../types';
 import { createTencentClient } from '../../common/tencentClient';
+import { cachedRefreshRead } from '../../common/refreshCache';
+import { PLAN_READ_CONCURRENCY, mapWithConcurrency } from '../../common/concurrency';
 import { functionToScfConfig, extractScfDefinition } from './scfTypes';
 import { getAllResources, getResource } from '../../common/stateManager';
 import { attributesEqual, computeZipContentHash } from '../../common/hashUtils';
@@ -37,8 +39,10 @@ export const generateFunctionPlan = async (
 
   const desiredLogicalIds = new Set(functions.map((fn) => `functions.${fn.key}`));
 
-  const functionItems = await Promise.all(
-    functions.map(async (fn): Promise<PlanItem> => {
+  const functionItems = await mapWithConcurrency(
+    functions,
+    PLAN_READ_CONCURRENCY,
+    async (fn): Promise<PlanItem> => {
       const logicalId = `functions.${fn.key}`;
       const currentState = getResource(state, logicalId);
       let config = functionToScfConfig(fn);
@@ -59,7 +63,9 @@ export const generateFunctionPlan = async (
         // may belong to another project — fail fast in the plan instead of
         // letting the executor discover it mid-deploy.
         const client = createTencentClient(context);
-        const remoteFunction = await client.scf.getFunction(fn.name);
+        const remoteFunction = await cachedRefreshRead(context, `scf.getFunction:${fn.name}`, () =>
+          client.scf.getFunction(fn.name),
+        );
         if (remoteFunction && !isOwnedByStack(context, logicalId, remoteFunction.Tags)) {
           throw new Error(
             `Function ${fn.name} already exists in provider but is not owned by this stack (missing ${OWNERSHIP_TAG_KEY} tag). Refusing to create — resolve manually.`,
@@ -76,7 +82,9 @@ export const generateFunctionPlan = async (
 
       try {
         const client = createTencentClient(context);
-        const remoteFunction = await client.scf.getFunction(fn.name);
+        const remoteFunction = await cachedRefreshRead(context, `scf.getFunction:${fn.name}`, () =>
+          client.scf.getFunction(fn.name),
+        );
 
         if (!remoteFunction) {
           return {
@@ -110,7 +118,7 @@ export const generateFunctionPlan = async (
           changes: { before: currentState.definition, after: desiredDefinition },
         };
       }
-    }),
+    },
   );
 
   const allStates = getAllResources(state);

--- a/src/stack/scfStack/tdsqlcPlanner.ts
+++ b/src/stack/scfStack/tdsqlcPlanner.ts
@@ -8,6 +8,8 @@ import {
   ResourceAttributes,
 } from '../../types';
 import { createTencentClient } from '../../common/tencentClient';
+import { cachedRefreshRead } from '../../common/refreshCache';
+import { PLAN_READ_CONCURRENCY, mapWithConcurrency } from '../../common/concurrency';
 import {
   databaseToTdsqlcConfig,
   extractTdsqlcDefinition,
@@ -49,8 +51,10 @@ export const generateDatabasePlan = async (
 
   const desiredLogicalIds = new Set(tdsqlcDatabases.map((db) => `databases.${db.key}`));
 
-  const databaseItems = await Promise.all(
-    tdsqlcDatabases.map(async (database): Promise<PlanItem> => {
+  const databaseItems = await mapWithConcurrency(
+    tdsqlcDatabases,
+    PLAN_READ_CONCURRENCY,
+    async (database): Promise<PlanItem> => {
       const logicalId = `databases.${database.key}`;
       const currentState = getResource(state, logicalId);
       const config = databaseToTdsqlcConfig(database);
@@ -62,7 +66,11 @@ export const generateDatabasePlan = async (
         // belong to another project — fail fast in the plan instead of letting
         // the executor discover it mid-deploy.
         const client = createTencentClient(context);
-        const remoteCluster = await client.tdsqlc.getClusterByName(database.name);
+        const remoteCluster = await cachedRefreshRead(
+          context,
+          `tdsqlc.getClusterByName:${database.name}`,
+          () => client.tdsqlc.getClusterByName(database.name),
+        );
         if (
           remoteCluster &&
           !isOwnedByStack(context, logicalId, tdsqlcTagsToOwnershipTags(remoteCluster.ResourceTags))
@@ -85,7 +93,11 @@ export const generateDatabasePlan = async (
 
       try {
         const client = createTencentClient(context);
-        const remoteCluster = clusterId ? await client.tdsqlc.getCluster(clusterId) : null;
+        const remoteCluster = clusterId
+          ? await cachedRefreshRead(context, `tdsqlc.getCluster:${clusterId}`, () =>
+              client.tdsqlc.getCluster(clusterId),
+            )
+          : null;
 
         if (!remoteCluster) {
           return {
@@ -119,7 +131,7 @@ export const generateDatabasePlan = async (
           changes: { before: currentState.definition, after: desiredDefinition },
         };
       }
-    }),
+    },
   );
 
   const allStates = getAllResources(state);

--- a/src/stack/volcengineStack/apigwPlanner.ts
+++ b/src/stack/volcengineStack/apigwPlanner.ts
@@ -1,5 +1,7 @@
 import { Context, EventDomain, Plan, PlanItem, StateFile } from '../../types';
 import { createVolcengineClient } from '../../common/volcengineClient';
+import { cachedRefreshRead } from '../../common/refreshCache';
+import { PLAN_READ_CONCURRENCY, mapWithConcurrency } from '../../common/concurrency';
 import { buildEventResourceDefinition, buildGatewayName } from './apigwTypes';
 import { getAllResources, getResource } from '../../common/stateManager';
 import { attributesEqual } from '../../common/hashUtils';
@@ -28,8 +30,10 @@ export const generateApigwPlan = async (
 
   const desiredLogicalIds = new Set(events.map((e) => `events.${e.key}`));
 
-  const eventItems = await Promise.all(
-    events.map(async (event): Promise<PlanItem> => {
+  const eventItems = await mapWithConcurrency(
+    events,
+    PLAN_READ_CONCURRENCY,
+    async (event): Promise<PlanItem> => {
       const logicalId = `events.${event.key}`;
       const currentState = getResource(state, logicalId);
       const client = createVolcengineClient(context);
@@ -49,8 +53,10 @@ export const generateApigwPlan = async (
         // may belong to another project — fail fast in the plan instead of
         // letting the executor discover it mid-deploy. The serverless gateway
         // is account-scoped, so only refuse when the NAMED one is foreign.
-        const remoteGateway = await client.apigw.findGatewayByName(
-          buildGatewayName(serviceName, context.stage),
+        const remoteGateway = await cachedRefreshRead(
+          context,
+          `apigw.findGatewayByName:${serviceName}:${context.stage}`,
+          () => client.apigw.findGatewayByName(buildGatewayName(serviceName, context.stage)),
         );
         if (remoteGateway?.gatewayId && !isOwnedByStack(context, logicalId, remoteGateway.tags)) {
           throw new Error(
@@ -71,7 +77,13 @@ export const generateApigwPlan = async (
       );
 
       if (serviceInstance) {
-        const remoteService = await client.apigw.getService(serviceInstance.id).catch(() => null);
+        // Keep the not-found swallow OUTSIDE the cached read: a cached rejection
+        // evicts its key so the next plan pass retries against the provider.
+        const remoteService = await cachedRefreshRead(
+          context,
+          `apigw.getService:${serviceInstance.id}`,
+          () => client.apigw.getService(serviceInstance.id),
+        ).catch(() => null);
 
         if (!remoteService) {
           return {
@@ -97,7 +109,7 @@ export const generateApigwPlan = async (
       }
 
       return { logicalId, action: 'noop', resourceType: 'VOLCENGINE_APIGW' };
-    }),
+    },
   );
 
   const allStates = getAllResources(state);

--- a/src/stack/volcengineStack/tosPlanner.ts
+++ b/src/stack/volcengineStack/tosPlanner.ts
@@ -1,6 +1,8 @@
 import path from 'node:path';
 import { Context, BucketDomain, Plan, PlanItem, StateFile, ResourceAttributes } from '../../types';
 import { createVolcengineClient } from '../../common/volcengineClient';
+import { cachedRefreshRead } from '../../common/refreshCache';
+import { PLAN_READ_CONCURRENCY, mapWithConcurrency } from '../../common/concurrency';
 import { bucketToTosConfig, extractTosBucketDefinition } from './tosTypes';
 import { getAllResources, getResource } from '../../common/stateManager';
 import { attributesEqual, computeDirectoryHash } from '../../common';
@@ -28,8 +30,10 @@ export const generateBucketPlan = async (
 
   const desiredLogicalIds = new Set(buckets.map((bucket) => `buckets.${bucket.key}`));
 
-  const bucketItems = await Promise.all(
-    buckets.map(async (bucket): Promise<PlanItem> => {
+  const bucketItems = await mapWithConcurrency(
+    buckets,
+    PLAN_READ_CONCURRENCY,
+    async (bucket): Promise<PlanItem> => {
       const logicalId = `buckets.${bucket.key}`;
       const currentState = getResource(state, logicalId);
       const config = bucketToTosConfig(bucket);
@@ -49,7 +53,9 @@ export const generateBucketPlan = async (
         // may belong to another project — fail fast in the plan instead of
         // letting the executor discover it mid-deploy.
         const client = createVolcengineClient(context);
-        const remoteBucket = await client.tos.getBucket(bucket.name);
+        const remoteBucket = await cachedRefreshRead(context, `tos.getBucket:${bucket.name}`, () =>
+          client.tos.getBucket(bucket.name),
+        );
         if (remoteBucket && !isOwnedByStack(context, logicalId, remoteBucket.Tags)) {
           throw new Error(
             `Bucket ${bucket.name} already exists in provider but is not owned by this stack (missing ${OWNERSHIP_TAG_KEY} tag). Refusing to create — resolve manually.`,
@@ -66,7 +72,9 @@ export const generateBucketPlan = async (
 
       try {
         const client = createVolcengineClient(context);
-        const remoteBucket = await client.tos.getBucket(bucket.name);
+        const remoteBucket = await cachedRefreshRead(context, `tos.getBucket:${bucket.name}`, () =>
+          client.tos.getBucket(bucket.name),
+        );
 
         if (!remoteBucket) {
           return {
@@ -106,7 +114,7 @@ export const generateBucketPlan = async (
           },
         };
       }
-    }),
+    },
   );
 
   const allStates = getAllResources(state);

--- a/src/stack/volcengineStack/vefaasPlanner.ts
+++ b/src/stack/volcengineStack/vefaasPlanner.ts
@@ -1,6 +1,8 @@
 import { attributesEqual, computeZipContentHash, getResource } from '../../common';
 import { getAllResources, getSharedResource } from '../../common/stateManager';
 import { createVolcengineClient } from '../../common/volcengineClient';
+import { cachedRefreshRead } from '../../common/refreshCache';
+import { PLAN_READ_CONCURRENCY, mapWithConcurrency } from '../../common/concurrency';
 import {
   Context,
   FunctionDomain,
@@ -37,8 +39,10 @@ export const generateFunctionPlan = async (
 
   const desiredLogicalIds = new Set(functions.map((fn) => `functions.${fn.key}`));
 
-  const functionItems = await Promise.all(
-    functions.map(async (fn): Promise<PlanItem> => {
+  const functionItems = await mapWithConcurrency(
+    functions,
+    PLAN_READ_CONCURRENCY,
+    async (fn): Promise<PlanItem> => {
       const logicalId = `functions.${fn.key}`;
       const currentState = getResource(state, logicalId);
       const config = functionToVefaasConfig(fn);
@@ -101,7 +105,11 @@ export const generateFunctionPlan = async (
         // may belong to another project — fail fast in the plan instead of
         // letting the executor discover it mid-deploy.
         const client = createVolcengineClient(context);
-        const remoteFunction = await client.vefaas.getFunction(fn.name);
+        const remoteFunction = await cachedRefreshRead(
+          context,
+          `vefaas.getFunction:${fn.name}`,
+          () => client.vefaas.getFunction(fn.name),
+        );
         if (remoteFunction && !isOwnedByStack(context, logicalId, remoteFunction.Tags)) {
           throw new Error(
             `Function ${fn.name} already exists in provider but is not owned by this stack (missing ${OWNERSHIP_TAG_KEY} tag). Refusing to create — resolve manually.`,
@@ -118,7 +126,11 @@ export const generateFunctionPlan = async (
 
       try {
         const client = createVolcengineClient(context);
-        const remoteFunction = await client.vefaas.getFunction(fn.name);
+        const remoteFunction = await cachedRefreshRead(
+          context,
+          `vefaas.getFunction:${fn.name}`,
+          () => client.vefaas.getFunction(fn.name),
+        );
 
         if (!remoteFunction) {
           return {
@@ -180,7 +192,7 @@ export const generateFunctionPlan = async (
           },
         };
       }
-    }),
+    },
   );
 
   const allStates = getAllResources(state);

--- a/src/types/domains/context.ts
+++ b/src/types/domains/context.ts
@@ -1,6 +1,7 @@
 import { ProviderEnum } from '../../common';
 import { ServerlessIac } from '../index';
 import type { DeploymentEventRecord } from '../../common/eventQueue';
+import type { RefreshCache } from '../../common/refreshCache';
 
 export type Context = {
   region: string;
@@ -21,6 +22,8 @@ export type Context = {
   iac?: ServerlessIac;
   /** ADR-005: emit a typed deployment event (executors call this per resource op). */
   reportEvent?: (event: DeploymentEventRecord) => void;
+  /** Command-lifecycle cache for planning/refresh reads (created by setContext); executor reads must not use it. */
+  refreshCache?: RefreshCache;
 };
 
 export enum TemplateFormat {

--- a/tests/fixtures/role-reconcile-fixtures/serverless-insight.yml
+++ b/tests/fixtures/role-reconcile-fixtures/serverless-insight.yml
@@ -1,0 +1,31 @@
+version: 0.0.1
+app: role-reconcile-test-app
+provider:
+  name: aliyun
+  region: cn-hangzhou
+
+service: role-reconcile-test-service
+
+backend:
+  state_manager:
+    type: LOCAL
+
+functions:
+  role_reconcile_fn:
+    name: role-reconcile-fn
+    code:
+      runtime: nodejs18
+      handler: index.handler
+      path: tests/fixtures/artifacts/artifact.zip
+    memory: 128
+    timeout: 10
+    log: true
+    iam:
+      role:
+        statements:
+          - sid: OSSRead
+            effect: Allow
+            action:
+              - oss:GetObject
+            resource:
+              - acs:oss:*:*:my-bucket/*

--- a/tests/service/role-reconcile-flow.spec.test.ts
+++ b/tests/service/role-reconcile-flow.spec.test.ts
@@ -1,0 +1,136 @@
+import path from 'node:path';
+import fs from 'node:fs/promises';
+import { deploy } from '../../src/commands/deploy';
+import { createMockAliyunClient, type MockAliyunClient } from './mockCloudClient';
+
+jest.mock('../../src/common/aliyunClient', () => ({
+  createAliyunClient: jest.fn(),
+}));
+
+jest.mock('../../src/common/imsClient', () => ({
+  getIamInfo: jest.fn().mockResolvedValue({
+    accountId: '123456789012',
+    displayName: 'Test User',
+    userId: 'test-user-id',
+  }),
+}));
+
+jest.mock('../../src/common/logger', () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+jest.mock('../../src/lang', () => ({
+  lang: {
+    __: (key: string) => key,
+  },
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const mockCreateAliyunClient = require('../../src/common/aliyunClient')
+  .createAliyunClient as jest.Mock;
+
+const deployOptions = {
+  location: path.join(__dirname, '../fixtures/role-reconcile-fixtures'),
+  stage: 'dev',
+  autoApprove: true,
+  region: 'cn-hangzhou',
+  provider: 'aliyun',
+};
+
+const stateFilePath = path.join(
+  process.cwd(),
+  '.serverlessinsight',
+  'state-role-reconcile-test-app-role-reconcile-test-service.json',
+);
+
+const loadState = async (): Promise<{
+  stages: Record<
+    string,
+    {
+      resources: Record<
+        string,
+        {
+          definition?: { iam?: unknown };
+          instances?: Array<{ id?: string; type?: string; roleArn?: string }>;
+        }
+      >;
+    }
+  >;
+}> => JSON.parse(await fs.readFile(stateFilePath, 'utf-8'));
+
+const fnResourceOf = async (): Promise<{
+  definition?: { iam?: unknown };
+  instances?: Array<{ id?: string; type?: string; roleArn?: string }>;
+}> => {
+  const state = await loadState();
+  return state.stages.dev.resources['functions.role_reconcile_fn'];
+};
+
+describe('Role Reconciliation Deploy Flow (issue #234)', () => {
+  let mockClient: MockAliyunClient;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    mockClient = createMockAliyunClient();
+    mockCreateAliyunClient.mockReturnValue(mockClient);
+    await fs.rm(stateFilePath, { force: true }).catch(() => {});
+  });
+
+  afterEach(async () => {
+    await fs.rm(stateFilePath, { force: true }).catch(() => {});
+  });
+
+  it('plans update and rebinds when the recorded RAM role is gone from the provider', async () => {
+    await deploy(deployOptions);
+
+    const fnResource = await fnResourceOf();
+    const roleInstance = fnResource?.instances?.find((i) => i.type === 'ALIYUN_RAM_ROLE');
+    expect(roleInstance?.id).toBeTruthy();
+    expect(mockClient.ram.createRole).toHaveBeenCalled();
+
+    // Cloud drift: the role is deleted out-of-band while state still records it.
+    mockClient.ram.getRole.mockResolvedValue(null);
+    mockClient.ram.createRole.mockResolvedValue({
+      roleName: roleInstance?.id,
+      arn: `acs:ram::123456789012:role/${roleInstance?.id}`,
+    });
+    mockClient.ram.createRole.mockClear();
+    mockClient.fc3.updateFunctionConfiguration.mockClear();
+
+    await deploy(deployOptions);
+
+    expect(mockClient.ram.createRole).toHaveBeenCalledWith(
+      roleInstance?.id,
+      ['fc.aliyuncs.com'],
+      undefined,
+      expect.any(Array),
+      undefined,
+      expect.any(Array),
+    );
+    // Binding must be pushed even though the function config definition is unchanged.
+    expect(mockClient.fc3.updateFunctionConfiguration).toHaveBeenCalledWith(
+      expect.objectContaining({ role: `acs:ram::123456789012:role/${roleInstance?.id}` }),
+    );
+    const healedResource = await fnResourceOf();
+    const healedRoles = (healedResource?.instances ?? []).filter(
+      (i) => i.type === 'ALIYUN_RAM_ROLE',
+    );
+    expect(healedRoles).toHaveLength(1);
+  });
+
+  it('stays noop on redeploy when the role still exists in the provider', async () => {
+    await deploy(deployOptions);
+    mockClient.ram.createRole.mockClear();
+    mockClient.fc3.updateFunctionConfiguration.mockClear();
+
+    await deploy(deployOptions);
+
+    expect(mockClient.ram.createRole).not.toHaveBeenCalled();
+    expect(mockClient.fc3.updateFunctionConfiguration).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/common/concurrency.test.ts
+++ b/tests/unit/common/concurrency.test.ts
@@ -1,0 +1,45 @@
+import { PLAN_READ_CONCURRENCY, mapWithConcurrency } from '../../../src/common/concurrency';
+
+describe('mapWithConcurrency', () => {
+  it('maps all items preserving order', async () => {
+    const result = await mapWithConcurrency([1, 2, 3, 4, 5], 2, async (n) => n * 2);
+
+    expect(result).toEqual([2, 4, 6, 8, 10]);
+  });
+
+  it('never runs more than limit items concurrently', async () => {
+    let inflight = 0;
+    let peak = 0;
+    const result = await mapWithConcurrency(
+      Array.from({ length: 25 }, (_, i) => i),
+      5,
+      async (n) => {
+        inflight += 1;
+        peak = Math.max(peak, inflight);
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        inflight -= 1;
+        return n;
+      },
+    );
+
+    expect(result).toHaveLength(25);
+    expect(peak).toBeLessThanOrEqual(5);
+  });
+
+  it('handles an empty input array', async () => {
+    const result = await mapWithConcurrency([], PLAN_READ_CONCURRENCY, async () => 1);
+
+    expect(result).toEqual([]);
+  });
+
+  it('propagates worker rejections', async () => {
+    await expect(
+      mapWithConcurrency([1, 2], 2, async (n) => {
+        if (n === 2) {
+          throw new Error('boom');
+        }
+        return n;
+      }),
+    ).rejects.toThrow('boom');
+  });
+});

--- a/tests/unit/common/refreshCache.test.ts
+++ b/tests/unit/common/refreshCache.test.ts
@@ -1,0 +1,96 @@
+import { cachedRefreshRead, createRefreshCache } from '../../../src/common/refreshCache';
+
+jest.mock('../../../src/common/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+}));
+
+jest.mock('../../../src/lang', () => ({
+  lang: { __: (key: string) => key },
+}));
+
+describe('refreshCache', () => {
+  describe('createRefreshCache', () => {
+    it('should load once and serve subsequent reads from cache', async () => {
+      const cache = createRefreshCache();
+      const loader = jest.fn().mockResolvedValue({ id: 'fn-1' });
+
+      const first = await cache.read('fc3.getFunction:test', loader);
+      const second = await cache.read('fc3.getFunction:test', loader);
+
+      expect(first).toEqual({ id: 'fn-1' });
+      expect(second).toEqual({ id: 'fn-1' });
+      expect(loader).toHaveBeenCalledTimes(1);
+    });
+
+    it('should share a single in-flight promise for concurrent reads of the same key', async () => {
+      const cache = createRefreshCache();
+      const loader = jest.fn().mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            setTimeout(() => resolve({ id: 'sg-1' }), 10);
+          }),
+      );
+
+      const [a, b, c] = await Promise.all([
+        cache.read('ecs.getSecurityGroupByName:app-sg', loader),
+        cache.read('ecs.getSecurityGroupByName:app-sg', loader),
+        cache.read('ecs.getSecurityGroupByName:app-sg', loader),
+      ]);
+
+      expect(a).toEqual({ id: 'sg-1' });
+      expect(b).toEqual({ id: 'sg-1' });
+      expect(c).toEqual({ id: 'sg-1' });
+      expect(loader).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not cache failures so later callers retry against the provider', async () => {
+      const cache = createRefreshCache();
+      const loader = jest
+        .fn()
+        .mockRejectedValueOnce(new Error('throttled'))
+        .mockResolvedValueOnce({ id: 'fn-1' });
+
+      await expect(cache.read('fc3.getFunction:test', loader)).rejects.toThrow('throttled');
+      await expect(cache.read('fc3.getFunction:test', loader)).resolves.toEqual({ id: 'fn-1' });
+      expect(loader).toHaveBeenCalledTimes(2);
+    });
+
+    it('should isolate keys and cache instances from each other', async () => {
+      const cache = createRefreshCache();
+      const loaderA = jest.fn().mockResolvedValue('a');
+      const loaderB = jest.fn().mockResolvedValue('b');
+      const otherCache = createRefreshCache();
+      const loaderOther = jest.fn().mockResolvedValue('other');
+
+      await expect(cache.read('key:a', loaderA)).resolves.toBe('a');
+      await expect(cache.read('key:b', loaderB)).resolves.toBe('b');
+      await expect(otherCache.read('key:a', loaderOther)).resolves.toBe('other');
+
+      expect(loaderA).toHaveBeenCalledTimes(1);
+      expect(loaderB).toHaveBeenCalledTimes(1);
+      expect(loaderOther).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('cachedRefreshRead', () => {
+    it('should route through the context cache when present', async () => {
+      const context = { refreshCache: createRefreshCache() };
+      const loader = jest.fn().mockResolvedValue({ id: 'fn-1' });
+
+      await cachedRefreshRead(context, 'fc3.getFunction:test', loader);
+      await cachedRefreshRead(context, 'fc3.getFunction:test', loader);
+
+      expect(loader).toHaveBeenCalledTimes(1);
+    });
+
+    it('should load directly when the context carries no cache', async () => {
+      const context = {};
+      const loader = jest.fn().mockResolvedValue({ id: 'fn-1' });
+
+      await cachedRefreshRead(context, 'fc3.getFunction:test', loader);
+      await cachedRefreshRead(context, 'fc3.getFunction:test', loader);
+
+      expect(loader).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/tests/unit/common/throttleRetry.test.ts
+++ b/tests/unit/common/throttleRetry.test.ts
@@ -1,0 +1,54 @@
+import { isThrottlingError, withThrottleRetry } from '../../../src/common/throttleRetry';
+
+describe('isThrottlingError', () => {
+  it('recognizes Aliyun throttling codes', () => {
+    expect(isThrottlingError({ code: 'Throttling' })).toBe(true);
+    expect(isThrottlingError({ code: 'Throttling.User' })).toBe(true);
+    expect(isThrottlingError({ code: 'RequestLimitExceeded' })).toBe(true);
+  });
+
+  it('recognizes Tencent scoped frequency limits', () => {
+    expect(isThrottlingError({ code: 'RequestLimitExceeded.UinLimitExceeded' })).toBe(true);
+  });
+
+  it('recognizes Volcengine flow-limit shapes', () => {
+    expect(isThrottlingError({ code: 'FlowLimitExceeded' })).toBe(true);
+    expect(isThrottlingError({ code: 100018 })).toBe(true);
+    expect(
+      isThrottlingError({ response: { data: { Error: { Code: 'FlowLimitExceeded' } } } }),
+    ).toBe(true);
+  });
+
+  it('rejects non-throttling errors and non-error values', () => {
+    expect(isThrottlingError({ code: 'EntityNotExist.Role' })).toBe(false);
+    expect(isThrottlingError({ code: 'LimitExceeded' })).toBe(false);
+    expect(isThrottlingError(undefined)).toBe(false);
+    expect(isThrottlingError('Throttling')).toBe(false);
+  });
+});
+
+describe('withThrottleRetry', () => {
+  it('retries only on throttling errors and eventually succeeds', async () => {
+    const load = jest
+      .fn()
+      .mockRejectedValueOnce({ code: 'Throttling' })
+      .mockResolvedValueOnce('ok');
+
+    await expect(withThrottleRetry(load, 3)).resolves.toBe('ok');
+    expect(load).toHaveBeenCalledTimes(2);
+  });
+
+  it('gives up after maxAttempts when throttling persists', async () => {
+    const load = jest.fn().mockRejectedValue({ code: 'RequestLimitExceeded' });
+
+    await expect(withThrottleRetry(load, 2)).rejects.toEqual({ code: 'RequestLimitExceeded' });
+    expect(load).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not retry non-throttling failures', async () => {
+    const load = jest.fn().mockRejectedValue(new Error('EntityNotExist'));
+
+    await expect(withThrottleRetry(load, 3)).rejects.toThrow('EntityNotExist');
+    expect(load).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/stack/aliyunStack/fc3Planner.test.ts
+++ b/tests/unit/stack/aliyunStack/fc3Planner.test.ts
@@ -1,4 +1,5 @@
-import { ProviderEnum, setResource } from '../../../../src/common';
+import { ProviderEnum, buildFunctionRoleName, setResource } from '../../../../src/common';
+import { createRefreshCache } from '../../../../src/common/refreshCache';
 import { generateFunctionPlan } from '../../../../src/stack/aliyunStack/fc3Planner';
 import { Context, CURRENT_STATE_VERSION, FunctionDomain } from '../../../../src/types';
 
@@ -21,9 +22,16 @@ const mockFc3Operations = {
 const mockEcsOperations = {
   getSecurityGroupByName: jest.fn(),
 };
+const mockRamOperations = {
+  getRole: jest.fn(),
+};
 
 jest.mock('../../../../src/common/aliyunClient', () => ({
-  createAliyunClient: () => ({ fc3: mockFc3Operations, ecs: mockEcsOperations }),
+  createAliyunClient: () => ({
+    fc3: mockFc3Operations,
+    ecs: mockEcsOperations,
+    ram: mockRamOperations,
+  }),
 }));
 jest.mock('../../../../src/common/hashUtils', () => ({
   ...jest.requireActual('../../../../src/common/hashUtils'),
@@ -486,6 +494,175 @@ describe('FC3 Planner', () => {
         action: 'update',
         resourceType: 'ALIYUN_FC3',
       });
+    });
+
+    it('should reuse cached provider reads across plan passes within one command lifecycle', async () => {
+      const cachedContext: Context = { ...mockContext, refreshCache: createRefreshCache() };
+      mockFc3Operations.getFunction.mockResolvedValue(null);
+
+      const firstPlan = await generateFunctionPlan(cachedContext, initalState, [testFunction]);
+      const secondPlan = await generateFunctionPlan(cachedContext, initalState, [testFunction]);
+
+      expect(firstPlan.items[0]).toMatchObject({ action: 'create' });
+      expect(secondPlan.items[0]).toMatchObject({ action: 'create' });
+      expect(mockFc3Operations.getFunction).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('managed role reconciliation (issue #234)', () => {
+    const remoteFunctionExists = {
+      functionName: 'test-function',
+      runtime: 'nodejs20',
+      handler: 'index.handler',
+      memorySize: 512,
+      timeout: 10,
+      environmentVariables: { NODE_ENV: 'production' },
+      tags: [{ key: 'si:owner', value: 'test-app:test-service:functions.test_fn' }],
+    };
+
+    const stateWithDefinition = (definition: Record<string, unknown>): unknown =>
+      setResource(initalState, 'functions.test_fn', {
+        mode: 'managed',
+        region: 'cn-hangzhou',
+        definition,
+        instances: [],
+        lastUpdated: new Date().toISOString(),
+      });
+
+    const remoteFc3Instance = {
+      sid: 'si:aliyun:fc3:default:test-function',
+      id: 'test-function',
+      functionName: 'test-function',
+    };
+
+    it('plans update when iam.role is declared, no instance recorded, and the role is absent in the provider', async () => {
+      const statements = [{ effect: 'Allow' as const, action: ['oss:PutObject'], resource: ['*'] }];
+      const fnWithIam: FunctionDomain = { ...testFunction, iam: { role: { statements } } };
+      const state = stateWithDefinition({
+        functionName: 'test-function',
+        runtime: 'nodejs20',
+        handler: 'index.handler',
+        memorySize: 512,
+        timeout: 10,
+        environment: { NODE_ENV: 'production' },
+        codeHash: 'mock-code-hash',
+        iam: { role: { statements } },
+      });
+      mockFc3Operations.getFunction.mockResolvedValue(remoteFunctionExists);
+      mockRamOperations.getRole.mockResolvedValue(null);
+
+      const plan = await generateFunctionPlan(mockContext, state as never, [fnWithIam]);
+
+      expect(plan.items[0]).toMatchObject({
+        logicalId: 'functions.test_fn',
+        action: 'update',
+        drifted: true,
+      });
+      expect(mockRamOperations.getRole).toHaveBeenCalledWith(
+        buildFunctionRoleName('test-app-test-service', 'default', 'test_fn'),
+      );
+    });
+
+    it('plans update when the recorded role instance is gone from the provider', async () => {
+      const state = setResource(initalState, 'functions.test_fn', {
+        mode: 'managed',
+        region: 'cn-hangzhou',
+        definition: {
+          functionName: 'test-function',
+          runtime: 'nodejs20',
+          handler: 'index.handler',
+          memorySize: 512,
+          timeout: 10,
+          environment: { NODE_ENV: 'production' },
+          codeHash: 'mock-code-hash',
+        },
+        instances: [
+          remoteFc3Instance,
+          {
+            sid: 'si:aliyun:ram:default:legacy-role',
+            id: 'legacy-role',
+            type: 'ALIYUN_RAM_ROLE',
+            roleArn: 'acs:ram::123456789012:role/legacy-role',
+          },
+        ],
+        lastUpdated: new Date().toISOString(),
+      });
+      mockFc3Operations.getFunction.mockResolvedValue(remoteFunctionExists);
+      mockRamOperations.getRole.mockResolvedValue(null);
+
+      const plan = await generateFunctionPlan(mockContext, state, [testFunction]);
+
+      expect(plan.items[0]).toMatchObject({
+        logicalId: 'functions.test_fn',
+        action: 'update',
+        drifted: true,
+      });
+      expect(mockRamOperations.getRole).toHaveBeenCalledWith('legacy-role');
+    });
+
+    it('stays noop when the recorded role still exists in the provider', async () => {
+      const state = setResource(initalState, 'functions.test_fn', {
+        mode: 'managed',
+        region: 'cn-hangzhou',
+        definition: {
+          functionName: 'test-function',
+          runtime: 'nodejs20',
+          handler: 'index.handler',
+          memorySize: 512,
+          timeout: 10,
+          environment: { NODE_ENV: 'production' },
+          codeHash: 'mock-code-hash',
+        },
+        instances: [
+          remoteFc3Instance,
+          {
+            sid: 'si:aliyun:ram:default:legacy-role',
+            id: 'legacy-role',
+            type: 'ALIYUN_RAM_ROLE',
+            roleArn: 'acs:ram::123456789012:role/legacy-role',
+          },
+        ],
+        lastUpdated: new Date().toISOString(),
+      });
+      mockFc3Operations.getFunction.mockResolvedValue(remoteFunctionExists);
+      mockRamOperations.getRole.mockResolvedValue({
+        roleName: 'legacy-role',
+        arn: 'acs:ram::123456789012:role/legacy-role',
+      });
+
+      const plan = await generateFunctionPlan(mockContext, state, [testFunction]);
+
+      expect(plan.items[0]).toMatchObject({ action: 'noop' });
+    });
+
+    it('skips the role probe for external (string) roles', async () => {
+      const externalRoleArn = 'acs:ram::123456789012:role/someone-elses-role';
+      const state = setResource(initalState, 'functions.test_fn', {
+        mode: 'managed',
+        region: 'cn-hangzhou',
+        definition: {
+          functionName: 'test-function',
+          runtime: 'nodejs20',
+          handler: 'index.handler',
+          memorySize: 512,
+          timeout: 10,
+          environment: { NODE_ENV: 'production' },
+          codeHash: 'mock-code-hash',
+          iam: { role: externalRoleArn },
+        },
+        instances: [remoteFc3Instance],
+        lastUpdated: new Date().toISOString(),
+      });
+      const fnWithExternalRole: FunctionDomain = {
+        ...testFunction,
+        iam: { role: externalRoleArn },
+      };
+      mockFc3Operations.getFunction.mockResolvedValue(remoteFunctionExists);
+
+      const plan = await generateFunctionPlan(mockContext, state, [fnWithExternalRole]);
+
+      expect(plan.items[0]).toMatchObject({ action: 'noop' });
+      expect(mockRamOperations.getRole).not.toHaveBeenCalled();
     });
   });
 });

--- a/tests/unit/stack/aliyunStack/fc3Resource.test.ts
+++ b/tests/unit/stack/aliyunStack/fc3Resource.test.ts
@@ -1,4 +1,4 @@
-import { ProviderEnum } from '../../../../src/common';
+import { ProviderEnum, buildFunctionRoleName } from '../../../../src/common';
 import {
   createResource,
   deleteResource,
@@ -55,6 +55,7 @@ const mockedSlsOperations = {
 };
 const mockedRamOperations = {
   createRole: jest.fn(),
+  getRole: jest.fn(),
   updateRoleTrustPolicy: jest.fn(),
   updateRolePolicy: jest.fn(),
   updateExecutionPolicyDocument: jest.fn(),
@@ -226,6 +227,10 @@ describe('Fc3Resource', () => {
 
     // Mock dependent resource operations
     mockedRamOperations.createRole.mockResolvedValue({
+      roleName: 'test-role',
+      arn: 'acs:ram::123456789012:role/test-role',
+    });
+    mockedRamOperations.getRole.mockResolvedValue({
       roleName: 'test-role',
       arn: 'acs:ram::123456789012:role/test-role',
     });
@@ -3536,6 +3541,12 @@ describe('Fc3Resource', () => {
                 id: 'test-function',
                 type: 'ALIYUN_FC3_FUNCTION',
               },
+              {
+                sid: 'si:aliyun:ram:default:test-role',
+                id: 'test-role',
+                type: 'ALIYUN_RAM_ROLE',
+                roleArn: 'acs:ram::123456789012:role/test-role',
+              },
             ],
             lastUpdated: '2025-01-01T00:00:00Z',
           },
@@ -4156,6 +4167,146 @@ describe('Fc3Resource', () => {
       const docArg = mockedRamOperations.updateExecutionPolicyDocument.mock.calls[0][1] as string;
       const parsed = JSON.parse(docArg) as { Statement: Array<{ Action: string[] }> };
       expect(parsed.Statement.some((s) => s.Action.includes('oss:GetObject'))).toBe(true);
+    });
+  });
+
+  describe('role reconciliation on update (issue #234)', () => {
+    const readyResourceState = (overrides: {
+      definition?: Record<string, unknown>;
+      instances?: Array<{ sid: string; id: string; type: string; roleArn?: string }>;
+      status?: 'ready' | 'tainted';
+    }): StateFile => ({
+      ...initialState,
+      resources: {
+        'functions.test_fn': {
+          mode: 'managed',
+          region: 'cn-hangzhou',
+          definition: overrides.definition ?? mockDefinition,
+          instances: overrides.instances ?? [],
+          lastUpdated: '2025-01-01T00:00:00Z',
+          status: overrides.status ?? 'ready',
+        },
+      },
+    });
+
+    const roleInstance = (id: string, roleArn?: string) => ({
+      sid: `si:aliyun:ram:default:${id}`,
+      id,
+      type: 'ALIYUN_RAM_ROLE',
+      roleArn: roleArn ?? `acs:ram::123456789012:role/${id}`,
+    });
+
+    it('recreates the recorded role when the provider lost it and rebinds the function', async () => {
+      const recordedRole = roleInstance('legacy-role');
+      const state = readyResourceState({ instances: [recordedRole] });
+      mockedRamOperations.getRole.mockResolvedValue(null);
+      mockedRamOperations.createRole.mockResolvedValue({
+        roleName: 'legacy-role',
+        arn: 'acs:ram::123456789012:role/legacy-role',
+      });
+      mockedStateManager.setResource.mockReturnValue({ ...initialState, _saved: true });
+
+      await updateResource(mockContext, testFunction, state);
+
+      expect(mockedRamOperations.createRole).toHaveBeenCalledWith(
+        'legacy-role',
+        ['fc.aliyuncs.com'],
+        undefined,
+        undefined,
+        undefined,
+        expect.any(Array),
+      );
+      // role is not part of extractFc3Definition — recreation must force the binding update
+      expect(mockedFc3Operations.updateFunctionConfiguration).toHaveBeenCalledWith(
+        expect.objectContaining({ role: 'acs:ram::123456789012:role/legacy-role' }),
+      );
+      const savedResourceState = (mockedStateManager.setResource as jest.Mock).mock.calls.at(
+        -1,
+      )?.[2];
+      const savedRamInstances = (savedResourceState?.instances ?? []).filter(
+        (i: { type?: string }) => i.type === 'ALIYUN_RAM_ROLE',
+      );
+      expect(savedRamInstances).toHaveLength(1);
+      expect(savedRamInstances[0]).toMatchObject({ id: 'legacy-role' });
+    });
+
+    it('creates and binds the managed role when iam.role is declared but no instance is recorded', async () => {
+      const statements = [{ effect: 'Allow' as const, action: ['oss:PutObject'], resource: ['*'] }];
+      const fnWithIam: FunctionDomain = { ...testFunction, iam: { role: { statements } } };
+      const state = readyResourceState({
+        definition: { ...mockDefinition, iam: { role: { statements } } },
+        instances: [],
+      });
+      const roleName = buildFunctionRoleName('test-app-test-service', 'default', 'test_fn');
+      mockedRamOperations.createRole.mockResolvedValue({
+        roleName,
+        arn: `acs:ram::123456789012:role/${roleName}`,
+      });
+      mockedStateManager.setResource.mockReturnValue({ ...initialState, _saved: true });
+
+      await updateResource(mockContext, fnWithIam, state);
+
+      expect(mockedRamOperations.createRole).toHaveBeenCalledWith(
+        roleName,
+        ['fc.aliyuncs.com'],
+        undefined,
+        statements,
+        undefined,
+        expect.any(Array),
+      );
+      expect(mockedFc3Operations.updateFunctionConfiguration).toHaveBeenCalledWith(
+        expect.objectContaining({ role: `acs:ram::123456789012:role/${roleName}` }),
+      );
+      const savedResourceState = (mockedStateManager.setResource as jest.Mock).mock.calls.at(
+        -1,
+      )?.[2];
+      const savedRamInstances = (savedResourceState?.instances ?? []).filter(
+        (i: { type?: string }) => i.type === 'ALIYUN_RAM_ROLE',
+      );
+      expect(savedRamInstances).toHaveLength(1);
+      expect(savedRamInstances[0]).toMatchObject({ id: roleName });
+    });
+  });
+
+  describe('role reconciliation during createResource retry (issue #234)', () => {
+    it('recreates a recorded role that the provider lost instead of failing on trust updates', async () => {
+      const recordedRole = {
+        sid: 'si:aliyun:ram:default:legacy-role',
+        id: 'legacy-role',
+        type: 'ALIYUN_RAM_ROLE',
+        roleArn: 'acs:ram::123456789012:role/legacy-role',
+      };
+      const taintedState: StateFile = {
+        ...initialState,
+        resources: {
+          'functions.test_fn': {
+            mode: 'managed',
+            region: 'cn-hangzhou',
+            definition: mockDefinition,
+            instances: [recordedRole],
+            lastUpdated: '2025-01-01T00:00:00Z',
+            status: 'tainted',
+          },
+        },
+      };
+      mockedRamOperations.getRole.mockResolvedValue(null);
+      mockedRamOperations.createRole.mockResolvedValue({
+        roleName: 'legacy-role',
+        arn: 'acs:ram::123456789012:role/legacy-role',
+      });
+      mockedStateManager.setResource.mockReturnValue({ ...taintedState, _saved: true });
+
+      await createResource(mockContext, testFunction, taintedState);
+
+      expect(mockedRamOperations.createRole).toHaveBeenCalledWith(
+        'legacy-role',
+        ['fc.aliyuncs.com'],
+        undefined,
+        undefined,
+        undefined,
+        expect.any(Array),
+      );
+      expect(mockedRamOperations.updateRoleTrustPolicy).not.toHaveBeenCalled();
     });
   });
 });

--- a/tests/unit/stack/aliyunStack/fc3Resource.test.ts
+++ b/tests/unit/stack/aliyunStack/fc3Resource.test.ts
@@ -3412,6 +3412,19 @@ describe('Fc3Resource', () => {
       expect(mockedNasOperations.createMountTarget).toHaveBeenCalled();
     });
 
+    it('does not create duplicate security group or role when NAS resources are missing', async () => {
+      mockedFc3Operations.updateFunctionConfiguration.mockResolvedValue(undefined);
+      mockedFc3Operations.updateFunctionCode.mockResolvedValue(undefined);
+      const newState = { ...initialState, _updated: true };
+      mockedStateManager.setResource.mockReturnValue(newState);
+
+      await updateResource(mockContext, fnWithNas, initialState);
+
+      expect(mockedEcsOperations.createSecurityGroup).toHaveBeenCalledTimes(1);
+      expect(mockedRamOperations.createRole).toHaveBeenCalledTimes(1);
+      expect(mockedNasOperations.createFileSystem).toHaveBeenCalledTimes(1);
+    });
+
     it('should reuse existing NAS mount targets during update', async () => {
       const stateWithNas: StateFile = {
         ...initialState,
@@ -3735,6 +3748,7 @@ describe('Fc3Resource', () => {
       await updateResource(mockContext, fnWithExternalRole, stateWithRamRole);
 
       // Should NOT manage existing role policy or trust policy
+      expect(mockedRamOperations.getRole).not.toHaveBeenCalled();
       expect(mockedRamOperations.updateRoleTrustPolicy).not.toHaveBeenCalled();
       expect(mockedRamOperations.updateRolePolicy).not.toHaveBeenCalled();
       expect(mockedRamOperations.updateManagedPolicies).not.toHaveBeenCalled();
@@ -3743,6 +3757,49 @@ describe('Fc3Resource', () => {
         expect.objectContaining({
           role: 'acs:ram::123456789012:role/external-role',
         }),
+        'mock-code-hash',
+      );
+    });
+
+    it('should not probe RAM with the recorded ARN when redeploying an unchanged external role', async () => {
+      const externalArn = 'acs:ram::123456789012:role/external-role';
+      const stateWithExternalRole: StateFile = {
+        ...initialState,
+        resources: {
+          'functions.test_fn': {
+            mode: 'managed',
+            region: 'cn-hangzhou',
+            definition: { ...mockDefinition, iam: { role: externalArn } },
+            instances: [
+              {
+                sid: 'si:aliyun:ram:default:external',
+                id: externalArn,
+                roleArn: externalArn,
+                type: 'ALIYUN_RAM_ROLE',
+                external: true,
+              },
+              {
+                sid: 'si:aliyun:fc3:default:test-function',
+                id: 'test-function',
+                type: 'ALIYUN_FC3_FUNCTION',
+              },
+            ],
+            lastUpdated: '2025-01-01T00:00:00Z',
+          },
+        },
+      };
+
+      mockedFc3Operations.updateFunctionConfiguration.mockResolvedValue(undefined);
+      mockedFc3Operations.updateFunctionCode.mockResolvedValue(undefined);
+      mockedStateManager.setResource.mockReturnValue({ ...stateWithExternalRole, _updated: true });
+
+      const fnWithExternal = { ...testFunction, iam: { role: externalArn } };
+      await updateResource(mockContext, fnWithExternal, stateWithExternalRole);
+
+      expect(mockedRamOperations.getRole).not.toHaveBeenCalled();
+      expect(mockedRamOperations.createRole).not.toHaveBeenCalled();
+      expect(mockedFc3Types.extractFc3Definition).toHaveBeenCalledWith(
+        expect.objectContaining({ role: externalArn }),
         'mock-code-hash',
       );
     });
@@ -4265,6 +4322,37 @@ describe('Fc3Resource', () => {
       );
       expect(savedRamInstances).toHaveLength(1);
       expect(savedRamInstances[0]).toMatchObject({ id: roleName });
+    });
+
+    it('recreates the lost role exactly once even when other dependents are missing too', async () => {
+      const recordedRole = roleInstance('legacy-role');
+      const state = readyResourceState({ instances: [recordedRole] });
+      const fnWithNetwork = {
+        ...testFunction,
+        network: {
+          vpc_id: 'vpc-123',
+          subnet_ids: ['vsw-123'],
+          security_group: {
+            name: 'test-sg',
+            ingress: [] as string[],
+            egress: [] as string[],
+          },
+        },
+      };
+      mockedRamOperations.getRole.mockResolvedValue(null);
+      mockedRamOperations.createRole.mockResolvedValue({
+        roleName: 'legacy-role',
+        arn: 'acs:ram::123456789012:role/legacy-role',
+      });
+      mockedStateManager.setResource.mockReturnValue({ ...initialState, _saved: true });
+
+      await updateResource(mockContext, fnWithNetwork, state);
+
+      expect(mockedRamOperations.createRole).toHaveBeenCalledTimes(1);
+      expect(mockedEcsOperations.createSecurityGroup).toHaveBeenCalledTimes(1);
+      expect(mockedFc3Operations.updateFunctionConfiguration).toHaveBeenCalledWith(
+        expect.objectContaining({ role: 'acs:ram::123456789012:role/legacy-role' }),
+      );
     });
   });
 


### PR DESCRIPTION
## Summary

Phase 0 of epic **#234** — Plan 引入云端 Refresh（noop 语义升级为「现实一致」）。

Two layers of work:

### 1. RAM role drift reconciliation (the issue itself)

Before: role lifecycle lived entirely inside the FC3 executor, keyed on state instances only. When the function plan was `noop`, the executor never ran — a role that was never created (or deleted out-of-band) stayed missing **forever**, and the function ran without injected credentials. `iam` was in the stored definition so the planner's intent-diff never fired.

- **`fc3Planner`**: probes the managed RAM role (recorded instance first, stored-first; otherwise the executor's own derived name via `buildFunctionRoleName`) and plans `update + drifted` with a readable warning when the provider role is missing. External (string) roles and functions without role config are deliberately not probed.
- **`fc3Resource.updateResource`**: dual check — recorded instance **and** provider `getRole` must both hold. Missing → recreate via `createRole` with **peer-union grants** (`resolveRoleGrant`, so shared legacy roles never lose other functions' statements/trust) → drop the stale instance from state → **force `updateFunctionConfiguration`** to rebind the function (critical: `role` is not part of `extractFc3Definition`, so `configChanged` alone would never push the binding — the second half of the reported runtime failure).
- **`createDependentResources`** (createResource / tainted-retry / adoption flows): same rebuild path instead of failing on `updateRoleTrustPolicy` with `EntityNotExist.Role`. The fresh-create branch also switched from own-only grants to `resolveRoleGrant` unions.

**Post-review fixes (`86ce13b`):**

- `updateResource` probes `ram.getRole` only for recorded **managed** roles — external role instances store the ARN as the instance id, which is not a valid `GetRole` roleName, so an unchanged external-role redeploy no longer issues an invalid probe (and switching external → managed no longer derives the repair name from an ARN-shaped id)
- `createDependentResources` gains a `skipRole` opt-out used by all three `updateResource` call sites (log / security-group / NAS): the role is reconciled exactly once on the drift-repair path; threading role state into the helper would instead re-create the just-repaired role and rewrite the execution policy from a grant derived without the caller's `logConfig` (stripping SLS statements)
- the NAS-path call now receives the reconciled security group so the helper reuses it instead of creating an untracked duplicate

### 2. Refresh read infrastructure (rate-limit mitigation)

- **Command-lifecycle read cache** (`refreshCache.ts`) injected via `Context` (`setContext`): same refresh/plan read executes once per command — `si deploy`'s double-plan (display + deployer re-plan) issues **zero duplicate reads**; single-flight collapses concurrent same-key reads; failures evict so the next pass retries the provider.
- **Bounded concurrency** (`concurrency.ts`, `mapWithConcurrency` limit 10) across all 12 planners' `Promise.all` fan-outs.
- **Throttling backoff retry** (`throttleRetry.ts`) on the refresh read path — Aliyun `Throttling*`/`RequestLimitExceeded`, Tencent `RequestLimitExceeded.*`, Volcengine `FlowLimitExceeded`/`100018`, COS `SlowDown`; none of the three SDKs retry by default. Executor reads stay uncached and are not auto-retried.

## Verification

- New unit tests: refresh cache, concurrency gate (peak ≤ limit), throttling matcher/backoff, fc3Planner 4 role-probe scenarios, fc3Resource rebuild/binding/dropped-instance scenarios, createResource retry rebuild, external-role probe skip, single-create drift repair
- New service test `role-reconcile-flow`: real deploy → role deleted out-of-band → redeploy plans update, recreates with union grants, **rebinds** the function, state converges to a single role instance; healthy redeploy stays noop
- One existing test fixture corrected: it had no role instance in state, under which the old code silently recreated a role every update without ever binding it (the #234 latent bug); fixture now records the role so the test asserts its original "code-only update" intent
- `npm run build` ✓ · `lint:check` ✓ · full suite **160 suites / 3327 tests** ✓ (85% coverage gate)

## Known boundaries (documented in epic #234)

1. createResource tainted-retry + role rebuild does not force-rebind an *existing* function (function-exists skip path) — deferred to Phase 1 attribute refresh
2. Throttling retry currently covers the refresh/plan read path only; executor-side operations-layer retry is Phase 1+ per-provider work
3. Concurrency gate is per-planner-group (~10), equivalent to provider-wide since planner groups run sequentially
