### PR TITLE
feat(plan): live drift detection phase 1 (issue #234)

### DIFF
--- a/src/common/aliyunClient/ramOperations.ts
+++ b/src/common/aliyunClient/ramOperations.ts
@@ -221,6 +221,38 @@ const buildExecutionPolicy = (
     }
   };
 
+  const readExecutionPolicyDocument = async (
+    policyName: string,
+  ): Promise<{ found: boolean; document?: string }> => {
+    try {
+      const getPolicyResponse = await ramClient.getPolicy(
+        new ram.GetPolicyRequest({ policyName, policyType: 'Custom' }),
+      );
+      const defaultVersionId = getPolicyResponse.body?.policy?.defaultVersion;
+      if (!defaultVersionId) {
+        return { found: true };
+      }
+      const versionResponse = await ramClient.getPolicyVersion(
+        new ram.GetPolicyVersionRequest({
+          policyName,
+          policyType: 'Custom',
+          versionId: defaultVersionId,
+        }),
+      );
+      return { found: true, document: versionResponse.body?.policyVersion?.policyDocument };
+    } catch (error: unknown) {
+      if (
+        error &&
+        typeof error === 'object' &&
+        'code' in error &&
+        error.code === 'EntityNotExist.Policy'
+      ) {
+        return { found: false };
+      }
+      throw error;
+    }
+  };
+
   const updateExecutionPolicyDocumentFn = async (
     roleName: string,
     policyDocument: string,
@@ -244,31 +276,8 @@ const buildExecutionPolicy = (
       }
     };
 
-    let currentDocument: string | undefined;
-    try {
-      const getPolicyResponse = await ramClient.getPolicy(
-        new ram.GetPolicyRequest({ policyName, policyType: 'Custom' }),
-      );
-      const defaultVersionId = getPolicyResponse.body?.policy?.defaultVersion;
-      if (defaultVersionId) {
-        const versionResponse = await ramClient.getPolicyVersion(
-          new ram.GetPolicyVersionRequest({
-            policyName,
-            policyType: 'Custom',
-            versionId: defaultVersionId,
-          }),
-        );
-        currentDocument = versionResponse.body?.policyVersion?.policyDocument;
-      }
-    } catch (error: unknown) {
-      if (!(
-        error &&
-        typeof error === 'object' &&
-        'code' in error &&
-        error.code === 'EntityNotExist.Policy'
-      )) {
-        throw error;
-      }
+    const readResult = await readExecutionPolicyDocument(policyName);
+    if (!readResult.found) {
       try {
         await ramClient.createPolicy(
           new ram.CreatePolicyRequest({
@@ -291,6 +300,7 @@ const buildExecutionPolicy = (
       return;
     }
 
+    const currentDocument = readResult.document;
     if (currentDocument === policyDocument) {
       return;
     }
@@ -521,6 +531,12 @@ const buildExecutionPolicy = (
     },
 
     updateExecutionPolicyDocument: updateExecutionPolicyDocumentFn,
+
+    getExecutionPolicyDocument: async (roleName: string): Promise<string | undefined> => {
+      const policyName = buildRolePolicyName(roleName);
+      const readResult = await readExecutionPolicyDocument(policyName);
+      return readResult.found ? readResult.document : undefined;
+    },
 
     getRole: async (roleName: string): Promise<RamRoleInfo | null> => {
       try {

--- a/src/common/planCompare.ts
+++ b/src/common/planCompare.ts
@@ -1,0 +1,22 @@
+import { attributesEqual } from './hashUtils';
+
+/**
+ * One-directional live-drift check (issue #234 Phase 1 contract):
+ * compares only the attributes a cloud->definition mapper emits (remote) that
+ * the desired definition actually declares non-null. A desired value with no
+ * matching cloud value IS drift (the executor sets it on update); a cloud-only
+ * extra the config never asked for is ignored (the executor may not clear it).
+ * Unreadable/config-only keys never appear in `remote` — so matching reality
+ * stays `noop` instead of phantom-drifting every plan.
+ */
+export const remoteDiffersFromDesired = (
+  remote: Record<string, unknown>,
+  desired: Record<string, unknown>,
+): boolean =>
+  Object.entries(remote).some(([key]) => {
+    const desiredValue = desired[key];
+    if (desiredValue === undefined || desiredValue === null) {
+      return false;
+    }
+    return !attributesEqual({ [key]: remote[key] }, { [key]: desiredValue });
+  });

--- a/src/common/planCompare.ts
+++ b/src/common/planCompare.ts
@@ -1,11 +1,33 @@
 import { attributesEqual } from './hashUtils';
 
 /**
+ * A desired value "declares" a dimension only when the executor would write it:
+ * `undefined`/`null` mean unset, and an empty plain object means the executor
+ * omits the field entirely (e.g. fc3 `environment: {}`, oss
+ * `websiteConfiguration: {}`) — so cloud-side values in that dimension can
+ * never be cleared and are not drift. Arrays and empty strings stay declared:
+ * the executor writes them explicitly.
+ */
+const isDeclared = (value: unknown): boolean => {
+  if (value === undefined || value === null) {
+    return false;
+  }
+  if (
+    typeof value === 'object' &&
+    !Array.isArray(value) &&
+    Object.keys(value as Record<string, unknown>).length === 0
+  ) {
+    return false;
+  }
+  return true;
+};
+
+/**
  * One-directional live-drift check (issue #234 Phase 1 contract):
  * compares only the attributes a cloud->definition mapper emits (remote) that
- * the desired definition actually declares non-null. A desired value with no
- * matching cloud value IS drift (the executor sets it on update); a cloud-only
- * extra the config never asked for is ignored (the executor may not clear it).
+ * the desired definition actually declares. A desired value with no matching
+ * cloud value IS drift (the executor sets it on update); a cloud-only extra
+ * the config never asked for is ignored (the executor may not clear it).
  * Unreadable/config-only keys never appear in `remote` — so matching reality
  * stays `noop` instead of phantom-drifting every plan.
  */
@@ -15,7 +37,7 @@ export const remoteDiffersFromDesired = (
 ): boolean =>
   Object.entries(remote).some(([key]) => {
     const desiredValue = desired[key];
-    if (desiredValue === undefined || desiredValue === null) {
+    if (!isDeclared(desiredValue)) {
       return false;
     }
     return !attributesEqual({ [key]: remote[key] }, { [key]: desiredValue });

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -277,6 +277,8 @@ export const en = {
   REFRESH_CACHE_HIT: 'Refresh read cache hit: {{key}}',
   PLAN_FUNCTION_ROLE_MISSING:
     'Function {{functionName}} role {{roleName}} is missing in the provider; it will be recreated and rebound on deploy',
+  PLAN_FUNCTION_ROLE_PROBE_FAILED:
+    'Live role policy check for function {{functionName}} (role {{roleName}}) failed: {{error}}; skipping role drift detection for this plan',
   RAM_ROLE_MISSING_RECREATE:
     'RAM role {{roleName}} is missing in the provider; recreating it with the union of all functions that share it',
   SLS_PROJECT_FOREIGN_OWNED:

--- a/src/lang/zh-CN.ts
+++ b/src/lang/zh-CN.ts
@@ -257,6 +257,8 @@ export const zhCN = {
   REFRESH_CACHE_HIT: '刷新读缓存命中：{{key}}',
   PLAN_FUNCTION_ROLE_MISSING:
     '函数 {{functionName}} 的角色 {{roleName}} 在云端不存在；部署时将重建并重新绑定',
+  PLAN_FUNCTION_ROLE_PROBE_FAILED:
+    '函数 {{functionName}}（角色 {{roleName}}）的实时角色策略检查失败：{{error}}；本次计划跳过角色漂移检测',
   RAM_ROLE_MISSING_RECREATE:
     'RAM 角色 {{roleName}} 在云端不存在；将以共享该角色的所有函数的并集权限重建',
   SLS_PROJECT_FOREIGN_OWNED: 'SLS 项目 {{projectName}} 已存在但不属于当前应用，拒绝采用',

--- a/src/stack/aliyunStack/apigwPlanner.ts
+++ b/src/stack/aliyunStack/apigwPlanner.ts
@@ -1,13 +1,19 @@
 import { Context, EventDomain, Plan, PlanItem, StateFile } from '../../types';
 import { createAliyunClient } from '../../common/aliyunClient';
 import {
+  buildAliyunApigwApiName,
+  buildEventLogSnapshot,
+  cloudApigwApiToTriggerAttributes,
+  cloudApigwGroupToDefinition,
   eventToApigwGroupConfig,
   extractApigwGroupDefinition,
   extractEventDomainDefinition,
-  buildEventLogSnapshot,
+  generateApiKey,
 } from './apigwTypes';
 import { getAllResources, getResource } from '../../common/stateManager';
 import { attributesEqual } from '../../common/hashUtils';
+import { getIacDefinition, isFunctionDomain } from '../../common/iacHelper';
+import { remoteDiffersFromDesired } from '../../common/planCompare';
 import { cachedRefreshRead } from '../../common/refreshCache';
 import { PLAN_READ_CONCURRENCY, mapWithConcurrency } from '../../common/concurrency';
 import { OWNERSHIP_TAG_KEY, isOwnedByStack } from '../ownershipTag';
@@ -23,6 +29,28 @@ const planEventDeletion = (logicalId: string, definition: Record<string, unknown
   resourceType: 'ALIYUN_APIGW',
   changes: { before: definition },
 });
+
+const buildDesiredTriggerApiName = (
+  event: EventDomain,
+  trigger: EventDomain['triggers'][number],
+  stage: string,
+): string =>
+  buildAliyunApigwApiName(
+    event.name as string,
+    stage,
+    generateApiKey(trigger.method as string, trigger.path as string),
+  );
+
+const resolveTriggerBackend = (iac: Context['iac'], backendRef: string): string => {
+  if (!iac) {
+    return backendRef;
+  }
+  const functionDef = getIacDefinition(iac, backendRef);
+  if (!functionDef || !isFunctionDomain(functionDef)) {
+    return backendRef;
+  }
+  return functionDef.name;
+};
 
 /**
  * Generate plan for API Gateway events
@@ -108,6 +136,12 @@ export const generateApigwPlan = async (
       try {
         const groupInstance = currentState.instances.find((i) => i.type === 'ALIYUN_APIGW_GROUP');
 
+        const currentDefinition = currentState.definition || {};
+        const definitionChanged = !attributesEqual(currentDefinition, desiredDefinition);
+
+        let groupRemoteDiffers = false;
+        let triggersDiffer = false;
+
         if (groupInstance) {
           const remoteGroup = await cachedRefreshRead(
             context,
@@ -125,17 +159,88 @@ export const generateApigwPlan = async (
               drifted: true,
             };
           }
+
+          // Issue #234 Phase 1: a local config change already forces update, so
+          // the live cloud is only probed when state == config — a console edit
+          // to the group/trigger then surfaces as update + drifted, and a read
+          // failure cannot degrade a config-driven update into a create.
+          // Domain/log stay existence-only in Phase 0-2 — never compared live.
+          if (!definitionChanged) {
+            const remoteGroupAttrs = cloudApigwGroupToDefinition(remoteGroup);
+            groupRemoteDiffers = remoteDiffersFromDesired(remoteGroupAttrs, desiredDefinition);
+
+            if (event.triggers.length > 0) {
+              const desiredApis = new Map<
+                string,
+                { method: string; path: string; backend: string }
+              >(
+                event.triggers.map((trigger) => {
+                  const apiName = buildDesiredTriggerApiName(event, trigger, context.stage);
+                  return [
+                    apiName,
+                    {
+                      method: trigger.method as string,
+                      path: trigger.path as string,
+                      backend: resolveTriggerBackend(context.iac, String(trigger.backend)),
+                    },
+                  ] as [string, { method: string; path: string; backend: string }];
+                }),
+              );
+
+              const cloudSummaries = ((await cachedRefreshRead(
+                context,
+                `apigw.listApisByGroup:${groupInstance.id}`,
+                () => client.apigw.listApisByGroup(groupInstance.id),
+              )) ?? []) as Array<{ apiId: string; apiName: string }>;
+
+              const cloudApis = new Map<
+                string,
+                { method?: string; path?: string; backend?: string }
+              >();
+              for (const summary of cloudSummaries) {
+                // Only reconcile expected APIs — the executor never touches
+                // same-group APIs outside our derived name set (buildCloudInstance
+                // in apigwResource), so foreign/console-added APIs are ignored.
+                if (!desiredApis.has(summary.apiName)) {
+                  continue;
+                }
+                const apiInfo = await cachedRefreshRead(
+                  context,
+                  `apigw.getApi:${groupInstance.id}:${summary.apiId}`,
+                  () => client.apigw.getApi(groupInstance.id, summary.apiId),
+                );
+                if (apiInfo) {
+                  const attrs = cloudApigwApiToTriggerAttributes(apiInfo);
+                  if (attrs.apiName) {
+                    cloudApis.set(attrs.apiName, attrs);
+                  }
+                }
+              }
+
+              // A desired API absent from the cloud is recreated by the executor.
+              triggersDiffer = [...desiredApis.keys()].sort().some((apiName) => {
+                const desired = desiredApis.get(apiName);
+                const cloud = cloudApis.get(apiName);
+                if (!desired || !cloud) {
+                  return true;
+                }
+                return (
+                  desired.method !== cloud.method ||
+                  desired.path !== cloud.path ||
+                  desired.backend !== cloud.backend
+                );
+              });
+            }
+          }
         }
 
-        const currentDefinition = currentState.definition || {};
-        const definitionChanged = !attributesEqual(currentDefinition, desiredDefinition);
-
-        if (definitionChanged) {
+        if (definitionChanged || groupRemoteDiffers || triggersDiffer) {
           return {
             logicalId,
             action: 'update',
             resourceType: 'ALIYUN_APIGW',
             changes: { before: currentDefinition, after: desiredDefinition },
+            drifted: true,
           };
         }
 

--- a/src/stack/aliyunStack/apigwTypes.ts
+++ b/src/stack/aliyunStack/apigwTypes.ts
@@ -12,15 +12,19 @@ import {
 import { lang } from '../../lang';
 import { OWNERSHIP_TAG_KEY, buildOwnershipTagValue } from '../ownershipTag';
 import { buildSharedProjectName, buildGatewayLogstoreName } from './sharedLogProject';
-// Re-export the info types from the shared client layer so there is a single
-// source of truth — the operations layer owns the cloud-returned field shape
-// and the stack layer consumes it (previous duplicated copies could drift).
-export type {
+// The cloud-returned info types are imported locally (the normalizers below
+// consume them) and re-exported so there is a single source of truth — the
+// operations layer owns the cloud-returned field shape and the stack layer
+// consumes it (previous duplicated copies could drift).
+import type {
   ApigwGroupInfo,
   ApigwApiInfo,
   ApigwCustomDomainItem,
   ApigwRequestParameter,
 } from '../../common/aliyunClient/apigwOperations';
+import type { ApigwLogConfigInfo } from '../../common/aliyunClient/types';
+
+export type { ApigwGroupInfo, ApigwApiInfo, ApigwCustomDomainItem, ApigwRequestParameter };
 export { buildAliyunApigwApiName, generateApiKey } from '../../common';
 
 // API Group types
@@ -421,4 +425,77 @@ export const extractEventDomainDefinition = (
   }
 
   return definition;
+};
+
+// Cloud response normalizers (issue #234): pure field mappings from already
+// fetched cloud objects back to the desired/config extract shapes. Never call a
+// client API; Wave C diffs these against the desired definitions and only
+// compares keys both sides declare, so omitting config-only or unreadable keys
+// here prevents phantom drift.
+
+/**
+ * Cloud-side counterpart of extractApigwGroupDefinition: maps an ApigwGroupInfo
+ * to the same {groupName, description, basePath} shape the planner diffs.
+ */
+export const cloudApigwGroupToDefinition = (group: ApigwGroupInfo): ResourceAttributes => {
+  return {
+    groupName: group.groupName ?? null,
+    description: group.description ?? null,
+    basePath: group.basePath ?? null,
+  };
+};
+
+/**
+ * Cloud-side counterpart of a desired trigger {method, path, backend}: the API's
+ * recorded apiName plus the request method/path and the FunctionCompute backend
+ * name. Fields with no clear cloud value stay undefined (never invented).
+ */
+export const cloudApigwApiToTriggerAttributes = (
+  api: ApigwApiInfo,
+): { apiName: string; method?: string; path?: string; backend?: string } => {
+  return {
+    apiName: api.apiName ?? '',
+    method: api.requestConfig?.requestHttpMethod,
+    path: api.requestConfig?.requestPath,
+    backend: api.serviceConfig?.functionComputeConfig?.functionName,
+  };
+};
+
+/**
+ * Cloud-side counterpart of extractEventDomainDefinition restricted to the keys
+ * the cloud reliably reports (domainName + certificateId). wwwBindApex,
+ * protocol, certificate bodies and cdn* have no cloud source and are omitted so
+ * they can never trigger phantom drift. Undefined when the item has no
+ * domainName to key on.
+ */
+export const cloudApigwCustomDomainToDefinition = (
+  domain: ApigwCustomDomainItem,
+): ResourceAttributes | undefined => {
+  if (!domain.domainName) {
+    return undefined;
+  }
+  return {
+    domainName: domain.domainName,
+    certificateId: domain.certificateId ?? null,
+  };
+};
+
+/**
+ * Cloud-side counterpart of buildEventLogSnapshot: maps the region-wide PROVIDER
+ * gateway log config into the snapshot shape. Undefined when no PROVIDER config
+ * exists (describeGatewayLogConfig returned null or an empty config).
+ */
+export const cloudGatewayLogToLogConfig = (
+  log: ApigwLogConfigInfo | null,
+): EventLogSnapshot | undefined => {
+  if (!log || log.logType == null || log.logType === '') {
+    return undefined;
+  }
+  return {
+    logEnabled: log.logType === 'PROVIDER',
+    logConfig: {
+      project: log.slsProject ?? '',
+      logstore: log.slsLogStore ?? '',
+    },
+  };
 };

--- a/src/stack/aliyunStack/databasePlanner.ts
+++ b/src/stack/aliyunStack/databasePlanner.ts
@@ -10,8 +10,9 @@ import {
 import { createAliyunClient } from '../../common/aliyunClient';
 import { cachedRefreshRead } from '../../common/refreshCache';
 import { PLAN_READ_CONCURRENCY, mapWithConcurrency } from '../../common/concurrency';
-import { databaseToRdsConfig, extractRdsDefinition } from './rdsTypes';
-import { databaseToEsConfig, extractEsDefinition } from './esServerlessTypes';
+import { databaseToRdsConfig, extractRdsDefinition, cloudRdsToDefinition } from './rdsTypes';
+import { databaseToEsConfig, extractEsDefinition, cloudEsToDefinition } from './esServerlessTypes';
+import { remoteDiffersFromDesired } from '../../common/planCompare';
 import { getAllResources, getResource } from '../../common/stateManager';
 import { attributesEqual } from '../../common/hashUtils';
 import { OWNERSHIP_TAG_KEY, isOwnedByStack } from '../ownershipTag';
@@ -170,10 +171,16 @@ export const generateDatabasePlan = async (
           };
         }
 
+        const remoteAttributes =
+          resourceType === 'ALIYUN_ES_SERVERLESS'
+            ? cloudEsToDefinition(remoteInstance)
+            : cloudRdsToDefinition(remoteInstance);
+        const remoteDiffers = remoteDiffersFromDesired(remoteAttributes, desiredDefinition);
+
         const currentDefinition = currentState.definition || {};
         const definitionChanged = !attributesEqual(currentDefinition, desiredDefinition);
 
-        if (definitionChanged) {
+        if (definitionChanged || remoteDiffers) {
           return {
             logicalId,
             action: 'update',

--- a/src/stack/aliyunStack/esServerlessTypes.ts
+++ b/src/stack/aliyunStack/esServerlessTypes.ts
@@ -154,4 +154,53 @@ export const extractEsDefinition = (config: EsConfig): ResourceAttributes => {
   };
 };
 
+export const cloudEsToDefinition = (info: EsInfo): ResourceAttributes => ({
+  ...(info.appName === undefined ? {} : { appName: info.appName }),
+  ...(info.version === undefined ? {} : { appVersion: info.version }),
+  ...(info.description === undefined ? {} : { description: info.description }),
+  ...(info.chargeType === undefined ? {} : { chargeType: info.chargeType }),
+  ...(info.network === undefined
+    ? {}
+    : {
+        network: info.network.map((network) => ({
+          type: network.type ?? null,
+          enabled: network.enabled ?? null,
+          domain: network.domain ?? null,
+          port: network.port ?? null,
+          whiteIpGroup: network.whiteIpGroup
+            ? network.whiteIpGroup.map((group) => ({
+                groupName: group.groupName ?? null,
+                ips: group.ips ?? [],
+              }))
+            : null,
+        })),
+      }),
+  ...(info.privateNetwork === undefined
+    ? {}
+    : {
+        privateNetwork: info.privateNetwork.map((network) => ({
+          type: network.type ?? null,
+          enabled: network.enabled ?? null,
+          domain: network.domain ?? null,
+          port: network.port ?? null,
+          vpcId: network.vpcId ?? null,
+          pvlEndpointId: network.pvlEndpointId ?? null,
+          whiteIpGroup: network.whiteIpGroup
+            ? network.whiteIpGroup.map((group) => ({
+                groupName: group.groupName ?? null,
+                ips: group.ips ?? [],
+              }))
+            : null,
+        })),
+      }),
+  ...(info.tags === undefined
+    ? {}
+    : {
+        tags: info.tags.map((tag) => ({
+          key: tag.key ?? null,
+          value: tag.value ?? null,
+        })),
+      }),
+});
+
 export { EsConfig, EsInfo };

--- a/src/stack/aliyunStack/fc3Planner.ts
+++ b/src/stack/aliyunStack/fc3Planner.ts
@@ -321,8 +321,7 @@ export const generateFunctionPlan = async (
       const currentState = getResource(state, logicalId);
       const rawConfig = functionToFc3Config(fn);
       const config = await resolveVpcConfigSecurityGroup(context, rawConfig);
-      const codePath = fn.code!.path;
-      const desiredCodeHash = await computeZipContentHash(codePath);
+      const desiredCodeHash = fn.code ? await computeZipContentHash(fn.code.path) : null;
       const baseDefinition = extractFc3Definition(config, desiredCodeHash);
       const desiredDefinition = fn.iam ? { ...baseDefinition, iam: fn.iam } : baseDefinition;
 
@@ -393,42 +392,52 @@ export const generateFunctionPlan = async (
 
         const roleProbe = resolveManagedRoleProbe(context, fn, currentState);
         if (roleProbe) {
-          const cloudRole = await cachedRefreshRead(
-            context,
-            `ram.getRole:${roleProbe.roleName}`,
-            () => client.ram.getRole(roleProbe.roleName),
-          );
-          if (!cloudRole) {
+          try {
+            const cloudRole = await cachedRefreshRead(
+              context,
+              `ram.getRole:${roleProbe.roleName}`,
+              () => client.ram.getRole(roleProbe.roleName),
+            );
+            if (!cloudRole) {
+              logger.warn(
+                lang.__('PLAN_FUNCTION_ROLE_MISSING', {
+                  roleName: roleProbe.roleName,
+                  functionName: fn.name,
+                }),
+              );
+              return {
+                logicalId,
+                action: 'update',
+                resourceType: 'ALIYUN_FC3',
+                changes: { before: normalizedCurrent, after: normalizedDesired },
+                drifted: true,
+              };
+            }
+            const rolePolicyDrifted = await detectRolePolicyDrift(
+              context,
+              state,
+              fn,
+              currentState,
+              roleProbe.roleName,
+              cloudRole,
+            );
+            if (rolePolicyDrifted) {
+              return {
+                logicalId,
+                action: 'update',
+                resourceType: 'ALIYUN_FC3',
+                changes: { before: normalizedCurrent, after: normalizedDesired },
+                drifted: true,
+              };
+            }
+          } catch (error: unknown) {
             logger.warn(
-              lang.__('PLAN_FUNCTION_ROLE_MISSING', {
+              lang.__('PLAN_FUNCTION_ROLE_PROBE_FAILED', {
                 roleName: roleProbe.roleName,
                 functionName: fn.name,
+                error: String(error),
               }),
             );
-            return {
-              logicalId,
-              action: 'update',
-              resourceType: 'ALIYUN_FC3',
-              changes: { before: normalizedCurrent, after: normalizedDesired },
-              drifted: true,
-            };
-          }
-          const rolePolicyDrifted = await detectRolePolicyDrift(
-            context,
-            state,
-            fn,
-            currentState,
-            roleProbe.roleName,
-            cloudRole,
-          );
-          if (rolePolicyDrifted) {
-            return {
-              logicalId,
-              action: 'update',
-              resourceType: 'ALIYUN_FC3',
-              changes: { before: normalizedCurrent, after: normalizedDesired },
-              drifted: true,
-            };
           }
         }
 

--- a/src/stack/aliyunStack/fc3Planner.ts
+++ b/src/stack/aliyunStack/fc3Planner.ts
@@ -7,7 +7,9 @@ import {
   logger,
 } from '../../common';
 import { createAliyunClient } from '../../common/aliyunClient';
+import { buildFc3ExecutionPolicyDocument } from '../../common/aliyunClient/ramOperations';
 import { cachedRefreshRead } from '../../common/refreshCache';
+import { remoteDiffersFromDesired } from '../../common/planCompare';
 import { PLAN_READ_CONCURRENCY, mapWithConcurrency } from '../../common/concurrency';
 import {
   Context,
@@ -18,7 +20,13 @@ import {
   ResourceState,
   StateFile,
 } from '../../types';
-import { extractFc3Definition, Fc3FunctionConfig, functionToFc3Config } from './fc3Types';
+import {
+  cloudFc3ToDefinition,
+  extractFc3Definition,
+  Fc3FunctionConfig,
+  functionToFc3Config,
+} from './fc3Types';
+import { resolveRoleGrant } from './fc3Resource';
 import { lang } from '../../lang';
 import { OWNERSHIP_TAG_KEY, isOwnedByStack } from '../ownershipTag';
 
@@ -141,6 +149,153 @@ const resolveManagedRoleProbe = (
   return undefined;
 };
 
+/**
+ * Parse a cloud RAM trust/policy document. Aliyun returns these URL-encoded
+ * (GetRole / GetPolicyVersion) while mocks return plain JSON — accept both.
+ * Unparseable/absent yields `undefined` so the caller treats the dimension as
+ * unreadable instead of phantom-drifting on garbage.
+ */
+const parseRolePolicyDocument = (raw: string | undefined): Record<string, unknown> | undefined => {
+  if (!raw) {
+    return undefined;
+  }
+  const tryParse = (candidate: string): Record<string, unknown> | undefined => {
+    try {
+      const parsed: unknown = JSON.parse(candidate);
+      return parsed && typeof parsed === 'object' ? (parsed as Record<string, unknown>) : undefined;
+    } catch {
+      return undefined;
+    }
+  };
+  return tryParse(raw) ?? tryParse(decodeURIComponent(raw));
+};
+
+/**
+ * Live RAM role policy drift against the grant the executor would write via
+ * resolveRoleGrant (the very call updateResource uses), so the planner never
+ * diverges from the executor. Scoped to avoid false drift:
+ * - Only functions declaring a managed `iam.role` object: legacy recorded roles
+ *   without one carry older si-written documents whose baseline differs from
+ *   today's derivation — flagging them would fabricate drift with no console
+ *   edit behind them (the existence probe still covers them).
+ * - Only single-owner roles; shared roles need an executor peer-union the
+ *   planner cannot reproduce → probe-only (coverage gap accepted).
+ * - logConfig must be derivable from state: with logging on but no recorded
+ *   logstore instance the executor creates one during update and derives the
+ *   grant from that new logstore, which the planner cannot know → skip.
+ */
+const detectRolePolicyDrift = async (
+  context: Context,
+  state: StateFile,
+  fn: FunctionDomain,
+  currentState: ResourceState,
+  roleName: string,
+  cloudRole: { assumeRolePolicyDocument?: string } | null,
+): Promise<boolean> => {
+  const client = createAliyunClient(context);
+  const logicalId = `functions.${fn.key}`;
+
+  const iamRole = fn.iam?.role;
+  if (!iamRole || typeof iamRole === 'string') {
+    return false;
+  }
+
+  const roleInstance = currentState.instances?.find(
+    (i) =>
+      (i as { type?: string }).type === 'ALIYUN_RAM_ROLE' &&
+      (i as { id?: string }).id === roleName &&
+      !(i as { external?: boolean }).external,
+  );
+  if (!roleInstance) {
+    return false;
+  }
+
+  // Conservative ownership scan (mirrors collectRolePeers semantics without
+  // requiring context.iac): any OTHER function in state recording the same
+  // managed role instance makes the role shared → executor uses a peer union.
+  const sharedRole = Object.entries(getAllResources(state)).some(
+    ([peerLogicalId, peerState]) =>
+      peerLogicalId !== logicalId &&
+      peerLogicalId.startsWith('functions.') &&
+      (peerState.instances ?? []).some(
+        (i) =>
+          (i as { type?: string }).type === 'ALIYUN_RAM_ROLE' &&
+          (i as { id?: string }).id === roleName &&
+          !(i as { external?: boolean }).external,
+      ),
+  );
+  if (sharedRole) {
+    return false;
+  }
+
+  let logConfig: { project: string; logstore: string } | undefined;
+  if (fn.log) {
+    const logstoreInstance = currentState.instances?.find(
+      (i) => (i as { type?: string }).type === 'ALIYUN_SLS_LOGSTORE',
+    ) as { id?: string } | undefined;
+    if (!logstoreInstance?.id) {
+      return false;
+    }
+    const [project, logstore] = logstoreInstance.id.split('/');
+    logConfig = { project, logstore };
+  }
+
+  const roleGrant = resolveRoleGrant(context, state, fn, logConfig, roleName);
+
+  // a. trust policy — console edits to the assume-role principals.
+  const cloudTrust = parseRolePolicyDocument(cloudRole?.assumeRolePolicyDocument);
+  const desiredTrust: Record<string, unknown> = {
+    Version: '1',
+    Statement: [
+      {
+        Action: 'sts:AssumeRole',
+        Effect: 'Allow',
+        Principal: { Service: [...roleGrant.trustedServices] },
+      },
+    ],
+  };
+  if (cloudTrust && !attributesEqual(cloudTrust, desiredTrust)) {
+    return true;
+  }
+
+  // b. execution + custom policy (the `<roleName>-policy` custom document). An
+  // absent/unreadable cloud document is drift: the executor recreates it on
+  // update, so leaving it unread would mask a deleted policy.
+  const cloudPolicyDocument = await cachedRefreshRead(
+    context,
+    `ram.getExecutionPolicyDocument:${roleName}`,
+    () => client.ram.getExecutionPolicyDocument(roleName),
+  );
+  const cloudPolicy = parseRolePolicyDocument(cloudPolicyDocument);
+  const desiredPolicyDocument = parseRolePolicyDocument(
+    buildFc3ExecutionPolicyDocument(roleGrant.executionStatements, roleGrant.customStatements),
+  );
+  if (
+    !cloudPolicy ||
+    !desiredPolicyDocument ||
+    !attributesEqual(cloudPolicy, desiredPolicyDocument)
+  ) {
+    return true;
+  }
+
+  // c. managed (system) policies as sorted name sets; desired ARNs strip the
+  // `acs:ram::<uid>:policy/` prefix.
+  const desiredManagedNames = (iamRole.managed_policies ?? []).map(
+    (policyArn) => policyArn.split('/').pop() ?? '',
+  );
+  const cloudManagedNames = await cachedRefreshRead(
+    context,
+    `ram.listAttachedRolePolicies:${roleName}`,
+    () => client.ram.listAttachedRolePolicies(roleName),
+  );
+  const asSortedSetKey = (names: string[]): string => [...names].sort().join(',');
+  if (asSortedSetKey(desiredManagedNames) !== asSortedSetKey(cloudManagedNames ?? [])) {
+    return true;
+  }
+
+  return false;
+};
+
 export const generateFunctionPlan = async (
   context: Context,
   state: StateFile,
@@ -218,7 +373,15 @@ export const generateFunctionPlan = async (
         const normalizedDesired = normalizeDefinitionForComparison(desiredDefinition);
         const definitionChanged = !attributesEqual(normalizedCurrent, normalizedDesired);
 
-        if (definitionChanged) {
+        // Issue #234 phase 1: live attribute drift. The stored definition can
+        // be untouched while the console edited the deployed function
+        // (memory/timeout/env/...). One-directional: only mapper-emitted keys
+        // the desired definition declares are compared, so cloud-only extras
+        // the config never asked for are ignored (desired-declared contract).
+        const remoteAttributes = cloudFc3ToDefinition(remoteFunction);
+        const remoteDiffers = remoteDiffersFromDesired(remoteAttributes, desiredDefinition);
+
+        if (definitionChanged || remoteDiffers) {
           return {
             logicalId,
             action: 'update',
@@ -242,6 +405,23 @@ export const generateFunctionPlan = async (
                 functionName: fn.name,
               }),
             );
+            return {
+              logicalId,
+              action: 'update',
+              resourceType: 'ALIYUN_FC3',
+              changes: { before: normalizedCurrent, after: normalizedDesired },
+              drifted: true,
+            };
+          }
+          const rolePolicyDrifted = await detectRolePolicyDrift(
+            context,
+            state,
+            fn,
+            currentState,
+            roleProbe.roleName,
+            cloudRole,
+          );
+          if (rolePolicyDrifted) {
             return {
               logicalId,
               action: 'update',

--- a/src/stack/aliyunStack/fc3Resource.ts
+++ b/src/stack/aliyunStack/fc3Resource.ts
@@ -145,7 +145,7 @@ const unionTrustedServices = (serviceLists: string[][]): string[] => [
  * functions — a single function's update would otherwise strip another
  * function's requirements.
  */
-const resolveRoleGrant = (
+export const resolveRoleGrant = (
   context: Context,
   state: StateFile | undefined,
   fn: FunctionDomain,

--- a/src/stack/aliyunStack/fc3Types.ts
+++ b/src/stack/aliyunStack/fc3Types.ts
@@ -281,7 +281,7 @@ export const functionToFc3Config = (fn: FunctionDomain): Fc3FunctionConfig => {
 
 export const extractFc3Definition = (
   config: Fc3FunctionConfig,
-  codeHash: string,
+  codeHash: string | null,
 ): ResourceAttributes => {
   return {
     functionName: config.functionName,
@@ -302,12 +302,21 @@ export const extractFc3Definition = (
 
 export const extractFunctionDomainDefinition = (
   fn: FunctionDomain,
-  codeHash: string,
+  codeHash: string | null,
 ): ResourceAttributes => {
   const config = functionToFc3Config(fn);
   return extractFc3Definition(config, codeHash);
 };
 
+/**
+ * Cloud-side counterpart of extractFc3Definition (issue #234 live drift): maps
+ * a GetFunction response back to the desired-definition shape. Must mirror the
+ * executor's write shape (`functionToFc3Config`) key-for-key — keys the
+ * executor never writes (customContainerConfig entrypoint/accelerationType)
+ * are omitted entirely, and command/enableTls are emitted only when the cloud
+ * reports them, so image-level or provider-defaulted values can never
+ * phantom-drift against a config that does not declare them.
+ */
 export const cloudFc3ToDefinition = (info: Fc3FunctionInfo): ResourceAttributes => {
   return {
     functionName: info.functionName ?? null,
@@ -333,10 +342,10 @@ export const cloudFc3ToDefinition = (info: Fc3FunctionInfo): ResourceAttributes 
     customContainerConfig: info.customContainerConfig
       ? {
           image: info.customContainerConfig.image ?? null,
-          entrypoint: info.customContainerConfig.entrypoint ?? [],
-          command: info.customContainerConfig.command ?? [],
           port: info.customContainerConfig.port ?? null,
-          accelerationType: info.customContainerConfig.accelerationType ?? null,
+          ...(info.customContainerConfig.command !== undefined
+            ? { command: info.customContainerConfig.command }
+            : {}),
         }
       : null,
     nasConfig: info.nasConfig
@@ -346,6 +355,7 @@ export const cloudFc3ToDefinition = (info: Fc3FunctionInfo): ResourceAttributes 
           mountPoints: (info.nasConfig.mountPoints ?? []).map((mp) => ({
             serverAddr: mp.serverAddr ?? null,
             mountDir: mp.mountDir ?? null,
+            enableTls: mp.enableTls ?? null,
           })),
         }
       : null,

--- a/src/stack/aliyunStack/fc3Types.ts
+++ b/src/stack/aliyunStack/fc3Types.ts
@@ -307,3 +307,53 @@ export const extractFunctionDomainDefinition = (
   const config = functionToFc3Config(fn);
   return extractFc3Definition(config, codeHash);
 };
+
+export const cloudFc3ToDefinition = (info: Fc3FunctionInfo): ResourceAttributes => {
+  return {
+    functionName: info.functionName ?? null,
+    runtime: info.runtime ?? null,
+    handler: info.handler ?? null,
+    memorySize: info.memorySize ?? null,
+    timeout: info.timeout ?? null,
+    diskSize: info.diskSize ?? null,
+    environment: info.environmentVariables ?? {},
+    vpcConfig: info.vpcConfig
+      ? {
+          vpcId: info.vpcConfig.vpcId ?? null,
+          vSwitchIds: info.vpcConfig.vSwitchIds ?? [],
+          securityGroupId: info.vpcConfig.securityGroupId ?? null,
+        }
+      : null,
+    gpuConfig: info.gpuConfig
+      ? {
+          gpuMemorySize: info.gpuConfig.gpuMemorySize ?? null,
+          gpuType: info.gpuConfig.gpuType ?? null,
+        }
+      : null,
+    customContainerConfig: info.customContainerConfig
+      ? {
+          image: info.customContainerConfig.image ?? null,
+          entrypoint: info.customContainerConfig.entrypoint ?? [],
+          command: info.customContainerConfig.command ?? [],
+          port: info.customContainerConfig.port ?? null,
+          accelerationType: info.customContainerConfig.accelerationType ?? null,
+        }
+      : null,
+    nasConfig: info.nasConfig
+      ? {
+          userId: info.nasConfig.userId ?? null,
+          groupId: info.nasConfig.groupId ?? null,
+          mountPoints: (info.nasConfig.mountPoints ?? []).map((mp) => ({
+            serverAddr: mp.serverAddr ?? null,
+            mountDir: mp.mountDir ?? null,
+          })),
+        }
+      : null,
+    logConfig: info.logConfig
+      ? {
+          enableRequestMetrics: info.logConfig.enableRequestMetrics ?? null,
+          enableInstanceMetrics: info.logConfig.enableInstanceMetrics ?? null,
+        }
+      : null,
+  };
+};

--- a/src/stack/aliyunStack/ossPlanner.ts
+++ b/src/stack/aliyunStack/ossPlanner.ts
@@ -3,9 +3,14 @@ import { Context, BucketDomain, Plan, PlanItem, StateFile, ResourceAttributes } 
 import { createAliyunClient } from '../../common/aliyunClient';
 import { cachedRefreshRead } from '../../common/refreshCache';
 import { PLAN_READ_CONCURRENCY, mapWithConcurrency } from '../../common/concurrency';
-import { bucketToOssBucketConfig, extractOssBucketDefinition } from './ossTypes';
+import {
+  bucketToOssBucketConfig,
+  cloudOssToDefinition,
+  extractOssBucketDefinition,
+} from './ossTypes';
 import { getAllResources, getResource } from '../../common/stateManager';
 import { attributesEqual, computeDirectoryHash } from '../../common/hashUtils';
+import { remoteDiffersFromDesired } from '../../common/planCompare';
 import { OWNERSHIP_TAG_KEY, isOwnedByStack } from '../ownershipTag';
 
 const planBucketDeletion = (logicalId: string, definition: ResourceAttributes): PlanItem => ({
@@ -109,15 +114,17 @@ export const generateBucketPlan = async (
         const normalizedDesired = normalizeDefinitionForDisplay(desiredDefinition);
         const { domainBound } = currentDefinition as { domainBound?: boolean | null };
         const definitionChanged = !attributesEqual(normalizedCurrent, normalizedDesired);
+        const remoteAttributes = cloudOssToDefinition(remoteBucket);
+        const remoteDiffers = remoteDiffersFromDesired(remoteAttributes, desiredDefinition);
         const domainBindingPending = domainBound === false;
 
-        if (definitionChanged || domainBindingPending) {
+        if (definitionChanged || remoteDiffers || domainBindingPending) {
           return {
             logicalId,
             action: 'update',
             resourceType: 'ALIYUN_OSS_BUCKET',
             changes: { before: normalizedCurrent, after: normalizedDesired },
-            ...(definitionChanged ? { drifted: true } : {}),
+            ...(definitionChanged || remoteDiffers ? { drifted: true } : {}),
           };
         }
 

--- a/src/stack/aliyunStack/ossTypes.ts
+++ b/src/stack/aliyunStack/ossTypes.ts
@@ -1,4 +1,5 @@
 import { BucketAccessEnum, BucketDomain, BucketIam, ResourceAttributes } from '../../types';
+import type { OssBucketInfo } from '../../common/aliyunClient/ossOperations';
 import { BucketACL, CommonBucketConfig } from '../bucketTypes';
 
 export type OssBucketConfig = CommonBucketConfig & {
@@ -160,3 +161,27 @@ export const extractOssBucketDefinition = (
 
   return def;
 };
+
+export const cloudOssToDefinition = (info: OssBucketInfo): ResourceAttributes => ({
+  bucketName: info.name,
+  ...(info.acl !== undefined ? { acl: info.acl } : {}),
+  ...(info.websiteConfig
+    ? {
+        websiteConfiguration: {
+          indexDocument: info.websiteConfig.indexDocument,
+          errorDocument: info.websiteConfig.errorDocument ?? null,
+        },
+      }
+    : {}),
+  ...(info.storageClass !== undefined ? { storageClass: info.storageClass } : {}),
+  ...(info.versioningConfig?.status !== undefined
+    ? { versioningStatus: info.versioningConfig.status }
+    : {}),
+  ...(info.encryptionConfig?.sseAlgorithm !== undefined
+    ? { sseAlgorithm: info.encryptionConfig.sseAlgorithm }
+    : {}),
+  ...(info.policy !== undefined ? { policy: info.policy } : {}),
+  ...(typeof info.transferAccelerationStatus === 'boolean'
+    ? { accelerateEnabled: info.transferAccelerationStatus }
+    : {}),
+});

--- a/src/stack/aliyunStack/rdsTypes.ts
+++ b/src/stack/aliyunStack/rdsTypes.ts
@@ -236,4 +236,41 @@ export const extractRdsDefinition = (config: RdsConfig): ResourceAttributes => {
   };
 };
 
+export const cloudRdsToDefinition = (info: RdsInfo): ResourceAttributes => ({
+  ...(info.dbInstanceDescription === undefined
+    ? {}
+    : { dbInstanceDescription: info.dbInstanceDescription }),
+  ...(info.engine === undefined ? {} : { engine: info.engine }),
+  ...(info.engineVersion === undefined ? {} : { engineVersion: info.engineVersion }),
+  ...(info.dbInstanceClass === undefined ? {} : { dbInstanceClass: info.dbInstanceClass }),
+  ...(info.dbInstanceStorage === undefined ? {} : { dbInstanceStorage: info.dbInstanceStorage }),
+  ...(info.category === undefined ? {} : { category: info.category }),
+  ...(info.dbInstanceStorageType === undefined
+    ? {}
+    : { dbInstanceStorageType: info.dbInstanceStorageType }),
+  ...(info.burstingEnabled === undefined ? {} : { burstingEnabled: info.burstingEnabled }),
+  ...(info.serverlessConfig === undefined
+    ? {}
+    : {
+        serverlessConfig: {
+          ...(info.serverlessConfig.minCapacity === undefined
+            ? {}
+            : { minCapacity: info.serverlessConfig.minCapacity }),
+          ...(info.serverlessConfig.maxCapacity === undefined
+            ? {}
+            : { maxCapacity: info.serverlessConfig.maxCapacity }),
+          ...(info.serverlessConfig.autoPause === undefined
+            ? {}
+            : { autoPause: info.serverlessConfig.autoPause }),
+          ...(info.serverlessConfig.switchForce === undefined
+            ? {}
+            : { switchForce: info.serverlessConfig.switchForce }),
+        },
+      }),
+  ...(info.multiAZ === undefined ? {} : { multiAZ: info.multiAZ }),
+  ...(info.securityIPList === undefined ? {} : { securityIPList: info.securityIPList }),
+  ...(info.vpcId === undefined ? {} : { vpcId: info.vpcId }),
+  ...(info.vSwitchId === undefined ? {} : { vSwitchId: info.vSwitchId }),
+});
+
 export { RdsConfig, RdsInfo };

--- a/src/stack/aliyunStack/tablestorePlanner.ts
+++ b/src/stack/aliyunStack/tablestorePlanner.ts
@@ -2,7 +2,12 @@ import { Context, TableDomain, Plan, PlanItem, StateFile, ResourceAttributes } f
 import { createAliyunClient } from '../../common/aliyunClient';
 import { cachedRefreshRead } from '../../common/refreshCache';
 import { PLAN_READ_CONCURRENCY, mapWithConcurrency } from '../../common/concurrency';
-import { tableToTableStoreConfig, extractTableStoreDefinition } from './tablestoreTypes';
+import {
+  tableToTableStoreConfig,
+  extractTableStoreDefinition,
+  cloudTableStoreToDefinition,
+} from './tablestoreTypes';
+import { remoteDiffersFromDesired } from '../../common/planCompare';
 import { getAllResources, getResource } from '../../common/stateManager';
 import { attributesEqual } from '../../common/hashUtils';
 
@@ -84,10 +89,13 @@ export const generateTablePlan = async (
           };
         }
 
+        const remoteAttributes = cloudTableStoreToDefinition(remoteTable);
+        const remoteDiffers = remoteDiffersFromDesired(remoteAttributes, desiredDefinition);
+
         const currentDefinition = currentState.definition || {};
         const definitionChanged = !attributesEqual(currentDefinition, desiredDefinition);
 
-        if (definitionChanged) {
+        if (definitionChanged || remoteDiffers) {
           // Check if primary keys changed (not updatable in TableStore)
           const currentPrimaryKey = JSON.stringify(currentDefinition.primaryKey || []);
           const desiredPrimaryKey = JSON.stringify(desiredDefinition.primaryKey || []);

--- a/src/stack/aliyunStack/tablestoreTypes.ts
+++ b/src/stack/aliyunStack/tablestoreTypes.ts
@@ -1,4 +1,5 @@
 import { TableDomain, TableEnum, AttributeTypeEnum, ResourceAttributes } from '../../types';
+import type { TableStoreTableInfo } from '../../common/aliyunClient/tablestoreOperations';
 
 export type TableStoreConfig = {
   instanceName: string;
@@ -128,5 +129,38 @@ export const extractTableStoreDefinition = (config: TableStoreConfig): ResourceA
     onDemandThroughput: config.onDemandThroughput ?? null,
     tableOptions: config.tableOptions ?? null,
     network: config.network ?? null,
+  };
+};
+
+export const cloudTableStoreToDefinition = (info: TableStoreTableInfo): ResourceAttributes => {
+  const capacityUnit = info.reservedThroughputDetails?.capacityUnit;
+  const tableOptions = info.tableOptions;
+
+  return {
+    tableName: info.tableName,
+    ...(info.primaryKey ? { primaryKey: info.primaryKey } : {}),
+    ...(capacityUnit?.read !== undefined && capacityUnit.write !== undefined
+      ? {
+          reservedThroughput: {
+            capacityUnit: {
+              read: capacityUnit.read,
+              write: capacityUnit.write,
+            },
+          },
+        }
+      : {}),
+    ...(tableOptions &&
+    (tableOptions.timeToLive !== undefined || tableOptions.maxVersions !== undefined)
+      ? {
+          tableOptions: {
+            ...(tableOptions.timeToLive !== undefined
+              ? { timeToLive: tableOptions.timeToLive }
+              : {}),
+            ...(tableOptions.maxVersions !== undefined
+              ? { maxVersions: tableOptions.maxVersions }
+              : {}),
+          },
+        }
+      : {}),
   };
 };

--- a/tests/unit/common/aliyunClient/ramOperations.test.ts
+++ b/tests/unit/common/aliyunClient/ramOperations.test.ts
@@ -710,6 +710,66 @@ describe('ramOperations', () => {
     });
   });
 
+  describe('getExecutionPolicyDocument', () => {
+    const policyDocument = JSON.stringify({
+      Version: '1',
+      Statement: [{ Effect: 'Allow', Action: ['fc:InvokeFunction'], Resource: '*' }],
+    });
+
+    it('should return the default policy document when policy and version exist', async () => {
+      mockGetPolicy.mockResolvedValue({
+        body: { policy: { policyName: 'fc-execution-role-policy', defaultVersion: 'v1' } },
+      });
+      mockGetPolicyVersion.mockResolvedValue({
+        body: { policyVersion: { versionId: 'v1', policyDocument } },
+      });
+
+      const result = await operations.getExecutionPolicyDocument('fc-execution-role');
+
+      expect(result).toBe(policyDocument);
+      expect(mockGetPolicy).toHaveBeenCalledWith(
+        expect.objectContaining({ policyName: 'fc-execution-role-policy', policyType: 'Custom' }),
+      );
+      expect(mockGetPolicyVersion).toHaveBeenCalledWith(
+        expect.objectContaining({
+          policyName: 'fc-execution-role-policy',
+          policyType: 'Custom',
+          versionId: 'v1',
+        }),
+      );
+    });
+
+    it('should return undefined when getPolicy throws EntityNotExist.Policy', async () => {
+      const notFound = new Error('EntityNotExist.Policy');
+      Object.assign(notFound, { code: 'EntityNotExist.Policy' });
+      mockGetPolicy.mockRejectedValue(notFound);
+
+      const result = await operations.getExecutionPolicyDocument('fc-execution-role');
+
+      expect(result).toBeUndefined();
+      expect(mockGetPolicyVersion).not.toHaveBeenCalled();
+    });
+
+    it('should rethrow non-not-found errors from getPolicy', async () => {
+      mockGetPolicy.mockRejectedValue(new Error('AccessDenied'));
+
+      await expect(operations.getExecutionPolicyDocument('fc-execution-role')).rejects.toThrow(
+        'AccessDenied',
+      );
+    });
+
+    it('should return undefined when the policy has no default version (role without policy)', async () => {
+      mockGetPolicy.mockResolvedValue({
+        body: { policy: { policyName: 'fc-execution-role-policy' } },
+      });
+
+      const result = await operations.getExecutionPolicyDocument('fc-execution-role');
+
+      expect(result).toBeUndefined();
+      expect(mockGetPolicyVersion).not.toHaveBeenCalled();
+    });
+  });
+
   describe('attachManagedPolicies', () => {
     it('should attach multiple managed policies', async () => {
       mockAttachPolicyToRole.mockResolvedValue({});

--- a/tests/unit/common/planCompare.test.ts
+++ b/tests/unit/common/planCompare.test.ts
@@ -49,4 +49,28 @@ describe('remoteDiffersFromDesired', () => {
 
     expect(remoteDiffersFromDesired(remote, desired)).toBe(true);
   });
+
+  it('ignores remote values behind a desired empty plain object (executor omits the field)', () => {
+    const remote = {
+      environment: { CONSOLE_ADDED: '1' },
+      websiteConfiguration: { indexDocument: 'index.html' },
+    };
+    const desired = { environment: {}, websiteConfiguration: {} };
+
+    expect(remoteDiffersFromDesired(remote, desired)).toBe(false);
+  });
+
+  it('still flags drift when the desired empty object is replaced by a declared one', () => {
+    const remote = { environment: {} };
+    const desired = { environment: { NODE_ENV: 'production' } };
+
+    expect(remoteDiffersFromDesired(remote, desired)).toBe(true);
+  });
+
+  it('does not treat empty arrays or empty strings as undeclared', () => {
+    const remote = { mountPoints: [{ serverAddr: 'addr' }], handler: '' };
+    const desired = { mountPoints: [], handler: '' };
+
+    expect(remoteDiffersFromDesired(remote, desired)).toBe(true);
+  });
 });

--- a/tests/unit/common/planCompare.test.ts
+++ b/tests/unit/common/planCompare.test.ts
@@ -1,0 +1,52 @@
+import { remoteDiffersFromDesired } from '../../../src/common/planCompare';
+
+describe('remoteDiffersFromDesired', () => {
+  it('returns false when every declared desired value matches the remote', () => {
+    const remote = { memorySize: 256, timeout: 30, logConfig: { enableRequestMetrics: true } };
+    const desired = { memorySize: 256, timeout: 30, logConfig: { enableRequestMetrics: true } };
+
+    expect(remoteDiffersFromDesired(remote, desired)).toBe(false);
+  });
+
+  it('returns true when a declared desired value differs from the remote', () => {
+    const remote = { memorySize: 256, timeout: 30 };
+    const desired = { memorySize: 128, timeout: 30 };
+
+    expect(remoteDiffersFromDesired(remote, desired)).toBe(true);
+  });
+
+  it('returns false for remote keys the desired definition does not declare', () => {
+    const remote = { description: 'console note', codeChecksum: 'abc' };
+    const desired = { memorySize: 256 };
+
+    expect(remoteDiffersFromDesired(remote, desired)).toBe(false);
+  });
+
+  it('returns false for remote keys the desired definition declares as null/undefined', () => {
+    const remote = { vpcConfig: { vpcId: 'vpc-1' }, logConfig: { project: 'p' } };
+    const desired = { vpcConfig: null, logConfig: undefined };
+
+    expect(remoteDiffersFromDesired(remote, desired)).toBe(false);
+  });
+
+  it('returns true when the remote is missing a value the desired declares', () => {
+    const remote = { memorySize: null };
+    const desired = { memorySize: 256 };
+
+    expect(remoteDiffersFromDesired(remote, desired)).toBe(true);
+  });
+
+  it('treats null and undefined as equal within nested objects', () => {
+    const remote = { logConfig: { enableRequestMetrics: true, enableInstanceMetrics: null } };
+    const desired = { logConfig: { enableRequestMetrics: true } };
+
+    expect(remoteDiffersFromDesired(remote, desired)).toBe(false);
+  });
+
+  it('returns true on nested object mismatches inside declared keys', () => {
+    const remote = { vpcConfig: { vpcId: 'vpc-other' } };
+    const desired = { vpcConfig: { vpcId: 'vpc-1' } };
+
+    expect(remoteDiffersFromDesired(remote, desired)).toBe(true);
+  });
+});

--- a/tests/unit/stack/aliyunStack/apigwPlanner.test.ts
+++ b/tests/unit/stack/aliyunStack/apigwPlanner.test.ts
@@ -1,13 +1,14 @@
 import { generateApigwPlan } from '../../../../src/stack/aliyunStack/apigwPlanner';
 import { loadState, setResource } from '../../../../src/common/stateManager';
 import { Context, EventDomain, EventTypes } from '../../../../src/types';
-import { ProviderEnum } from '../../../../src/common';
+import { ProviderEnum, buildAliyunApigwApiName, generateApiKey } from '../../../../src/common';
 import fs from 'node:fs';
 
 // Create mock apigw operations
 const mockApigwOperations = {
   findApiGroupByName: jest.fn(),
   getApiGroup: jest.fn(),
+  listApisByGroup: jest.fn(),
   createApiGroup: jest.fn(),
   updateApiGroup: jest.fn(),
   deleteApiGroup: jest.fn(),
@@ -56,6 +57,71 @@ describe('Apigw Planner', () => {
         backend: 'userFunction',
       },
     ],
+  };
+
+  const derivedApiName = (method: string, path: string): string =>
+    buildAliyunApigwApiName('Test API Gateway', 'default', generateApiKey(method, path));
+
+  const matchingGroup = {
+    groupId: 'group-123',
+    groupName: 'test-service-default-test-api-agw-group',
+    description: 'API Gateway group for test-service',
+    basePath: null,
+  };
+
+  const cloudApiDetail = (
+    overrides: { apiName?: string; method?: string; path?: string; backend?: string } = {},
+  ) => ({
+    apiId: 'api-1',
+    apiName: overrides.apiName ?? derivedApiName('GET', '/users'),
+    groupId: 'group-123',
+    requestConfig: {
+      requestProtocol: 'HTTP',
+      requestHttpMethod: overrides.method ?? 'GET',
+      requestPath: overrides.path ?? '/users',
+      requestMode: 'PASSTHROUGH',
+    },
+    serviceConfig: {
+      serviceProtocol: 'FunctionCompute',
+      functionComputeConfig: {
+        fcRegionId: 'cn-hangzhou',
+        functionName: overrides.backend ?? 'userFunction',
+        fcVersion: '3.0',
+        method: 'GET',
+      },
+    },
+  });
+
+  const buildMatchingState = () => {
+    let state = loadState('aliyun', 'test-app', 'test-service', 'default', testDir);
+    state = setResource(state, 'events.test_api', {
+      mode: 'managed',
+      region: 'cn-hangzhou',
+      definition: {
+        groupName: 'test-service-default-test-api-agw-group',
+        description: 'API Gateway group for test-service',
+        basePath: null,
+        triggers: [{ method: 'GET', path: '/users', backend: 'userFunction' }],
+        domain: null,
+      },
+      instances: [
+        {
+          type: 'ALIYUN_APIGW_GROUP',
+          sid: 'si:aliyun:apigateway:default:group-123',
+          id: 'group-123',
+          groupName: 'test-service-default-test-api-agw-group',
+        },
+      ],
+      lastUpdated: new Date().toISOString(),
+    });
+    return state;
+  };
+
+  const mockMatchingApis = () => {
+    mockApigwOperations.listApisByGroup.mockResolvedValue([
+      { apiId: 'api-1', apiName: derivedApiName('GET', '/users') },
+    ]);
+    mockApigwOperations.getApi.mockResolvedValue(cloudApiDetail());
   };
 
   beforeEach(() => {
@@ -256,6 +322,7 @@ describe('Apigw Planner', () => {
         groupName: 'test-service-default-test-api-agw-group',
         description: 'API Gateway group for test-service',
       });
+      mockMatchingApis();
 
       const plan = await generateApigwPlan(mockContext, state, [testEvent], 'test-service');
 
@@ -392,6 +459,7 @@ describe('Apigw Planner', () => {
         groupName: 'test-service-default-test-api-agw-group',
         description: 'API Gateway group for test-service',
       });
+      mockMatchingApis();
 
       const plan = await generateApigwPlan(mockContext, state, [eventWithHttps], 'test-service');
 
@@ -501,6 +569,124 @@ describe('Apigw Planner', () => {
         drifted: true,
       });
       expect(plan.items[0].changes?.after).toBeDefined();
+    });
+
+    it('should plan update+drifted when the live group description drifted from the config', async () => {
+      const state = buildMatchingState();
+      mockApigwOperations.getApiGroup.mockResolvedValue({
+        ...matchingGroup,
+        description: 'Edited in the console',
+      });
+      mockMatchingApis();
+
+      const plan = await generateApigwPlan(mockContext, state, [testEvent], 'test-service');
+
+      expect(plan.items).toHaveLength(1);
+      expect(plan.items[0]).toMatchObject({
+        logicalId: 'events.test_api',
+        action: 'update',
+        resourceType: 'ALIYUN_APIGW',
+        drifted: true,
+      });
+    });
+
+    it('should plan update+drifted when the live group name drifted from the config', async () => {
+      const state = buildMatchingState();
+      mockApigwOperations.getApiGroup.mockResolvedValue({
+        ...matchingGroup,
+        groupName: 'renamed-in-console-group',
+      });
+      mockMatchingApis();
+
+      const plan = await generateApigwPlan(mockContext, state, [testEvent], 'test-service');
+
+      expect(plan.items[0]).toMatchObject({ action: 'update', drifted: true });
+    });
+
+    it.each([
+      ['method', { method: 'POST' }],
+      ['path', { path: '/admin' }],
+      ['backend', { backend: 'another-function' }],
+    ] as const)(
+      'should plan update+drifted when the cloud trigger %s drifted from the config',
+      async (_field, overrides) => {
+        const state = buildMatchingState();
+        mockApigwOperations.getApiGroup.mockResolvedValue(matchingGroup);
+        mockApigwOperations.listApisByGroup.mockResolvedValue([
+          { apiId: 'api-1', apiName: derivedApiName('GET', '/users') },
+        ]);
+        mockApigwOperations.getApi.mockResolvedValue(cloudApiDetail(overrides));
+
+        const plan = await generateApigwPlan(mockContext, state, [testEvent], 'test-service');
+
+        expect(plan.items[0]).toMatchObject({ action: 'update', drifted: true });
+      },
+    );
+
+    it('should plan update+drifted when a desired trigger has no matching cloud API', async () => {
+      const state = buildMatchingState();
+      mockApigwOperations.getApiGroup.mockResolvedValue(matchingGroup);
+      mockApigwOperations.listApisByGroup.mockResolvedValue([]);
+
+      const plan = await generateApigwPlan(mockContext, state, [testEvent], 'test-service');
+
+      expect(plan.items[0]).toMatchObject({ action: 'update', drifted: true });
+    });
+
+    it('should plan noop when an extra foreign cloud API exists (executor never deletes it)', async () => {
+      const state = buildMatchingState();
+      mockApigwOperations.getApiGroup.mockResolvedValue(matchingGroup);
+      mockApigwOperations.listApisByGroup.mockResolvedValue([
+        { apiId: 'api-1', apiName: derivedApiName('GET', '/users') },
+        { apiId: 'foreign-9', apiName: 'console_created_api' },
+      ]);
+      mockApigwOperations.getApi.mockResolvedValue(cloudApiDetail());
+
+      const plan = await generateApigwPlan(mockContext, state, [testEvent], 'test-service');
+
+      expect(plan.items[0]).toMatchObject({ action: 'noop', resourceType: 'ALIYUN_APIGW' });
+      expect(mockApigwOperations.getApi).toHaveBeenCalledTimes(1);
+    });
+
+    it('should plan noop when group and triggers match despite cloud noise', async () => {
+      const state = buildMatchingState();
+      mockApigwOperations.getApiGroup.mockResolvedValue({
+        ...matchingGroup,
+        tags: [
+          { Key: 'si-owned-by', Value: 'test-app-test-service:events.test_api' },
+          { Key: 'env', Value: 'prod' },
+        ],
+        customDomains: [{ domainName: 'api.example.com', certificateId: 'cert-1' }],
+        stageItems: [{ stageName: 'RELEASE' }],
+      });
+      mockApigwOperations.listApisByGroup.mockResolvedValue([
+        { apiId: 'api-1', apiName: derivedApiName('GET', '/users') },
+        { apiId: 'foreign-7', apiName: 'console_only_api' },
+      ]);
+      mockApigwOperations.getApi.mockResolvedValue(cloudApiDetail());
+
+      const plan = await generateApigwPlan(mockContext, state, [testEvent], 'test-service');
+
+      expect(plan.items[0]).toMatchObject({ action: 'noop', resourceType: 'ALIYUN_APIGW' });
+    });
+
+    it('should plan update with drifted:true on a local definition change', async () => {
+      const changedEvent: EventDomain = {
+        ...testEvent,
+        triggers: [{ method: 'GET', path: '/v2/users', backend: 'userFunction' }],
+      };
+      const state = buildMatchingState();
+      mockApigwOperations.getApiGroup.mockResolvedValue(matchingGroup);
+      mockApigwOperations.listApisByGroup.mockResolvedValue([
+        { apiId: 'api-1', apiName: derivedApiName('GET', '/v2/users') },
+      ]);
+      mockApigwOperations.getApi.mockResolvedValue(
+        cloudApiDetail({ apiName: derivedApiName('GET', '/v2/users'), path: '/v2/users' }),
+      );
+
+      const plan = await generateApigwPlan(mockContext, state, [changedEvent], 'test-service');
+
+      expect(plan.items[0]).toMatchObject({ action: 'update', drifted: true });
     });
   });
 });

--- a/tests/unit/stack/aliyunStack/apigwTypes.test.ts
+++ b/tests/unit/stack/aliyunStack/apigwTypes.test.ts
@@ -5,6 +5,10 @@ import {
   extractApigwApiDefinition,
   extractApigwDeploymentDefinition,
   inferProtocolConfig,
+  cloudApigwGroupToDefinition,
+  cloudApigwApiToTriggerAttributes,
+  cloudApigwCustomDomainToDefinition,
+  cloudGatewayLogToLogConfig,
 } from '../../../../src/stack/aliyunStack/apigwTypes';
 import { EventDomain, EventTypes, ServerlessIac } from '../../../../src/types';
 import { ProviderEnum, setContext, setIac } from '../../../../src/common';
@@ -334,5 +338,135 @@ describe('Apigw Types', () => {
       expect(result.requestProtocol).toBe('HTTP');
       expect(result.isHttpRedirectToHttps).toBeUndefined();
     });
+  });
+});
+
+describe('cloudApigwGroupToDefinition', () => {
+  it('maps a full cloud group to the extract shape (groupName/description/basePath)', () => {
+    const definition = cloudApigwGroupToDefinition({
+      groupId: 'group-123',
+      groupName: 'test-service-default-test-api-agw-group',
+      description: 'API Gateway group for test-service',
+      basePath: '/api/v1',
+      subDomain: 'group-123.apigw.aliyuncs.com',
+      status: 'NORMAL',
+    });
+
+    expect(definition).toEqual({
+      groupName: 'test-service-default-test-api-agw-group',
+      description: 'API Gateway group for test-service',
+      basePath: '/api/v1',
+    });
+  });
+
+  it('maps null for optional fields the cloud does not report', () => {
+    const definition = cloudApigwGroupToDefinition({
+      groupId: 'group-123',
+      groupName: 'test-service-default-test-api-agw-group',
+    });
+
+    expect(definition).toEqual({
+      groupName: 'test-service-default-test-api-agw-group',
+      description: null,
+      basePath: null,
+    });
+  });
+});
+
+describe('cloudApigwApiToTriggerAttributes', () => {
+  it('maps apiName, request method/path and the FunctionCompute backend', () => {
+    const attributes = cloudApigwApiToTriggerAttributes({
+      apiId: 'api-456',
+      apiName: 'Test_API_Gateway_default_agw_api_GET_users',
+      groupId: 'group-123',
+      requestConfig: {
+        requestHttpMethod: 'GET',
+        requestPath: '/users',
+      },
+      serviceConfig: {
+        serviceProtocol: 'FunctionCompute',
+        functionComputeConfig: {
+          functionName: 'userFunction',
+        },
+      },
+    });
+
+    expect(attributes).toEqual({
+      apiName: 'Test_API_Gateway_default_agw_api_GET_users',
+      method: 'GET',
+      path: '/users',
+      backend: 'userFunction',
+    });
+  });
+
+  it('keeps optional fields undefined when the cloud does not report them', () => {
+    const attributes = cloudApigwApiToTriggerAttributes({
+      apiId: 'api-789',
+      apiName: 'bare-api',
+    });
+
+    expect(attributes.apiName).toBe('bare-api');
+    expect(attributes.method).toBeUndefined();
+    expect(attributes.path).toBeUndefined();
+    expect(attributes.backend).toBeUndefined();
+  });
+});
+
+describe('cloudApigwCustomDomainToDefinition', () => {
+  it('emits only the domain keys the cloud can reproduce (domainName + certificateId)', () => {
+    const definition = cloudApigwCustomDomainToDefinition({
+      domainName: 'api.example.com',
+      certificateId: 'cert-123',
+      bindStageName: 'RELEASE',
+      domainBindingStatus: 'BINDING',
+      isHttpRedirectToHttps: true,
+    });
+
+    expect(definition).toEqual({
+      domainName: 'api.example.com',
+      certificateId: 'cert-123',
+    });
+  });
+
+  it('maps certificateId to null when the cloud has none', () => {
+    const definition = cloudApigwCustomDomainToDefinition({
+      domainName: 'api.example.com',
+    });
+
+    expect(definition).toEqual({
+      domainName: 'api.example.com',
+      certificateId: null,
+    });
+  });
+
+  it('returns undefined when the domain item has no domainName', () => {
+    expect(cloudApigwCustomDomainToDefinition({ bindStageName: 'RELEASE' })).toBeUndefined();
+  });
+});
+
+describe('cloudGatewayLogToLogConfig', () => {
+  it('maps a PROVIDER gateway log config to the snapshot shape', () => {
+    const snapshot = cloudGatewayLogToLogConfig({
+      logType: 'PROVIDER',
+      regionId: 'cn-hangzhou',
+      slsProject: 'test-app-dev-sls',
+      slsLogStore: 'test-service-dev-apigw-logs',
+    });
+
+    expect(snapshot).toEqual({
+      logEnabled: true,
+      logConfig: {
+        project: 'test-app-dev-sls',
+        logstore: 'test-service-dev-apigw-logs',
+      },
+    });
+  });
+
+  it('returns undefined when no gateway log config exists', () => {
+    expect(cloudGatewayLogToLogConfig(null)).toBeUndefined();
+  });
+
+  it('returns undefined when the config carries no logType', () => {
+    expect(cloudGatewayLogToLogConfig({ slsProject: 'p', slsLogStore: 's' })).toBeUndefined();
   });
 });

--- a/tests/unit/stack/aliyunStack/databasePlanner.test.ts
+++ b/tests/unit/stack/aliyunStack/databasePlanner.test.ts
@@ -21,11 +21,13 @@ const mockedEsOperations = {
 const mockedRdsTypes = {
   databaseToRdsConfig: jest.fn(),
   extractRdsDefinition: jest.fn(),
+  cloudRdsToDefinition: jest.fn(),
 };
 
 const mockedEsTypes = {
   databaseToEsConfig: jest.fn(),
   extractEsDefinition: jest.fn(),
+  cloudEsToDefinition: jest.fn(),
 };
 
 const mockedStateManager = {
@@ -47,11 +49,13 @@ jest.mock('../../../../src/common/aliyunClient', () => ({
 jest.mock('../../../../src/stack/aliyunStack/rdsTypes', () => ({
   databaseToRdsConfig: (...args: unknown[]) => mockedRdsTypes.databaseToRdsConfig(...args),
   extractRdsDefinition: (...args: unknown[]) => mockedRdsTypes.extractRdsDefinition(...args),
+  cloudRdsToDefinition: (...args: unknown[]) => mockedRdsTypes.cloudRdsToDefinition(...args),
 }));
 
 jest.mock('../../../../src/stack/aliyunStack/esServerlessTypes', () => ({
   databaseToEsConfig: (...args: unknown[]) => mockedEsTypes.databaseToEsConfig(...args),
   extractEsDefinition: (...args: unknown[]) => mockedEsTypes.extractEsDefinition(...args),
+  cloudEsToDefinition: (...args: unknown[]) => mockedEsTypes.cloudEsToDefinition(...args),
 }));
 
 jest.mock('../../../../src/common/stateManager', () => ({
@@ -91,8 +95,14 @@ describe('DatabasePlanner', () => {
     jest.clearAllMocks();
     mockedRdsOperations.getInstanceByName.mockReset();
     mockedEsOperations.getApp.mockReset();
+    mockedRdsTypes.cloudRdsToDefinition.mockReset();
+    mockedEsTypes.cloudEsToDefinition.mockReset();
     mockedStateManager.getAllResources.mockReturnValue({});
     mockedStateManager.getResource.mockReturnValue(null);
+    // Default the live-attribute mappers to empty so unrelated state-exists
+    // tests keep the local definitionChanged-only behavior.
+    mockedRdsTypes.cloudRdsToDefinition.mockReturnValue({});
+    mockedEsTypes.cloudEsToDefinition.mockReturnValue({});
   });
 
   const createTestDatabase = (
@@ -393,6 +403,162 @@ describe('DatabasePlanner', () => {
           resourceType: 'ALIYUN_RDS_SERVERLESS',
         }),
       );
+    });
+
+    it('should plan RDS live drift when cloud attributes differ from desired', async () => {
+      const database = createTestDatabase(DatabaseEnum.RDS_MYSQL_SERVERLESS, 'test_db');
+      const desiredDefinition = {
+        dbInstanceClass: 'serverless',
+        dbInstanceStorage: 100,
+        serverlessConfig: { minCapacity: 1 },
+      };
+      const existingState = {
+        metadata: { instanceId: 'db-instance-123', resourceType: 'ALIYUN_RDS_SERVERLESS' },
+        instances: [{ id: 'db-instance-123' }],
+        definition: desiredDefinition,
+      };
+
+      mockedStateManager.getResource.mockReturnValue(existingState);
+      mockedRdsOperations.getInstance.mockResolvedValue({
+        dbInstanceId: 'db-instance-123',
+        dbInstanceClass: 'serverless',
+        dbInstanceStorage: 200,
+        serverlessConfig: { minCapacity: 2, maxCapacity: 8, autoPause: true },
+        connectionString: 'ignored-rich-cloud-field',
+      });
+      mockedRdsTypes.databaseToRdsConfig.mockReturnValue({});
+      mockedRdsTypes.extractRdsDefinition.mockReturnValue(desiredDefinition);
+      mockedRdsTypes.cloudRdsToDefinition.mockReturnValue({
+        dbInstanceClass: 'serverless',
+        dbInstanceStorage: 200,
+        serverlessConfig: { minCapacity: 2 },
+      });
+      const realAttributesEqual = jest.requireActual('../../../../src/common/hashUtils')
+        .attributesEqual as (a: unknown, b: unknown) => boolean;
+      mockedHashUtils.attributesEqual.mockImplementation(realAttributesEqual);
+
+      const plan = await generateDatabasePlan(mockContext, initialState, [database]);
+
+      expect(plan.items[0]).toEqual(expect.objectContaining({ action: 'update', drifted: true }));
+    });
+
+    it('should plan no-op for matching RDS cloud attributes including omitted fields', async () => {
+      const database = createTestDatabase(DatabaseEnum.RDS_MYSQL_SERVERLESS, 'test_db');
+      const desiredDefinition = {
+        dbInstanceClass: 'serverless',
+        dbInstanceStorage: 100,
+        serverlessConfig: { minCapacity: 1 },
+        connectionStringType: 'Standard',
+      };
+      const existingState = {
+        metadata: { instanceId: 'db-instance-123', resourceType: 'ALIYUN_RDS_SERVERLESS' },
+        instances: [{ id: 'db-instance-123' }],
+        definition: desiredDefinition,
+      };
+
+      mockedStateManager.getResource.mockReturnValue(existingState);
+      mockedRdsOperations.getInstance.mockResolvedValue({
+        dbInstanceId: 'db-instance-123',
+        dbInstanceClass: 'serverless',
+        dbInstanceStorage: 100,
+        serverlessConfig: { minCapacity: 1, maxCapacity: 8, autoPause: true },
+        connectionString: 'ignored-rich-cloud-field',
+      });
+      mockedRdsTypes.databaseToRdsConfig.mockReturnValue({});
+      mockedRdsTypes.extractRdsDefinition.mockReturnValue(desiredDefinition);
+      mockedRdsTypes.cloudRdsToDefinition.mockReturnValue({
+        dbInstanceClass: 'serverless',
+        dbInstanceStorage: 100,
+        serverlessConfig: { minCapacity: 1 },
+      });
+      const realAttributesEqual = jest.requireActual('../../../../src/common/hashUtils')
+        .attributesEqual as (a: unknown, b: unknown) => boolean;
+      mockedHashUtils.attributesEqual.mockImplementation(realAttributesEqual);
+
+      const plan = await generateDatabasePlan(mockContext, initialState, [database]);
+
+      expect(plan.items[0]).toEqual(expect.objectContaining({ action: 'noop' }));
+    });
+
+    it('should plan ES live drift when cloud app metadata or network differs', async () => {
+      const database = createTestDatabase(DatabaseEnum.ELASTICSEARCH_SERVERLESS, 'test_es');
+      const desiredDefinition = {
+        appName: 'test-es-app',
+        appVersion: '7.10',
+        description: 'desired',
+        network: [{ type: 'PUBLIC', whiteIpGroup: [{ groupName: 'default', ips: ['10.0.0.1'] }] }],
+      };
+      const existingState = {
+        metadata: { instanceId: 'es-app-123', resourceType: 'ALIYUN_ES_SERVERLESS' },
+        instances: [{ id: 'es-app-123' }],
+        definition: desiredDefinition,
+      };
+
+      mockedStateManager.getResource.mockReturnValue(existingState);
+      mockedEsOperations.getApp.mockResolvedValue({
+        appId: 'es-app-123',
+        appName: 'test-es-app',
+        version: '7.10',
+        description: 'cloud-edited',
+        network: [{ type: 'PUBLIC', whiteIpGroup: [{ groupName: 'default', ips: ['10.0.0.2'] }] }],
+        quotaInfo: { cu: 4 },
+      });
+      mockedEsTypes.databaseToEsConfig.mockReturnValue({});
+      mockedEsTypes.extractEsDefinition.mockReturnValue(desiredDefinition);
+      mockedEsTypes.cloudEsToDefinition.mockReturnValue({
+        appName: 'test-es-app',
+        appVersion: '7.10',
+        description: 'cloud-edited',
+        network: [{ type: 'PUBLIC', whiteIpGroup: [{ groupName: 'default', ips: ['10.0.0.2'] }] }],
+      });
+      const realAttributesEqual = jest.requireActual('../../../../src/common/hashUtils')
+        .attributesEqual as (a: unknown, b: unknown) => boolean;
+      mockedHashUtils.attributesEqual.mockImplementation(realAttributesEqual);
+
+      const plan = await generateDatabasePlan(mockContext, initialState, [database]);
+
+      expect(plan.items[0]).toEqual(expect.objectContaining({ action: 'update', drifted: true }));
+    });
+
+    it('should plan no-op for matching ES cloud attributes including omitted fields', async () => {
+      const database = createTestDatabase(DatabaseEnum.ELASTICSEARCH_SERVERLESS, 'test_es');
+      const desiredDefinition = {
+        appName: 'test-es-app',
+        appVersion: '7.10',
+        description: 'same',
+        network: [{ type: 'PUBLIC', whiteIpGroup: [{ groupName: 'default', ips: ['10.0.0.1'] }] }],
+        authentication: { basicAuth: [{ username: 'desired-user' }] },
+      };
+      const existingState = {
+        metadata: { instanceId: 'es-app-123', resourceType: 'ALIYUN_ES_SERVERLESS' },
+        instances: [{ id: 'es-app-123' }],
+        definition: desiredDefinition,
+      };
+
+      mockedStateManager.getResource.mockReturnValue(existingState);
+      mockedEsOperations.getApp.mockResolvedValue({
+        appId: 'es-app-123',
+        appName: 'test-es-app',
+        version: '7.10',
+        description: 'same',
+        network: [{ type: 'PUBLIC', whiteIpGroup: [{ groupName: 'default', ips: ['10.0.0.1'] }] }],
+        authentication: { basicAuth: [{ username: 'cloud-user' }] },
+      });
+      mockedEsTypes.databaseToEsConfig.mockReturnValue({});
+      mockedEsTypes.extractEsDefinition.mockReturnValue(desiredDefinition);
+      mockedEsTypes.cloudEsToDefinition.mockReturnValue({
+        appName: 'test-es-app',
+        appVersion: '7.10',
+        description: 'same',
+        network: [{ type: 'PUBLIC', whiteIpGroup: [{ groupName: 'default', ips: ['10.0.0.1'] }] }],
+      });
+      const realAttributesEqual = jest.requireActual('../../../../src/common/hashUtils')
+        .attributesEqual as (a: unknown, b: unknown) => boolean;
+      mockedHashUtils.attributesEqual.mockImplementation(realAttributesEqual);
+
+      const plan = await generateDatabasePlan(mockContext, initialState, [database]);
+
+      expect(plan.items[0]).toEqual(expect.objectContaining({ action: 'noop' }));
     });
 
     it('should plan deletion of unused database', async () => {

--- a/tests/unit/stack/aliyunStack/esServerlessTypes.test.ts
+++ b/tests/unit/stack/aliyunStack/esServerlessTypes.test.ts
@@ -1,7 +1,9 @@
 import {
+  cloudEsToDefinition,
   databaseToEsConfig,
   extractEsDefinition,
 } from '../../../../src/stack/aliyunStack/esServerlessTypes';
+import type { EsInfo } from '../../../../src/common/aliyunClient/esOperations';
 import { DatabaseDomain, DatabaseEnum, DatabaseVersionEnum } from '../../../../src/types';
 
 describe('EsServerlessTypes', () => {
@@ -345,6 +347,90 @@ describe('EsServerlessTypes', () => {
       const definition = extractEsDefinition(config);
 
       expect(definition.authentication).toBeNull();
+    });
+  });
+
+  describe('cloudEsToDefinition', () => {
+    it('maps network, private network, tags, and readable ES attributes', () => {
+      const info: EsInfo = {
+        appName: 'orders-search',
+        appType: 'STANDARD',
+        description: 'Elasticsearch serverless app: orders-search',
+        chargeType: 'POSTPAY',
+        version: '7.10',
+        network: [
+          {
+            type: 'PUBLIC_ES',
+            enabled: true,
+            domain: 'orders.es.aliyuncs.com',
+            port: 9200,
+            whiteIpGroup: [{ groupName: 'default', ips: ['10.0.0.0/8'] }],
+          },
+        ],
+        privateNetwork: [
+          {
+            type: 'PRIVATE_ES',
+            enabled: true,
+            domain: 'orders.private.aliyuncs.com',
+            port: 9200,
+            vpcId: 'vpc-123',
+            pvlEndpointId: 'ep-456',
+            whiteIpGroup: [{ groupName: 'private', ips: ['192.168.0.0/16'] }],
+          },
+        ],
+        tags: [{ key: 'env', value: 'prod' }],
+      };
+
+      expect(cloudEsToDefinition(info)).toEqual({
+        appName: 'orders-search',
+        appVersion: '7.10',
+        description: 'Elasticsearch serverless app: orders-search',
+        chargeType: 'POSTPAY',
+        network: [
+          {
+            type: 'PUBLIC_ES',
+            enabled: true,
+            domain: 'orders.es.aliyuncs.com',
+            port: 9200,
+            whiteIpGroup: [{ groupName: 'default', ips: ['10.0.0.0/8'] }],
+          },
+        ],
+        privateNetwork: [
+          {
+            type: 'PRIVATE_ES',
+            enabled: true,
+            domain: 'orders.private.aliyuncs.com',
+            port: 9200,
+            vpcId: 'vpc-123',
+            pvlEndpointId: 'ep-456',
+            whiteIpGroup: [{ groupName: 'private', ips: ['192.168.0.0/16'] }],
+          },
+        ],
+        tags: [{ key: 'env', value: 'prod' }],
+      });
+    });
+
+    it('omits config-only and unreadable attributes from minimal cloud info', () => {
+      const definition = cloudEsToDefinition({ appId: 'app-1' });
+
+      expect(definition).toEqual({});
+      expect(definition).not.toHaveProperty('appVersion');
+      expect(definition).not.toHaveProperty('authentication');
+      expect(definition).not.toHaveProperty('quotaInfo');
+      expect(definition).not.toHaveProperty('cu');
+      expect(definition).not.toHaveProperty('storage');
+    });
+
+    it('omits absent network collections and preserves empty white IP groups', () => {
+      const definition = cloudEsToDefinition({
+        network: [{ type: 'PUBLIC_ES', whiteIpGroup: [] }],
+        privateNetwork: undefined,
+      });
+
+      expect(definition.network).toEqual([
+        { type: 'PUBLIC_ES', enabled: null, domain: null, port: null, whiteIpGroup: [] },
+      ]);
+      expect(definition).not.toHaveProperty('privateNetwork');
     });
   });
 });

--- a/tests/unit/stack/aliyunStack/fc3Planner.test.ts
+++ b/tests/unit/stack/aliyunStack/fc3Planner.test.ts
@@ -1,10 +1,13 @@
 import { ProviderEnum, buildFunctionRoleName, setResource } from '../../../../src/common';
+import { computeZipContentHash } from '../../../../src/common/hashUtils';
 import { createRefreshCache } from '../../../../src/common/refreshCache';
 import { generateFunctionPlan } from '../../../../src/stack/aliyunStack/fc3Planner';
+import { extractFunctionDomainDefinition } from '../../../../src/stack/aliyunStack/fc3Types';
 import {
   Context,
   CURRENT_STATE_VERSION,
   FunctionDomain,
+  NasStorageClassEnum,
   ResourceInstance,
   StateFile,
 } from '../../../../src/types';
@@ -938,6 +941,24 @@ describe('FC3 Planner', () => {
       expect(mockRamOperations.listAttachedRolePolicies).toHaveBeenCalledWith('test-managed-role');
     });
 
+    it('stays noop (never create) when the role probe read fails transiently', async () => {
+      const fn: FunctionDomain = {
+        ...testFunction,
+        iam: { role: { name: 'test-managed-role' } },
+      };
+      const state = buildState(fn, [fc3Instance, roleInstance]);
+      mockFc3Operations.getFunction.mockResolvedValue(remoteFunctionMatch);
+      mockRamOperations.getRole.mockRejectedValue(new Error('RAM request throttled'));
+
+      const plan = await generateFunctionPlan(mockContext, state, [fn]);
+
+      expect(plan.items[0]).toMatchObject({
+        logicalId: 'functions.test_fn',
+        action: 'noop',
+        resourceType: 'ALIYUN_FC3',
+      });
+    });
+
     it('skips role-policy compare when the role is shared across functions (noop)', async () => {
       const fn: FunctionDomain = {
         ...testFunction,
@@ -1012,6 +1033,185 @@ describe('FC3 Planner', () => {
       });
       expect(mockRamOperations.getExecutionPolicyDocument).not.toHaveBeenCalled();
       expect(mockRamOperations.listAttachedRolePolicies).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('live drift shape parity for container & nas functions (issue #234)', () => {
+    // State definitions are built with the same extractor the planner uses, so
+    // any shape drift between cloudFc3ToDefinition and the desired definition
+    // surfaces here as a failed noop expectation.
+    const buildStateFromDefinition = async (fn: FunctionDomain): Promise<StateFile> => {
+      const codeHash = fn.code ? await computeZipContentHash(fn.code.path) : null;
+      const definition = extractFunctionDomainDefinition(fn, codeHash);
+      return setResource(initalState, `functions.${fn.key}`, {
+        mode: 'managed',
+        region: 'cn-hangzhou',
+        definition,
+        instances: [
+          {
+            sid: 'si:aliyun:fc3:default:test-function',
+            id: 'test-function',
+            functionName: 'test-function',
+          },
+        ],
+        lastUpdated: new Date().toISOString(),
+      });
+    };
+
+    it('stays noop for a container function without cmd even when the cloud reports image defaults', async () => {
+      const containerFn: FunctionDomain = {
+        key: 'test_fn',
+        name: 'test-function',
+        container: { image: 'registry.example.com/app:latest', port: 8080 },
+        memory: 512,
+        timeout: 60,
+        storage: {},
+      };
+      mockFc3Operations.getFunction.mockResolvedValue({
+        functionName: 'test-function',
+        runtime: 'custom-container',
+        handler: 'index.handler',
+        memorySize: 512,
+        timeout: 60,
+        customContainerConfig: {
+          image: 'registry.example.com/app:latest',
+          port: 8080,
+          entrypoint: ['/bin/sh'],
+          accelerationType: 'Default',
+        },
+      });
+
+      const plan = await generateFunctionPlan(
+        mockContext,
+        await buildStateFromDefinition(containerFn),
+        [containerFn],
+      );
+
+      expect(plan.items[0]).toMatchObject({
+        logicalId: 'functions.test_fn',
+        action: 'noop',
+        resourceType: 'ALIYUN_FC3',
+      });
+    });
+
+    it('flags update+drifted for a container function whose image or port changed live', async () => {
+      const containerFn: FunctionDomain = {
+        key: 'test_fn',
+        name: 'test-function',
+        container: { image: 'registry.example.com/app:latest', port: 8080 },
+        memory: 512,
+        timeout: 60,
+        storage: {},
+      };
+      mockFc3Operations.getFunction.mockResolvedValue({
+        functionName: 'test-function',
+        runtime: 'custom-container',
+        handler: 'index.handler',
+        memorySize: 512,
+        timeout: 60,
+        customContainerConfig: {
+          image: 'registry.example.com/app:v2',
+          port: 9090,
+        },
+      });
+
+      const plan = await generateFunctionPlan(
+        mockContext,
+        await buildStateFromDefinition(containerFn),
+        [containerFn],
+      );
+
+      expect(plan.items[0]).toMatchObject({
+        logicalId: 'functions.test_fn',
+        action: 'update',
+        drifted: true,
+      });
+    });
+
+    it('stays noop for a nas function when the cloud mirrors the declared mount points', async () => {
+      const nasFn: FunctionDomain = {
+        ...testFunction,
+        storage: {
+          nas: [
+            {
+              storage_class: NasStorageClassEnum.STANDARD_CAPACITY,
+              mount_path: '/mnt/data',
+            },
+          ],
+        },
+      };
+      mockFc3Operations.getFunction.mockResolvedValue({
+        functionName: 'test-function',
+        runtime: 'nodejs20',
+        handler: 'index.handler',
+        memorySize: 512,
+        timeout: 10,
+        environmentVariables: { NODE_ENV: 'production' },
+        nasConfig: {
+          userId: 10003,
+          groupId: 10003,
+          mountPoints: [
+            {
+              serverAddr: NasStorageClassEnum.STANDARD_CAPACITY,
+              mountDir: '/mnt/data',
+              enableTls: false,
+            },
+          ],
+        },
+      });
+
+      const plan = await generateFunctionPlan(mockContext, await buildStateFromDefinition(nasFn), [
+        nasFn,
+      ]);
+
+      expect(plan.items[0]).toMatchObject({
+        logicalId: 'functions.test_fn',
+        action: 'noop',
+        resourceType: 'ALIYUN_FC3',
+      });
+    });
+
+    it('flags update+drifted for a nas function whose mount points changed live', async () => {
+      const nasFn: FunctionDomain = {
+        ...testFunction,
+        storage: {
+          nas: [
+            {
+              storage_class: NasStorageClassEnum.STANDARD_CAPACITY,
+              mount_path: '/mnt/data',
+            },
+          ],
+        },
+      };
+      mockFc3Operations.getFunction.mockResolvedValue({
+        functionName: 'test-function',
+        runtime: 'nodejs20',
+        handler: 'index.handler',
+        memorySize: 512,
+        timeout: 10,
+        environmentVariables: { NODE_ENV: 'production' },
+        nasConfig: {
+          userId: 10003,
+          groupId: 10003,
+          mountPoints: [
+            {
+              serverAddr: NasStorageClassEnum.STANDARD_CAPACITY,
+              mountDir: '/mnt/other',
+              enableTls: false,
+            },
+          ],
+        },
+      });
+
+      const plan = await generateFunctionPlan(mockContext, await buildStateFromDefinition(nasFn), [
+        nasFn,
+      ]);
+
+      expect(plan.items[0]).toMatchObject({
+        logicalId: 'functions.test_fn',
+        action: 'update',
+        drifted: true,
+      });
     });
   });
 });

--- a/tests/unit/stack/aliyunStack/fc3Planner.test.ts
+++ b/tests/unit/stack/aliyunStack/fc3Planner.test.ts
@@ -1,7 +1,13 @@
 import { ProviderEnum, buildFunctionRoleName, setResource } from '../../../../src/common';
 import { createRefreshCache } from '../../../../src/common/refreshCache';
 import { generateFunctionPlan } from '../../../../src/stack/aliyunStack/fc3Planner';
-import { Context, CURRENT_STATE_VERSION, FunctionDomain } from '../../../../src/types';
+import {
+  Context,
+  CURRENT_STATE_VERSION,
+  FunctionDomain,
+  ResourceInstance,
+  StateFile,
+} from '../../../../src/types';
 
 const initalState = {
   version: CURRENT_STATE_VERSION,
@@ -24,6 +30,8 @@ const mockEcsOperations = {
 };
 const mockRamOperations = {
   getRole: jest.fn(),
+  getExecutionPolicyDocument: jest.fn(),
+  listAttachedRolePolicies: jest.fn(),
 };
 
 jest.mock('../../../../src/common/aliyunClient', () => ({
@@ -663,6 +671,347 @@ describe('FC3 Planner', () => {
 
       expect(plan.items[0]).toMatchObject({ action: 'noop' });
       expect(mockRamOperations.getRole).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('live attribute & role-policy drift (issue #234 phase 1)', () => {
+    const remoteFunctionMatch = {
+      functionName: 'test-function',
+      runtime: 'nodejs20',
+      handler: 'index.handler',
+      memorySize: 512,
+      timeout: 10,
+      environmentVariables: { NODE_ENV: 'production' },
+    };
+
+    const fc3Instance = {
+      sid: 'si:aliyun:fc3:default:test-function',
+      id: 'test-function',
+      functionName: 'test-function',
+    };
+
+    const roleInstance = {
+      sid: 'si:aliyun:ram:default:test-managed-role',
+      id: 'test-managed-role',
+      type: 'ALIYUN_RAM_ROLE',
+      roleArn: 'acs:ram::123456789012:role/test-managed-role',
+    };
+
+    // Docs mirroring what the executor writes for a plain fn (no network/nas,
+    // logConfig undefined): the planner compares parsed JSON against these.
+    const FC_TRUST_FC_ONLY = JSON.stringify({
+      Version: '1',
+      Statement: [
+        {
+          Action: 'sts:AssumeRole',
+          Effect: 'Allow',
+          Principal: { Service: ['fc.aliyuncs.com'] },
+        },
+      ],
+    });
+    const FC_TRUST_WITH_APIGATEWAY = JSON.stringify({
+      Version: '1',
+      Statement: [
+        {
+          Action: 'sts:AssumeRole',
+          Effect: 'Allow',
+          Principal: { Service: ['fc.aliyuncs.com', 'apigateway.aliyuncs.com'] },
+        },
+      ],
+    });
+    const buildExecDoc = (extraStatements: Array<Record<string, unknown>> = []): string =>
+      JSON.stringify({
+        Statement: [
+          {
+            Effect: 'Allow',
+            Action: ['fc:InvokeFunction'],
+            Resource: ['acs:fc:cn-hangzhou:123456789012:functions/test-function'],
+          },
+          {
+            Effect: 'Allow',
+            Action: [
+              'log:PostLogStoreLogs',
+              'log:CreateLogStore',
+              'log:GetLogStore',
+              'log:ListShards',
+              'log:GetCursorOrData',
+            ],
+            Resource: ['*'],
+          },
+          ...extraStatements,
+        ],
+        Version: '1',
+      });
+    const EXEC_BASELINE_DOC = buildExecDoc();
+
+    const definitionFor = (fn: FunctionDomain): Record<string, unknown> => ({
+      functionName: fn.name,
+      runtime: 'nodejs20',
+      handler: 'index.handler',
+      memorySize: fn.memory ?? 512,
+      timeout: fn.timeout ?? 10,
+      diskSize: null,
+      environment: fn.environment ?? {},
+      vpcConfig: null,
+      gpuConfig: null,
+      customContainerConfig: null,
+      nasConfig: null,
+      logConfig: fn.log ? { enableRequestMetrics: true, enableInstanceMetrics: true } : null,
+      codeHash: 'mock-code-hash',
+      ...(fn.iam ? { iam: fn.iam } : {}),
+    });
+
+    const buildState = (fn: FunctionDomain, instances: ResourceInstance[]): StateFile =>
+      setResource(initalState, `functions.${fn.key}`, {
+        mode: 'managed',
+        region: 'cn-hangzhou',
+        definition: definitionFor(fn),
+        instances,
+        lastUpdated: new Date().toISOString(),
+      });
+
+    it('flags update+drifted when the live memorySize drifted from the stored definition', async () => {
+      const fn = testFunction;
+      const state = buildState(fn, [fc3Instance]);
+      mockFc3Operations.getFunction.mockResolvedValue({ ...remoteFunctionMatch, memorySize: 256 });
+
+      const plan = await generateFunctionPlan(mockContext, state, [fn]);
+
+      expect(plan.items[0]).toMatchObject({
+        logicalId: 'functions.test_fn',
+        action: 'update',
+        resourceType: 'ALIYUN_FC3',
+        drifted: true,
+      });
+    });
+
+    it('flags update+drifted when the live timeout/environment drifted', async () => {
+      const fn = testFunction;
+      const state = buildState(fn, [fc3Instance]);
+      mockFc3Operations.getFunction.mockResolvedValue({
+        ...remoteFunctionMatch,
+        timeout: 30,
+        environmentVariables: { NODE_ENV: 'production', LOG_LEVEL: 'debug' },
+      });
+
+      const plan = await generateFunctionPlan(mockContext, state, [fn]);
+
+      expect(plan.items[0]).toMatchObject({
+        logicalId: 'functions.test_fn',
+        action: 'update',
+        drifted: true,
+      });
+    });
+
+    it('stays noop when a richer matching remote returns cloud-only fields', async () => {
+      const fn = testFunction;
+      const state = buildState(fn, [fc3Instance]);
+      mockFc3Operations.getFunction.mockResolvedValue({
+        ...remoteFunctionMatch,
+        cpu: 0.35,
+        codeChecksum: 'checksum-abc',
+        codeSize: 1024,
+        state: 'Running',
+        createdTime: '2025-01-01T00:00:00Z',
+        lastModifiedTime: '2025-02-01T00:00:00Z',
+        instanceConcurrency: 10,
+        idleTimeout: 60,
+        layers: [],
+        customDNS: { nameServers: ['100.100.2.136'] },
+      });
+
+      const plan = await generateFunctionPlan(mockContext, state, [fn]);
+
+      expect(plan.items[0]).toMatchObject({
+        logicalId: 'functions.test_fn',
+        action: 'noop',
+      });
+    });
+
+    it('flags update+drifted when the role trust policy drifted (single owner)', async () => {
+      const fn: FunctionDomain = {
+        ...testFunction,
+        iam: { role: { name: 'test-managed-role' } },
+      };
+      const state = buildState(fn, [fc3Instance, roleInstance]);
+      mockFc3Operations.getFunction.mockResolvedValue(remoteFunctionMatch);
+      mockRamOperations.getRole.mockResolvedValue({
+        roleName: 'test-managed-role',
+        assumeRolePolicyDocument: FC_TRUST_WITH_APIGATEWAY,
+      });
+      mockRamOperations.getExecutionPolicyDocument.mockResolvedValue(EXEC_BASELINE_DOC);
+      mockRamOperations.listAttachedRolePolicies.mockResolvedValue([]);
+
+      const plan = await generateFunctionPlan(mockContext, state, [fn]);
+
+      expect(plan.items[0]).toMatchObject({
+        logicalId: 'functions.test_fn',
+        action: 'update',
+        drifted: true,
+      });
+      expect(mockRamOperations.getRole).toHaveBeenCalledWith('test-managed-role');
+      // trust drift short-circuits before the execution-policy/managed reads.
+      expect(mockRamOperations.getExecutionPolicyDocument).not.toHaveBeenCalled();
+    });
+
+    it('flags update+drifted when the execution/custom policy drifted', async () => {
+      const fn: FunctionDomain = {
+        ...testFunction,
+        iam: {
+          role: {
+            name: 'test-managed-role',
+            statements: [{ effect: 'Allow' as const, action: ['oss:GetObject'], resource: ['*'] }],
+          },
+        },
+      };
+      const state = buildState(fn, [fc3Instance, roleInstance]);
+      mockFc3Operations.getFunction.mockResolvedValue(remoteFunctionMatch);
+      mockRamOperations.getRole.mockResolvedValue({
+        roleName: 'test-managed-role',
+        assumeRolePolicyDocument: FC_TRUST_FC_ONLY,
+      });
+      // Cloud policy is missing the custom statement the config declares.
+      mockRamOperations.getExecutionPolicyDocument.mockResolvedValue(EXEC_BASELINE_DOC);
+      mockRamOperations.listAttachedRolePolicies.mockResolvedValue([]);
+
+      const plan = await generateFunctionPlan(mockContext, state, [fn]);
+
+      expect(plan.items[0]).toMatchObject({
+        logicalId: 'functions.test_fn',
+        action: 'update',
+        drifted: true,
+      });
+    });
+
+    it('flags update+drifted when the attached managed policies drifted', async () => {
+      const fn: FunctionDomain = {
+        ...testFunction,
+        iam: {
+          role: {
+            name: 'test-managed-role',
+            managed_policies: ['acs:ram::123456789012:policy/AliyunLogFullAccess'],
+          },
+        },
+      };
+      const state = buildState(fn, [fc3Instance, roleInstance]);
+      mockFc3Operations.getFunction.mockResolvedValue(remoteFunctionMatch);
+      mockRamOperations.getRole.mockResolvedValue({
+        roleName: 'test-managed-role',
+        assumeRolePolicyDocument: FC_TRUST_FC_ONLY,
+      });
+      mockRamOperations.getExecutionPolicyDocument.mockResolvedValue(EXEC_BASELINE_DOC);
+      mockRamOperations.listAttachedRolePolicies.mockResolvedValue(['AliyunOSSFullAccess']);
+
+      const plan = await generateFunctionPlan(mockContext, state, [fn]);
+
+      expect(plan.items[0]).toMatchObject({
+        logicalId: 'functions.test_fn',
+        action: 'update',
+        drifted: true,
+      });
+      expect(mockRamOperations.listAttachedRolePolicies).toHaveBeenCalledWith('test-managed-role');
+    });
+
+    it('stays noop when trust, execution/custom and managed policies all match', async () => {
+      const fn: FunctionDomain = {
+        ...testFunction,
+        iam: { role: { name: 'test-managed-role' } },
+      };
+      const state = buildState(fn, [fc3Instance, roleInstance]);
+      mockFc3Operations.getFunction.mockResolvedValue(remoteFunctionMatch);
+      mockRamOperations.getRole.mockResolvedValue({
+        roleName: 'test-managed-role',
+        assumeRolePolicyDocument: FC_TRUST_FC_ONLY,
+      });
+      mockRamOperations.getExecutionPolicyDocument.mockResolvedValue(EXEC_BASELINE_DOC);
+      mockRamOperations.listAttachedRolePolicies.mockResolvedValue([]);
+
+      const plan = await generateFunctionPlan(mockContext, state, [fn]);
+
+      expect(plan.items[0]).toMatchObject({
+        logicalId: 'functions.test_fn',
+        action: 'noop',
+      });
+      expect(mockRamOperations.getExecutionPolicyDocument).toHaveBeenCalledWith(
+        'test-managed-role',
+      );
+      expect(mockRamOperations.listAttachedRolePolicies).toHaveBeenCalledWith('test-managed-role');
+    });
+
+    it('skips role-policy compare when the role is shared across functions (noop)', async () => {
+      const fn: FunctionDomain = {
+        ...testFunction,
+        iam: { role: { name: 'test-managed-role' } },
+      };
+      let state = buildState(fn, [fc3Instance, roleInstance]);
+      state = setResource(state, 'functions.other_fn', {
+        mode: 'managed',
+        region: 'cn-hangzhou',
+        definition: {
+          functionName: 'other-function',
+          runtime: 'nodejs20',
+          handler: 'index.handler',
+          memorySize: 128,
+          timeout: 3,
+          diskSize: null,
+          environment: {},
+          vpcConfig: null,
+          gpuConfig: null,
+          customContainerConfig: null,
+          nasConfig: null,
+          logConfig: null,
+          codeHash: 'other-hash',
+        },
+        instances: [
+          {
+            sid: 'si:aliyun:fc3:default:other-function',
+            id: 'other-function',
+            type: 'ALIYUN_FC3_FUNCTION',
+          },
+          roleInstance,
+        ],
+        lastUpdated: new Date().toISOString(),
+      });
+      mockFc3Operations.getFunction.mockResolvedValue(remoteFunctionMatch);
+      mockRamOperations.getRole.mockResolvedValue({
+        roleName: 'test-managed-role',
+        assumeRolePolicyDocument: FC_TRUST_WITH_APIGATEWAY,
+      });
+
+      const plan = await generateFunctionPlan(mockContext, state, [fn]);
+
+      const fnItem = plan.items.find((item) => item.logicalId === 'functions.test_fn');
+      expect(fnItem).toMatchObject({ action: 'noop' });
+      expect(mockRamOperations.getExecutionPolicyDocument).not.toHaveBeenCalled();
+      expect(mockRamOperations.listAttachedRolePolicies).not.toHaveBeenCalled();
+    });
+
+    it('skips role-policy compare when logConfig is not derivable from state (noop)', async () => {
+      const fn: FunctionDomain = {
+        ...testFunction,
+        log: true,
+        iam: { role: { name: 'test-managed-role' } },
+      };
+      // Logging enabled but NO recorded SLS logstore instance: the executor
+      // would create one during update, so the planner cannot derive logConfig.
+      const state = buildState(fn, [fc3Instance, roleInstance]);
+      mockFc3Operations.getFunction.mockResolvedValue({
+        ...remoteFunctionMatch,
+        logConfig: { enableRequestMetrics: true, enableInstanceMetrics: true },
+      });
+      mockRamOperations.getRole.mockResolvedValue({
+        roleName: 'test-managed-role',
+        assumeRolePolicyDocument: FC_TRUST_WITH_APIGATEWAY,
+      });
+
+      const plan = await generateFunctionPlan(mockContext, state, [fn]);
+
+      expect(plan.items[0]).toMatchObject({
+        logicalId: 'functions.test_fn',
+        action: 'noop',
+      });
+      expect(mockRamOperations.getExecutionPolicyDocument).not.toHaveBeenCalled();
+      expect(mockRamOperations.listAttachedRolePolicies).not.toHaveBeenCalled();
     });
   });
 });

--- a/tests/unit/stack/aliyunStack/fc3Types.test.ts
+++ b/tests/unit/stack/aliyunStack/fc3Types.test.ts
@@ -1,7 +1,9 @@
 import {
   functionToFc3Config,
   extractFc3Definition,
+  cloudFc3ToDefinition,
 } from '../../../../src/stack/aliyunStack/fc3Types';
+import type { Fc3FunctionInfo } from '../../../../src/stack/aliyunStack/fc3Types';
 import { FunctionDomain, FunctionGpuEnum } from '../../../../src/types';
 
 describe('FC3 Types', () => {
@@ -227,6 +229,166 @@ describe('FC3 Types', () => {
         gpuMemorySize: 8192,
         gpuType: 'fc.gpu.tesla.1',
       });
+    });
+  });
+
+  describe('cloudFc3ToDefinition', () => {
+    it('should map a full cloud Fc3FunctionInfo to the definition shape', () => {
+      const info: Fc3FunctionInfo = {
+        functionName: 'my-function',
+        runtime: 'nodejs20',
+        handler: 'index.handler',
+        memorySize: 512,
+        timeout: 30,
+        diskSize: 1024,
+        environmentVariables: { NODE_ENV: 'production', LOG_LEVEL: 'info' },
+        vpcConfig: {
+          vpcId: 'vpc-abc',
+          vSwitchIds: ['vsw-1', 'vsw-2'],
+          securityGroupId: 'sg-xyz',
+          role: 'acs:ram::123456789:role/extra-vpc-role',
+        },
+        gpuConfig: { gpuMemorySize: 8192, gpuType: 'fc.gpu.tesla.1' },
+        customContainerConfig: {
+          image: 'registry.example.com/app:latest',
+          entrypoint: ['/bin/sh'],
+          command: ['-c', 'start'],
+          port: 8080,
+          accelerationType: 'Default',
+          acrInstanceId: 'cri-12345',
+        },
+        nasConfig: {
+          userId: 10003,
+          groupId: 10003,
+          mountPoints: [
+            {
+              serverAddr: '0123456789-abc.cn-hangzhou.nas.aliyuncs.com:/data',
+              mountDir: '/mnt/data',
+              enableTls: false,
+            },
+          ],
+        },
+        logConfig: {
+          project: 'my-project',
+          logstore: 'my-logstore',
+          enableRequestMetrics: true,
+          enableInstanceMetrics: false,
+          logBeginRule: 'DefaultRegex',
+        },
+      };
+
+      expect(cloudFc3ToDefinition(info)).toEqual({
+        functionName: 'my-function',
+        runtime: 'nodejs20',
+        handler: 'index.handler',
+        memorySize: 512,
+        timeout: 30,
+        diskSize: 1024,
+        environment: { NODE_ENV: 'production', LOG_LEVEL: 'info' },
+        vpcConfig: { vpcId: 'vpc-abc', vSwitchIds: ['vsw-1', 'vsw-2'], securityGroupId: 'sg-xyz' },
+        gpuConfig: { gpuMemorySize: 8192, gpuType: 'fc.gpu.tesla.1' },
+        customContainerConfig: {
+          image: 'registry.example.com/app:latest',
+          entrypoint: ['/bin/sh'],
+          command: ['-c', 'start'],
+          port: 8080,
+          accelerationType: 'Default',
+        },
+        nasConfig: {
+          userId: 10003,
+          groupId: 10003,
+          mountPoints: [
+            {
+              serverAddr: '0123456789-abc.cn-hangzhou.nas.aliyuncs.com:/data',
+              mountDir: '/mnt/data',
+            },
+          ],
+        },
+        logConfig: { enableRequestMetrics: true, enableInstanceMetrics: false },
+      });
+    });
+
+    it('should map a minimal info to nulls and empties for the rest', () => {
+      const info: Fc3FunctionInfo = { functionName: 'minimal-function', memorySize: 128 };
+
+      expect(cloudFc3ToDefinition(info)).toEqual({
+        functionName: 'minimal-function',
+        runtime: null,
+        handler: null,
+        memorySize: 128,
+        timeout: null,
+        diskSize: null,
+        environment: {},
+        vpcConfig: null,
+        gpuConfig: null,
+        customContainerConfig: null,
+        nasConfig: null,
+        logConfig: null,
+      });
+    });
+
+    it('should keep logConfig null when the cloud response has none', () => {
+      const info: Fc3FunctionInfo = {
+        functionName: 'no-log-function',
+        runtime: 'python3.10',
+        handler: 'handler.main',
+        memorySize: 256,
+        timeout: 10,
+      };
+
+      const result = cloudFc3ToDefinition(info);
+
+      expect(result.logConfig).toBeNull();
+      expect(result).toEqual({
+        functionName: 'no-log-function',
+        runtime: 'python3.10',
+        handler: 'handler.main',
+        memorySize: 256,
+        timeout: 10,
+        diskSize: null,
+        environment: {},
+        vpcConfig: null,
+        gpuConfig: null,
+        customContainerConfig: null,
+        nasConfig: null,
+        logConfig: null,
+      });
+    });
+
+    it('should never emit codeHash, role, iam, or description keys', () => {
+      const info: Fc3FunctionInfo = {
+        functionName: 'roleful-function',
+        runtime: 'nodejs20',
+        handler: 'index.handler',
+        memorySize: 512,
+        timeout: 30,
+        role: 'acs:ram::123456789:role/my-execution-role',
+        description: 'deployed by si',
+        codeChecksum: 'deadbeef',
+      };
+
+      const result = cloudFc3ToDefinition(info);
+
+      expect(result).not.toHaveProperty('codeHash');
+      expect(result).not.toHaveProperty('role');
+      expect(result).not.toHaveProperty('iam');
+      expect(result).not.toHaveProperty('description');
+      expect(Object.keys(result).sort()).toEqual(
+        [
+          'customContainerConfig',
+          'diskSize',
+          'environment',
+          'functionName',
+          'gpuConfig',
+          'handler',
+          'logConfig',
+          'memorySize',
+          'nasConfig',
+          'runtime',
+          'timeout',
+          'vpcConfig',
+        ].sort(),
+      );
     });
   });
 });

--- a/tests/unit/stack/aliyunStack/fc3Types.test.ts
+++ b/tests/unit/stack/aliyunStack/fc3Types.test.ts
@@ -1,10 +1,12 @@
 import {
   functionToFc3Config,
   extractFc3Definition,
+  extractFunctionDomainDefinition,
   cloudFc3ToDefinition,
 } from '../../../../src/stack/aliyunStack/fc3Types';
 import type { Fc3FunctionInfo } from '../../../../src/stack/aliyunStack/fc3Types';
-import { FunctionDomain, FunctionGpuEnum } from '../../../../src/types';
+import { remoteDiffersFromDesired } from '../../../../src/common/planCompare';
+import { FunctionDomain, FunctionGpuEnum, NasStorageClassEnum } from '../../../../src/types';
 
 describe('FC3 Types', () => {
   describe('functionToFc3Config', () => {
@@ -289,10 +291,8 @@ describe('FC3 Types', () => {
         gpuConfig: { gpuMemorySize: 8192, gpuType: 'fc.gpu.tesla.1' },
         customContainerConfig: {
           image: 'registry.example.com/app:latest',
-          entrypoint: ['/bin/sh'],
-          command: ['-c', 'start'],
           port: 8080,
-          accelerationType: 'Default',
+          command: ['-c', 'start'],
         },
         nasConfig: {
           userId: 10003,
@@ -301,10 +301,55 @@ describe('FC3 Types', () => {
             {
               serverAddr: '0123456789-abc.cn-hangzhou.nas.aliyuncs.com:/data',
               mountDir: '/mnt/data',
+              enableTls: false,
             },
           ],
         },
         logConfig: { enableRequestMetrics: true, enableInstanceMetrics: false },
+      });
+    });
+
+    it('never emits executor-unmanaged container keys (entrypoint, accelerationType)', () => {
+      const info: Fc3FunctionInfo = {
+        functionName: 'container-fn',
+        runtime: 'custom-container',
+        handler: 'index.handler',
+        memorySize: 512,
+        timeout: 60,
+        customContainerConfig: {
+          image: 'registry.example.com/app:latest',
+          entrypoint: ['/bin/sh'],
+          port: 8080,
+          accelerationType: 'Default',
+        },
+      };
+
+      const attrs = cloudFc3ToDefinition(info);
+
+      expect(attrs.customContainerConfig).toEqual({
+        image: 'registry.example.com/app:latest',
+        port: 8080,
+      });
+      expect(attrs.customContainerConfig).not.toHaveProperty('entrypoint');
+      expect(attrs.customContainerConfig).not.toHaveProperty('accelerationType');
+    });
+
+    it('omits container command when the cloud does not report it', () => {
+      const info: Fc3FunctionInfo = {
+        functionName: 'container-fn',
+        runtime: 'custom-container',
+        handler: 'index.handler',
+        memorySize: 512,
+        timeout: 60,
+        customContainerConfig: {
+          image: 'registry.example.com/app:latest',
+          port: 8080,
+        },
+      };
+
+      expect(cloudFc3ToDefinition(info).customContainerConfig).toEqual({
+        image: 'registry.example.com/app:latest',
+        port: 8080,
       });
     });
 
@@ -389,6 +434,96 @@ describe('FC3 Types', () => {
           'vpcConfig',
         ].sort(),
       );
+    });
+  });
+
+  describe('cloudFc3ToDefinition roundtrip vs desired definition (issue #234)', () => {
+    // functionToFc3Config field names align with Fc3FunctionInfo, so its output
+    // is a faithful "cloud as the executor wrote it" simulation. This guard
+    // keeps cloudFc3ToDefinition and functionToFc3Config shape-compatible.
+    const expectNoRoundtripDrift = (fn: FunctionDomain): void => {
+      const desired = extractFunctionDomainDefinition(fn, 'abc123');
+      const cloudInfo = functionToFc3Config(fn) as unknown as Fc3FunctionInfo;
+
+      expect(remoteDiffersFromDesired(cloudFc3ToDefinition(cloudInfo), desired)).toBe(false);
+    };
+
+    it('plain code function', () => {
+      expectNoRoundtripDrift({
+        key: 'test_fn',
+        name: 'code-fn',
+        code: { runtime: 'nodejs20', handler: 'index.handler', path: 'test.zip' },
+        memory: 512,
+        timeout: 10,
+        environment: { NODE_ENV: 'production' },
+        storage: {},
+      });
+    });
+
+    it('code function with vpc, gpu, nas and log config', () => {
+      expectNoRoundtripDrift({
+        key: 'test_fn',
+        name: 'full-fn',
+        code: { runtime: 'nodejs20', handler: 'index.handler', path: 'test.zip' },
+        memory: 512,
+        timeout: 10,
+        environment: { NODE_ENV: 'production' },
+        gpu: FunctionGpuEnum.TESLA_8,
+        network: {
+          vpc_id: 'vpc-12345',
+          subnet_ids: ['vsw-123', 'vsw-456'],
+          security_group: { name: 'sg-12345', ingress: [], egress: [] },
+        },
+        storage: {
+          nas: [
+            {
+              storage_class: NasStorageClassEnum.STANDARD_CAPACITY,
+              mount_path: '/mnt/data',
+            },
+          ],
+        },
+        log: true,
+      });
+    });
+
+    it('container function with cmd declared', () => {
+      expectNoRoundtripDrift({
+        key: 'test_fn',
+        name: 'container-fn',
+        container: {
+          image: 'registry.example.com/app:latest',
+          cmd: 'python app.py',
+          port: 8080,
+        },
+        memory: 512,
+        timeout: 60,
+        storage: {},
+      });
+    });
+
+    it('container function without cmd declared', () => {
+      expectNoRoundtripDrift({
+        key: 'test_fn',
+        name: 'container-no-cmd-fn',
+        container: {
+          image: 'registry.example.com/app:latest',
+          port: 8080,
+        },
+        memory: 512,
+        timeout: 60,
+        storage: {},
+      });
+    });
+
+    it('function without environment declared (desired env {} vs cloud env {}) stays noop', () => {
+      expectNoRoundtripDrift({
+        key: 'test_fn',
+        name: 'envless-fn',
+        code: { runtime: 'nodejs20', handler: 'index.handler', path: 'test.zip' },
+        memory: 128,
+        timeout: 60,
+        storage: {},
+      });
     });
   });
 });

--- a/tests/unit/stack/aliyunStack/ossPlanner.test.ts
+++ b/tests/unit/stack/aliyunStack/ossPlanner.test.ts
@@ -63,6 +63,33 @@ describe('OSS Planner', () => {
     },
   };
 
+  const stateForDefinition = (definition: Record<string, unknown>) =>
+    setResource(initialState, 'buckets.test_bucket', {
+      mode: 'managed',
+      region: 'cn-hangzhou',
+      definition,
+      instances: [],
+      lastUpdated: new Date().toISOString(),
+    });
+
+  const baseDefinition = {
+    bucketName: 'test-bucket',
+    acl: 'private',
+    websiteConfiguration: { indexDocument: 'index.html', errorDocument: 'index.html' },
+    websiteCodeHash: 'mock-website-hash',
+    storageClass: null,
+    domain: null,
+    wwwBindApex: false,
+    domainCertificateId: null,
+    domainCertificateBody: null,
+    domainCertificatePrivateKey: null,
+    domainProtocol: null,
+    policy: null,
+    versioningStatus: null,
+    sseAlgorithm: null,
+    sseKmsMasterKeyId: null,
+  };
+
   afterEach(() => {
     jest.clearAllMocks();
   });
@@ -202,6 +229,10 @@ describe('OSS Planner', () => {
           indexDocument: 'index.html',
           errorDocument: 'index.html',
         },
+        tags: [{ key: 'environment', value: 'production' }],
+        location: 'oss-cn-hangzhou',
+        transferAccelerationStatus: 'Disabled',
+        domain: 'console.example.com',
       });
 
       const state = setResource(initialState, 'buckets.test_bucket', {
@@ -245,6 +276,59 @@ describe('OSS Planner', () => {
         action: 'noop',
         resourceType: 'ALIYUN_OSS_BUCKET',
       });
+    });
+
+    it('should plan live ACL drift as an update', async () => {
+      mockOssOperations.getBucket.mockResolvedValue({
+        name: 'test-bucket',
+        acl: 'public-read',
+      });
+
+      const desiredBucket = {
+        ...testBucket,
+        security: { acl: BucketAccessEnum.PRIVATE, force_delete: false },
+      };
+
+      const plan = await generateBucketPlan(mockContext, stateForDefinition(baseDefinition), [
+        desiredBucket,
+      ]);
+
+      expect(plan.items[0]).toMatchObject({ action: 'update', drifted: true });
+    });
+
+    it('should plan live website configuration drift as an update', async () => {
+      mockOssOperations.getBucket.mockResolvedValue({
+        name: 'test-bucket',
+        websiteConfig: { indexDocument: 'console.html', errorDocument: 'index.html' },
+      });
+
+      const plan = await generateBucketPlan(mockContext, stateForDefinition(baseDefinition), [
+        testBucket,
+      ]);
+
+      expect(plan.items[0]).toMatchObject({ action: 'update', drifted: true });
+    });
+
+    it('should plan live versioning drift as an update', async () => {
+      mockOssOperations.getBucket.mockResolvedValue({
+        name: 'test-bucket',
+        versioningConfig: { status: 'Suspended' },
+      });
+
+      const desiredBucket: BucketDomain = {
+        ...testBucket,
+        versioning: { status: 'Enabled' },
+      };
+      const desiredDefinition = {
+        ...baseDefinition,
+        versioningStatus: 'Enabled',
+      };
+
+      const plan = await generateBucketPlan(mockContext, stateForDefinition(desiredDefinition), [
+        desiredBucket,
+      ]);
+
+      expect(plan.items[0]).toMatchObject({ action: 'update', drifted: true });
     });
 
     it('should plan to update when domain binding previously failed (domainBound: false)', async () => {

--- a/tests/unit/stack/aliyunStack/ossTypes.test.ts
+++ b/tests/unit/stack/aliyunStack/ossTypes.test.ts
@@ -1,7 +1,9 @@
 import {
   bucketToOssBucketConfig,
+  cloudOssToDefinition,
   extractOssBucketDefinition,
 } from '../../../../src/stack/aliyunStack/ossTypes';
+import type { OssBucketInfo } from '../../../../src/common/aliyunClient/ossOperations';
 import { BucketDomain, BucketAccessEnum } from '../../../../src/types';
 import { BucketACL } from '../../../../src/stack/bucketTypes';
 
@@ -306,6 +308,100 @@ describe('OssTypes', () => {
       expect(definition.versioningStatus).toBeNull();
       expect(definition.sseAlgorithm).toBeNull();
       expect(definition.sseKmsMasterKeyId).toBeNull();
+    });
+  });
+
+  describe('cloudOssToDefinition', () => {
+    it('maps reconciliable attributes from a complete cloud bucket response', () => {
+      // Given: a cloud response with every attribute this mapper can compare
+      const info: OssBucketInfo = {
+        name: 'production-assets',
+        acl: 'public-read',
+        websiteConfig: {
+          indexDocument: 'index.html',
+          errorDocument: '404.html',
+        },
+        storageClass: 'Standard',
+        versioningConfig: { status: 'Enabled' },
+        encryptionConfig: { sseAlgorithm: 'AES256' },
+        transferAccelerationStatus: 'Enabled',
+        policy: '{"Version":"1"}',
+      };
+
+      // When: the cloud response is converted to a definition
+      const definition = cloudOssToDefinition(info);
+
+      // Then: only reconcilable definition keys are emitted
+      expect(definition).toEqual({
+        bucketName: 'production-assets',
+        acl: 'public-read',
+        websiteConfiguration: {
+          indexDocument: 'index.html',
+          errorDocument: '404.html',
+        },
+        storageClass: 'Standard',
+        versioningStatus: 'Enabled',
+        sseAlgorithm: 'AES256',
+        policy: '{"Version":"1"}',
+      });
+    });
+
+    it('maps only bucket name and ACL for a minimal response', () => {
+      // Given: a response with only the bucket identity and ACL
+      const info: OssBucketInfo = { name: 'minimal-bucket', acl: 'private' };
+
+      // When: the response is converted
+      const definition = cloudOssToDefinition(info);
+
+      // Then: unreadable and config-only attributes are absent
+      expect(definition).toEqual({ bucketName: 'minimal-bucket', acl: 'private' });
+      expect(definition).not.toHaveProperty('websiteConfiguration');
+      expect(definition).not.toHaveProperty('storageClass');
+      expect(definition).not.toHaveProperty('versioningStatus');
+      expect(definition).not.toHaveProperty('sseAlgorithm');
+      expect(definition).not.toHaveProperty('policy');
+      expect(definition).not.toHaveProperty('websiteCodeHash');
+      expect(definition).not.toHaveProperty('domain');
+      expect(definition).not.toHaveProperty('domainBound');
+      expect(definition).not.toHaveProperty('cdnEnabled');
+    });
+
+    it('omits website configuration when the cloud response has none', () => {
+      // Given: a bucket without website configuration
+      const info: OssBucketInfo = { name: 'api-bucket', acl: 'private' };
+
+      // When: the response is converted
+      const definition = cloudOssToDefinition(info);
+
+      // Then: website configuration is not treated as an empty desired value
+      expect(definition).not.toHaveProperty('websiteConfiguration');
+    });
+
+    it('omits versioning and encryption attributes when cloud data is absent', () => {
+      // Given: a bucket without versioning or encryption configuration
+      const info: OssBucketInfo = { name: 'plain-bucket', acl: 'private' };
+
+      // When: the response is converted
+      const definition = cloudOssToDefinition(info);
+
+      // Then: absent cloud values do not create drift candidates
+      expect(definition).not.toHaveProperty('versioningStatus');
+      expect(definition).not.toHaveProperty('sseAlgorithm');
+    });
+
+    it('does not include cloud tags in the definition', () => {
+      // Given: a bucket response containing provider tags
+      const info: OssBucketInfo = {
+        name: 'tagged-bucket',
+        acl: 'private',
+        tags: [{ key: 'environment', value: 'production' }],
+      };
+
+      // When: the response is converted
+      const definition = cloudOssToDefinition(info);
+
+      // Then: tags remain outside the definition comparison contract
+      expect(definition).not.toHaveProperty('tags');
     });
   });
 });

--- a/tests/unit/stack/aliyunStack/rdsTypes.test.ts
+++ b/tests/unit/stack/aliyunStack/rdsTypes.test.ts
@@ -1,7 +1,9 @@
 import {
+  cloudRdsToDefinition,
   databaseToRdsConfig,
   extractRdsDefinition,
 } from '../../../../src/stack/aliyunStack/rdsTypes';
+import type { RdsInfo } from '../../../../src/common/aliyunClient/rdsOperations';
 import { DatabaseDomain, DatabaseEnum, DatabaseVersionEnum } from '../../../../src/types';
 
 describe('RdsTypes', () => {
@@ -277,6 +279,57 @@ describe('RdsTypes', () => {
 
       expect(definition).not.toHaveProperty('masterUserPassword');
       expect(definition).not.toHaveProperty('MasterUserPassword');
+    });
+  });
+
+  describe('cloudRdsToDefinition', () => {
+    it('maps the reconciled RDS attributes from a full cloud response', () => {
+      const info: RdsInfo = {
+        dbInstanceDescription: 'orders-db',
+        engine: 'MySQL',
+        engineVersion: '8.0',
+        dbInstanceClass: 'mysql.n2.serverless.1c',
+        dbInstanceStorage: 20,
+        category: 'serverless_basic',
+        dbInstanceStorageType: 'general_essd',
+        burstingEnabled: true,
+        serverlessConfig: { minCapacity: 0, maxCapacity: 16, autoPause: true, switchForce: false },
+        multiAZ: false,
+        securityIPList: '10.0.0.0/8,192.168.0.0/16',
+        vpcId: 'vpc-123',
+        vSwitchId: 'vsw-456',
+      };
+
+      expect(cloudRdsToDefinition(info)).toEqual({
+        dbInstanceDescription: 'orders-db',
+        engine: 'MySQL',
+        engineVersion: '8.0',
+        dbInstanceClass: 'mysql.n2.serverless.1c',
+        dbInstanceStorage: 20,
+        category: 'serverless_basic',
+        dbInstanceStorageType: 'general_essd',
+        burstingEnabled: true,
+        serverlessConfig: { minCapacity: 0, maxCapacity: 16, autoPause: true, switchForce: false },
+        multiAZ: false,
+        securityIPList: '10.0.0.0/8,192.168.0.0/16',
+        vpcId: 'vpc-123',
+        vSwitchId: 'vsw-456',
+      });
+    });
+
+    it('omits unavailable and absent attributes', () => {
+      const definition = cloudRdsToDefinition({ dbInstanceId: 'rds-1' });
+
+      expect(definition).toEqual({});
+      expect(definition).not.toHaveProperty('connectionStringType');
+      expect(definition).not.toHaveProperty('dbInstanceNetType');
+      expect(definition).not.toHaveProperty('serverlessConfig');
+    });
+
+    it('omits serverless config when the cloud response has null config', () => {
+      expect(cloudRdsToDefinition({ serverlessConfig: undefined })).not.toHaveProperty(
+        'serverlessConfig',
+      );
     });
   });
 });

--- a/tests/unit/stack/aliyunStack/tablestorePlanner.test.ts
+++ b/tests/unit/stack/aliyunStack/tablestorePlanner.test.ts
@@ -115,7 +115,7 @@ describe('TableStore Planner', () => {
           reservedThroughput: null,
           onDemandThroughput: null,
           tableOptions: null,
-          network: null,
+          network: { type: 'PUBLIC', ingressRules: [] },
         },
         instances: [],
         lastUpdated: new Date().toISOString(),
@@ -163,7 +163,7 @@ describe('TableStore Planner', () => {
           reservedThroughput: null,
           onDemandThroughput: null,
           tableOptions: null,
-          network: null,
+          network: { type: 'PUBLIC', ingressRules: [] },
         },
         instances: [],
         lastUpdated: new Date().toISOString(),
@@ -185,6 +185,18 @@ describe('TableStore Planner', () => {
             write: 5,
           },
         },
+        tableOptions: {
+          timeToLive: -1,
+          maxVersions: 1,
+          maxTimeDeviation: 86400,
+          allowUpdate: true,
+        },
+        streamDetails: {
+          enableStream: true,
+          streamId: 'stream-id',
+          expirationTime: 1234567890,
+        },
+        definedColumn: [{ name: 'id', type: 'INTEGER' }],
       });
 
       const state = setResource(initialState, 'tables.test_table', {
@@ -234,6 +246,144 @@ describe('TableStore Planner', () => {
         logicalId: 'tables.test_table',
         action: 'noop',
         resourceType: 'ALIYUN_TABLESTORE_TABLE',
+      });
+    });
+
+    it('should plan update with drifted when the live cloud table differs from desired', async () => {
+      mockTablestoreOperations.getTable.mockResolvedValue({
+        tableName: 'test-table',
+        primaryKey: [{ name: 'id', type: 'INTEGER' }],
+        reservedThroughputDetails: {
+          capacityUnit: {
+            read: 20,
+            write: 10,
+          },
+        },
+        tableOptions: {
+          timeToLive: -1,
+          maxVersions: 1,
+        },
+      });
+
+      const state = setResource(initialState, 'tables.test_table', {
+        mode: 'managed',
+        region: 'cn-hangzhou',
+        definition: {
+          instanceName: 'test-instance',
+          tableName: 'test-table',
+          clusterType: 'HYBRID',
+          description: null,
+          primaryKey: [{ name: 'id', type: 'INTEGER' }],
+          attributes: [{ name: 'id', type: 'INTEGER' }],
+          reservedThroughput: {
+            capacityUnit: {
+              read: 10,
+              write: 5,
+            },
+          },
+          onDemandThroughput: null,
+          tableOptions: {
+            timeToLive: -1,
+            maxVersions: 1,
+          },
+          network: {
+            type: 'PUBLIC',
+            ingressRules: [],
+          },
+        },
+        instances: [
+          {
+            type: 'ALIYUN_TABLESTORE_TABLE',
+            sid: 'si:aliyun:ots:default:test-instance/test-table',
+            id: 'test-instance/test-table',
+            instanceName: 'test-instance',
+            tableName: 'test-table',
+            clusterType: 'HYBRID',
+            primaryKey: [{ name: 'id', type: 'INTEGER' }],
+          },
+        ],
+        lastUpdated: new Date().toISOString(),
+      });
+
+      const plan = await generateTablePlan(mockContext, state, [testTable]);
+
+      expect(plan.items[0]).toMatchObject({
+        logicalId: 'tables.test_table',
+        action: 'update',
+        resourceType: 'ALIYUN_TABLESTORE_TABLE',
+        drifted: true,
+      });
+    });
+
+    it('should plan noop when the live cloud table matches desired', async () => {
+      mockTablestoreOperations.getTable.mockResolvedValue({
+        tableName: 'test-table',
+        primaryKey: [{ name: 'id', type: 'INTEGER' }],
+        reservedThroughputDetails: {
+          capacityUnit: {
+            read: 10,
+            write: 5,
+          },
+        },
+        tableOptions: {
+          timeToLive: -1,
+          maxVersions: 1,
+          maxTimeDeviation: 86400,
+          allowUpdate: true,
+        },
+        streamDetails: {
+          enableStream: true,
+          streamId: 'stream-id',
+          expirationTime: 1234567890,
+        },
+        definedColumn: [{ name: 'id', type: 'INTEGER' }],
+      });
+
+      const state = setResource(initialState, 'tables.test_table', {
+        mode: 'managed',
+        region: 'cn-hangzhou',
+        definition: {
+          instanceName: 'test-instance',
+          tableName: 'test-table',
+          clusterType: 'HYBRID',
+          description: null,
+          primaryKey: [{ name: 'id', type: 'INTEGER' }],
+          attributes: [{ name: 'id', type: 'INTEGER' }],
+          reservedThroughput: {
+            capacityUnit: {
+              read: 10,
+              write: 5,
+            },
+          },
+          onDemandThroughput: null,
+          tableOptions: {
+            timeToLive: -1,
+            maxVersions: 1,
+          },
+          network: {
+            type: 'PUBLIC',
+            ingressRules: [],
+          },
+        },
+        instances: [
+          {
+            type: 'ALIYUN_TABLESTORE_TABLE',
+            sid: 'si:aliyun:ots:default:test-instance/test-table',
+            id: 'test-instance/test-table',
+            instanceName: 'test-instance',
+            tableName: 'test-table',
+            clusterType: 'HYBRID',
+            primaryKey: [{ name: 'id', type: 'INTEGER' }],
+          },
+        ],
+        lastUpdated: new Date().toISOString(),
+      });
+
+      const plan = await generateTablePlan(mockContext, state, [testTable]);
+
+      expect(plan.items[0]).toMatchObject({
+        logicalId: 'tables.test_table',
+        action: 'noop',
       });
     });
 
@@ -299,6 +449,86 @@ describe('TableStore Planner', () => {
       });
       expect(plan.items[0].changes?.before).toBeDefined();
       expect(plan.items[0].changes?.after).toBeDefined();
+    });
+
+    it('should plan to update when live reserved throughput drifts from desired', async () => {
+      mockTablestoreOperations.getTable.mockResolvedValue({
+        tableName: 'test-table',
+        primaryKey: [{ name: 'id', type: 'INTEGER' }],
+        reservedThroughputDetails: {
+          capacityUnit: {
+            read: 20,
+            write: 8,
+          },
+        },
+        tableOptions: { timeToLive: -1, maxVersions: 1 },
+      });
+
+      const state = setResource(initialState, 'tables.test_table', {
+        mode: 'managed',
+        region: 'cn-hangzhou',
+        definition: {
+          instanceName: 'test-instance',
+          tableName: 'test-table',
+          clusterType: 'HYBRID',
+          description: null,
+          primaryKey: [{ name: 'id', type: 'INTEGER' }],
+          attributes: [{ name: 'id', type: 'INTEGER' }],
+          reservedThroughput: { capacityUnit: { read: 10, write: 5 } },
+          onDemandThroughput: null,
+          tableOptions: { timeToLive: -1, maxVersions: 1 },
+          network: null,
+        },
+        instances: [],
+        lastUpdated: new Date().toISOString(),
+      });
+
+      const plan = await generateTablePlan(mockContext, state, [testTable]);
+
+      expect(plan.items[0]).toMatchObject({
+        action: 'update',
+        drifted: true,
+      });
+    });
+
+    it('should plan to update when live table options drift from desired', async () => {
+      mockTablestoreOperations.getTable.mockResolvedValue({
+        tableName: 'test-table',
+        primaryKey: [{ name: 'id', type: 'INTEGER' }],
+        reservedThroughputDetails: {
+          capacityUnit: {
+            read: 10,
+            write: 5,
+          },
+        },
+        tableOptions: { timeToLive: 3600, maxVersions: 3 },
+      });
+
+      const state = setResource(initialState, 'tables.test_table', {
+        mode: 'managed',
+        region: 'cn-hangzhou',
+        definition: {
+          instanceName: 'test-instance',
+          tableName: 'test-table',
+          clusterType: 'HYBRID',
+          description: null,
+          primaryKey: [{ name: 'id', type: 'INTEGER' }],
+          attributes: [{ name: 'id', type: 'INTEGER' }],
+          reservedThroughput: { capacityUnit: { read: 10, write: 5 } },
+          onDemandThroughput: null,
+          tableOptions: { timeToLive: -1, maxVersions: 1 },
+          network: null,
+        },
+        instances: [],
+        lastUpdated: new Date().toISOString(),
+      });
+
+      const plan = await generateTablePlan(mockContext, state, [testTable]);
+
+      expect(plan.items[0]).toMatchObject({
+        action: 'update',
+        drifted: true,
+      });
     });
 
     it('should plan to create when remote table does not exist', async () => {

--- a/tests/unit/stack/aliyunStack/tablestoreTypes.test.ts
+++ b/tests/unit/stack/aliyunStack/tablestoreTypes.test.ts
@@ -1,7 +1,9 @@
 import {
   tableToTableStoreConfig,
+  cloudTableStoreToDefinition,
   extractTableStoreDefinition,
 } from '../../../../src/stack/aliyunStack/tablestoreTypes';
+import type { TableStoreTableInfo } from '../../../../src/common/aliyunClient/tablestoreOperations';
 import { TableDomain, TableEnum, AttributeTypeEnum, KeyTypeEnum } from '../../../../src/types';
 
 describe('TableStoreTypes', () => {
@@ -339,6 +341,74 @@ describe('TableStoreTypes', () => {
         type: 'PRIVATE',
         ingressRules: ['10.0.0.0/8'],
       });
+    });
+  });
+
+  describe('cloudTableStoreToDefinition', () => {
+    it('maps the reproducible cloud attributes with exact provider value shapes', () => {
+      const info: TableStoreTableInfo = {
+        tableName: 'orders',
+        primaryKey: [
+          { name: 'tenantId', type: 'STRING' },
+          { name: 'createdAt', type: 'INTEGER' },
+        ],
+        reservedThroughputDetails: {
+          capacityUnit: { read: 12, write: 7 },
+          lastIncreaseTime: '2026-09-03T00:00:00Z',
+          lastDecreaseTime: '2026-09-02T00:00:00Z',
+        },
+        tableOptions: {
+          timeToLive: 86400,
+          maxVersions: 3,
+          maxTimeDeviation: 60,
+          allowUpdate: true,
+          bloomFilterType: 'ROW',
+          blockSize: 4096,
+        },
+      };
+
+      expect(cloudTableStoreToDefinition(info)).toEqual({
+        tableName: 'orders',
+        primaryKey: [
+          { name: 'tenantId', type: 'STRING' },
+          { name: 'createdAt', type: 'INTEGER' },
+        ],
+        reservedThroughput: {
+          capacityUnit: { read: 12, write: 7 },
+        },
+        tableOptions: { timeToLive: 86400, maxVersions: 3 },
+      });
+    });
+
+    it('emits only tableName when cloud details are unavailable', () => {
+      const definition = cloudTableStoreToDefinition({ tableName: 'orders' });
+
+      expect(definition).toEqual({ tableName: 'orders' });
+      expect(definition).not.toHaveProperty('instanceName');
+      expect(definition).not.toHaveProperty('clusterType');
+      expect(definition).not.toHaveProperty('description');
+      expect(definition).not.toHaveProperty('attributes');
+      expect(definition).not.toHaveProperty('onDemandThroughput');
+      expect(definition).not.toHaveProperty('network');
+    });
+
+    it('omits reservedThroughput when provider details have no capacity unit', () => {
+      const definition = cloudTableStoreToDefinition({
+        tableName: 'orders',
+        reservedThroughputDetails: {},
+      });
+
+      expect(definition).toEqual({ tableName: 'orders' });
+      expect(definition).not.toHaveProperty('reservedThroughput');
+    });
+
+    it('preserves the provider primary key type casing', () => {
+      const definition = cloudTableStoreToDefinition({
+        tableName: 'binary-table',
+        primaryKey: [{ name: 'key', type: 'BINARY' }],
+      });
+
+      expect(definition.primaryKey).toEqual([{ name: 'key', type: 'BINARY' }]);
     });
   });
 });


### PR DESCRIPTION
## Summary

Issue #234 phase 1: planners now compare the **live cloud resource** against the desired definition, so console-side edits surface as `update + drifted` instead of silently missing (the stored state alone can no longer mask them).

### What's in the branch

**Core contract** (`src/common/planCompare.ts`)
- One-directional `remoteDiffersFromDesired`: only cloud->definition mapper-emitted keys the desired definition actually declares are compared. Desired value missing in cloud = drift (executor sets it on update); cloud-only extras the config never asked for = ignored (executor may not clear it). Empty plain-object desired values count as undeclared, matching the executor's field omission.

**Per-resource live-drift planners (aliyun)**
- `fc3`: function attributes (memory/timeout/env/vpc/nas/container/log) + managed-role trust, execution/custom policy document and attached managed policies, reusing the executor's own `resolveRoleGrant` so planner and executor can never diverge
- `oss`: bucket acl/website/storage-class/versioning/encryption/policy/transfer-acceleration
- `apigw`: group attributes + per-trigger API reconciliation (method/path/FC backend), scoped to the derived API name set; local config changes now also marked `drifted`
- `rds` / `es serverless`: instance attribute drift
- `tablestore`: table PK / reserved throughput / table options drift

**Supporting changes**
- `ramOperations`: new `getExecutionPolicyDocument` read (refactor of the create-or-update policy path to share one reader)
- Fix: fc3 cloud mapper mirrors the executor write shape key-for-key — container/nas functions no longer phantom-drift on every plan
- Fix: fc3 planner stays `noop` on transient role-probe read failures instead of degrading an existing function into a `create` plan
- Fix: planner no longer crashes on container-only functions (`fn.code` is optional; null code hash)

### Known limitation (follow-up)

`fc3Resource` still dereferences `fn.code!.path` in create/update/refresh paths — container-only functions plan cleanly now but **deploy** still crashes (pre-existing, tracked as phase-2 work).

## Test plan

- [x] `npm run build` clean
- [x] `npm run lint:check` clean
- [x] Full `npm run test:ci`: 161/161 suites, 3411/3411 tests, coverage gates met
- [x] New roundtrip guards assert `remoteDiffersFromDesired(cloudFc3ToDefinition(cloud), desired) === false` across code / vpc+gpu+nas+log / container±cmd shapes

Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-openagent)
