### PR TITLE
feat(plan): live drift detection phase 2 — tencent & volcengine (issue #234)

### DIFF
--- a/src/common/dependencyGraph/graph.ts
+++ b/src/common/dependencyGraph/graph.ts
@@ -22,6 +22,11 @@ const RESOURCE_TYPE_PREFIX_MAP: Record<string, string> = {
   SCF: 'functions',
   COS_BUCKET: 'buckets',
   TDSQL_C_SERVERLESS: 'databases',
+  TENCENT_ES_SERVERLESS: 'databases',
+  // Volcengine resource types (as emitted by planners)
+  VOLCENGINE_VEFAAS: 'functions',
+  VOLCENGINE_TOS_BUCKET: 'buckets',
+  VOLCENGINE_APIGW: 'events',
 };
 
 const RESOURCE_DEPENDENCY_ORDER: Record<string, number> = {

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -279,6 +279,8 @@ export const en = {
     'Function {{functionName}} role {{roleName}} is missing in the provider; it will be recreated and rebound on deploy',
   PLAN_FUNCTION_ROLE_PROBE_FAILED:
     'Live role policy check for function {{functionName}} (role {{roleName}}) failed: {{error}}; skipping role drift detection for this plan',
+  PLAN_EVENT_TRIGGER_PROBE_FAILED:
+    'Live trigger check for API Gateway {{eventName}} failed: {{error}}; skipping trigger drift detection for this plan',
   RAM_ROLE_MISSING_RECREATE:
     'RAM role {{roleName}} is missing in the provider; recreating it with the union of all functions that share it',
   SLS_PROJECT_FOREIGN_OWNED:

--- a/src/lang/zh-CN.ts
+++ b/src/lang/zh-CN.ts
@@ -259,6 +259,8 @@ export const zhCN = {
     '函数 {{functionName}} 的角色 {{roleName}} 在云端不存在；部署时将重建并重新绑定',
   PLAN_FUNCTION_ROLE_PROBE_FAILED:
     '函数 {{functionName}}（角色 {{roleName}}）的实时角色策略检查失败：{{error}}；本次计划跳过角色漂移检测',
+  PLAN_EVENT_TRIGGER_PROBE_FAILED:
+    'API 网关 {{eventName}} 的实时触发器检查失败：{{error}}；本次计划跳过触发器漂移检测',
   RAM_ROLE_MISSING_RECREATE:
     'RAM 角色 {{roleName}} 在云端不存在；将以共享该角色的所有函数的并集权限重建',
   SLS_PROJECT_FOREIGN_OWNED: 'SLS 项目 {{projectName}} 已存在但不属于当前应用，拒绝采用',

--- a/src/stack/aliyunStack/fc3Executor.ts
+++ b/src/stack/aliyunStack/fc3Executor.ts
@@ -29,9 +29,12 @@ const executeUpdateAction = async (
   context: Context,
   fn: FunctionDomain,
   currentState: StateFile,
+  drifted?: boolean,
 ): Promise<StateFile> => {
   logger.info(lang.__('UPDATING_RESOURCE', { resourceType: 'function', name: fn.name }));
-  const newState = await updateResource(context, fn, currentState);
+  // A drifted plan item means the cloud left the config: force the config
+  // re-push even when state-vs-desired sees no change.
+  const newState = await updateResource(context, fn, currentState, { force: drifted === true });
   logger.info(lang.__('RESOURCE_UPDATED', { resourceType: 'function', name: fn.name }));
   return newState;
 };
@@ -72,7 +75,7 @@ const executeSingleItem = async (
       if (!fn) {
         throw new Error(`Function not found for logical ID: ${item.logicalId}`);
       }
-      return executeUpdateAction(context, fn, currentState);
+      return executeUpdateAction(context, fn, currentState, item.drifted);
     }
 
     case 'delete': {

--- a/src/stack/aliyunStack/fc3Resource.ts
+++ b/src/stack/aliyunStack/fc3Resource.ts
@@ -1070,6 +1070,7 @@ export const updateResource = async (
   context: Context,
   fn: FunctionDomain,
   state: StateFile,
+  options?: { force?: boolean },
 ): Promise<StateFile> => {
   const ctx = getContext();
   const serviceName = `${ctx.app}-${ctx.service}`;
@@ -1378,7 +1379,10 @@ export const updateResource = async (
   const { codeHash: _desiredCodeHash, ...desiredConfigOnly } = desiredDefinition;
   const configChanged = !attributesEqual(existingConfigOnly, desiredConfigOnly);
 
-  if (configChanged || roleBindingChanged) {
+  // `force` carries the plan's drifted flag: a live-drift update (state
+  // matches config, cloud edited in console) must re-push the config even
+  // though state-vs-desired sees no change.
+  if (configChanged || roleBindingChanged || options?.force) {
     await client.fc3.updateFunctionConfiguration(config);
   }
 

--- a/src/stack/scfStack/cosPlanner.ts
+++ b/src/stack/scfStack/cosPlanner.ts
@@ -2,9 +2,14 @@ import { Context, BucketDomain, Plan, PlanItem, StateFile, ResourceAttributes } 
 import { createTencentClient } from '../../common/tencentClient';
 import { cachedRefreshRead } from '../../common/refreshCache';
 import { PLAN_READ_CONCURRENCY, mapWithConcurrency } from '../../common/concurrency';
-import { bucketToCosBucketConfig, extractCosBucketDefinition } from './cosTypes';
+import {
+  bucketToCosBucketConfig,
+  cloudCosToDefinition,
+  extractCosBucketDefinition,
+} from './cosTypes';
 import { getAllResources, getResource } from '../../common/stateManager';
 import { attributesEqual } from '../../common/hashUtils';
+import { remoteDiffersFromDesired } from '../../common/planCompare';
 import { OWNERSHIP_TAG_KEY, isOwnedByStack } from '../ownershipTag';
 
 const planBucketDeletion = (logicalId: string, definition: ResourceAttributes): PlanItem => ({
@@ -84,7 +89,15 @@ export const generateBucketPlan = async (
         const currentDefinition = currentState.definition || {};
         const definitionChanged = !attributesEqual(currentDefinition, desiredDefinition);
 
-        if (definitionChanged) {
+        // Issue #234 phase 2: live attribute drift (console edits to
+        // acl/website/versioning/encryption). One-directional: only
+        // mapper-emitted keys the desired definition declares are compared.
+        const remoteDiffers = remoteDiffersFromDesired(
+          cloudCosToDefinition(remoteBucket),
+          desiredDefinition,
+        );
+
+        if (definitionChanged || remoteDiffers) {
           return {
             logicalId,
             action: 'update',

--- a/src/stack/scfStack/cosTypes.ts
+++ b/src/stack/scfStack/cosTypes.ts
@@ -1,4 +1,5 @@
 import { BucketDomain, BucketIam, ResourceAttributes } from '../../types';
+import type { CosBucketInfo as TencentCosBucketInfo } from '../../common/tencentClient/types';
 
 export type CosBucketConfig = {
   Bucket: string;
@@ -214,3 +215,31 @@ export const extractCosBucketDefinition = (config: CosBucketConfig): ResourceAtt
     policy: serializeBucketPolicy(config.IamPolicy),
   };
 };
+
+// issue #234 phase 2: cloud-side counterpart of extractCosBucketDefinition.
+// Mirrors the executor write shape key-for-key. Not refreshable (omitted so
+// they can never phantom-drift): region (cloud Location uses a different
+// format), domain/wwwBindApex/domainCertificate*/domainProtocol (GetBucket
+// returns none of these), policy (cloud returns a policy object; byte-order
+// comparison against the serialized desired document would false-drift).
+export const cloudCosToDefinition = (info: TencentCosBucketInfo): ResourceAttributes => ({
+  bucket: info.Name,
+  ...(info.ACL !== undefined ? { acl: info.ACL } : {}),
+  ...(info.WebsiteConfiguration
+    ? {
+        websiteConfiguration: {
+          indexDocument: info.WebsiteConfiguration.IndexDocument?.Suffix ?? null,
+          errorDocument: info.WebsiteConfiguration.ErrorDocument?.Key ?? null,
+        },
+      }
+    : {}),
+  ...(info.VersioningConfiguration?.status !== undefined
+    ? { versioningStatus: info.VersioningConfiguration.status }
+    : {}),
+  ...(info.SseConfiguration?.sseAlgorithm !== undefined
+    ? { sseAlgorithm: info.SseConfiguration.sseAlgorithm }
+    : {}),
+  ...(info.SseConfiguration?.sseKmsMasterKeyId !== undefined
+    ? { sseKmsMasterKeyId: info.SseConfiguration.sseKmsMasterKeyId }
+    : {}),
+});

--- a/src/stack/scfStack/esServerlessPlanner.ts
+++ b/src/stack/scfStack/esServerlessPlanner.ts
@@ -10,9 +10,14 @@ import {
 import { createTencentClient } from '../../common/tencentClient';
 import { cachedRefreshRead } from '../../common/refreshCache';
 import { PLAN_READ_CONCURRENCY, mapWithConcurrency } from '../../common/concurrency';
-import { databaseToTencentEsConfig, extractTencentEsDefinition } from './esServerlessTypes';
+import {
+  databaseToTencentEsConfig,
+  extractTencentEsDefinition,
+  cloudTencentEsToDefinition,
+} from './esServerlessTypes';
 import { getAllResources, getResource } from '../../common/stateManager';
 import { attributesEqual } from '../../common/hashUtils';
+import { remoteDiffersFromDesired } from '../../common/planCompare';
 import { OWNERSHIP_TAG_KEY, isOwnedByStack } from '../ownershipTag';
 
 const planEsDeletion = (logicalId: string, definition: ResourceAttributes): PlanItem => ({
@@ -100,7 +105,15 @@ export const generateEsPlan = async (
         const currentDefinition = currentState.definition || {};
         const definitionChanged = !attributesEqual(currentDefinition, desiredDefinition);
 
-        if (definitionChanged) {
+        // Issue #234 phase 2: live attribute drift (console edits to
+        // network/whitelist). One-directional: only mapper-emitted keys the
+        // desired definition declares are compared.
+        const remoteDiffers = remoteDiffersFromDesired(
+          cloudTencentEsToDefinition(remoteSpace),
+          desiredDefinition,
+        );
+
+        if (definitionChanged || remoteDiffers) {
           return {
             logicalId,
             action: 'update',

--- a/src/stack/scfStack/esServerlessTypes.ts
+++ b/src/stack/scfStack/esServerlessTypes.ts
@@ -107,3 +107,15 @@ export const extractTencentEsDefinition = (config: TencentEsConfig): ResourceAtt
     kibanaWhiteIpList: config.KibanaWhiteIpList ?? null,
   };
 };
+
+// issue #234 phase 2: cloud-side counterpart of extractTencentEsDefinition.
+// Mirrors the executor write shape key-for-key. Not refreshable (omitted so it
+// can never phantom-drift): version (DescribeServerlessSpaceVCU / getSpace
+// does not report the configured engine version).
+export const cloudTencentEsToDefinition = (info: TencentEsSpaceInfo): ResourceAttributes => ({
+  spaceName: info.SpaceName,
+  vpcId: info.VpcInfo?.[0]?.VpcId ?? null,
+  subnetId: info.VpcInfo?.[0]?.SubnetId ?? null,
+  zone: info.Zone ?? null,
+  kibanaWhiteIpList: info.KibanaPublicAcl?.WhiteIpList ?? null,
+});

--- a/src/stack/scfStack/scfExecutor.ts
+++ b/src/stack/scfStack/scfExecutor.ts
@@ -29,9 +29,12 @@ const executeUpdateAction = async (
   context: Context,
   fn: FunctionDomain,
   currentState: StateFile,
+  drifted?: boolean,
 ): Promise<StateFile> => {
   logger.info(lang.__('UPDATING_RESOURCE', { resourceType: 'function', name: fn.name }));
-  const newState = await updateResource(context, fn, currentState);
+  // A drifted plan item means the cloud left the config: force the config
+  // re-push even when state-vs-desired sees no change.
+  const newState = await updateResource(context, fn, currentState, { force: drifted === true });
   logger.info(lang.__('RESOURCE_UPDATED', { resourceType: 'function', name: fn.name }));
   return newState;
 };
@@ -72,7 +75,7 @@ const executeSingleItem = async (
       if (!fn) {
         throw new Error(`Function not found for logical ID: ${item.logicalId}`);
       }
-      return executeUpdateAction(context, fn, currentState);
+      return executeUpdateAction(context, fn, currentState, item.drifted);
     }
 
     case 'delete': {

--- a/src/stack/scfStack/scfPlanner.ts
+++ b/src/stack/scfStack/scfPlanner.ts
@@ -9,9 +9,10 @@ import {
 import { createTencentClient } from '../../common/tencentClient';
 import { cachedRefreshRead } from '../../common/refreshCache';
 import { PLAN_READ_CONCURRENCY, mapWithConcurrency } from '../../common/concurrency';
-import { functionToScfConfig, extractScfDefinition } from './scfTypes';
+import { functionToScfConfig, extractScfDefinition, cloudScfToDefinition } from './scfTypes';
 import { getAllResources, getResource } from '../../common/stateManager';
 import { attributesEqual, computeZipContentHash } from '../../common/hashUtils';
+import { remoteDiffersFromDesired } from '../../common/planCompare';
 import { OWNERSHIP_TAG_KEY, isOwnedByStack } from '../ownershipTag';
 import { buildSharedLogsetName, buildFunctionTopicName } from './sharedLogset';
 
@@ -99,7 +100,15 @@ export const generateFunctionPlan = async (
         const currentDefinition = currentState.definition || {};
         const definitionChanged = !attributesEqual(currentDefinition, desiredDefinition);
 
-        if (definitionChanged) {
+        // Issue #234 phase 2: live attribute drift (console edits to
+        // memory/timeout/env/vpc...). One-directional: only mapper-emitted keys
+        // the desired definition declares are compared.
+        const remoteDiffers = remoteDiffersFromDesired(
+          cloudScfToDefinition(remoteFunction),
+          desiredDefinition,
+        );
+
+        if (definitionChanged || remoteDiffers) {
           return {
             logicalId,
             action: 'update',

--- a/src/stack/scfStack/scfResource.ts
+++ b/src/stack/scfStack/scfResource.ts
@@ -866,6 +866,7 @@ export const updateResource = async (
   context: Context,
   fn: FunctionDomain,
   state: StateFile,
+  options?: { force?: boolean },
 ): Promise<StateFile> => {
   const logicalId = `functions.${fn.key}`;
 
@@ -1079,7 +1080,10 @@ export const updateResource = async (
     // Disabling log always re-pushes config so the empty Cls ids reach the
     // UpdateFunctionConfiguration unbind contract.
     disableLog;
-  if (configChanged) {
+  // `force` carries the plan's drifted flag: a live-drift update (state
+  // matches config, cloud edited in console) must re-push the config even
+  // though state-vs-desired sees no change.
+  if (configChanged || options?.force) {
     await client.scf.updateFunctionConfiguration(config);
   }
 

--- a/src/stack/scfStack/scfTypes.ts
+++ b/src/stack/scfStack/scfTypes.ts
@@ -1,5 +1,6 @@
 import type { FunctionDomain, ResourceAttributes } from '../../types';
 import { mapRuntime, ProviderEnum } from '../../common';
+import type { ScfFunctionInfo as TencentScfFunctionInfo } from '../../common/tencentClient/types';
 
 export type ScfFunctionConfig = {
   FunctionName: string;
@@ -277,4 +278,45 @@ export const extractFunctionDomainDefinition = (
 ): ResourceAttributes => {
   const config = functionToScfConfig(fn);
   return extractScfDefinition(config, codeHash, fn.iam);
+};
+
+// issue #234 phase 2: cloud-side counterpart of extractScfDefinition. Mirrors
+// the executor write shape key-for-key. Not refreshable (omitted so they can
+// never phantom-drift): logConfig (GetFunction returns ClsLogsetId/ClsTopicId
+// ids while the desired definition uses stable logset/topic names — ids churn
+// across redeploys), diskSize (GetFunction does not report it), iam/role
+// (planner-side role grant not reproduced for tencent in this phase).
+export const cloudScfToDefinition = (info: TencentScfFunctionInfo): ResourceAttributes => {
+  const envMap: Record<string, string> =
+    info.Environment?.Variables?.reduce<Record<string, string>>(
+      (acc, v) => ({ ...acc, [v.Key]: v.Value }),
+      {},
+    ) ?? {};
+
+  const cloudVpcConfig = info.VpcConfig as { VpcId?: string; SubnetId?: string } | undefined;
+  const cloudCfsConfig = info.CfsConfig as
+    { CfsInsList?: Array<{ LocalMountDir?: string; RemoteMountDir?: string }> } | undefined;
+  const cloudImageConfig = info.ImageConfig as { ImageUri?: string } | undefined;
+
+  return {
+    functionName: info.FunctionName ?? null,
+    runtime: info.Runtime ?? null,
+    handler: info.Handler ?? null,
+    memorySize: info.MemorySize ?? null,
+    timeout: info.Timeout ?? null,
+    environment: envMap,
+    vpcConfig: cloudVpcConfig
+      ? { VpcId: cloudVpcConfig.VpcId ?? null, SubnetId: cloudVpcConfig.SubnetId ?? null }
+      : null,
+    cfsConfig: cloudCfsConfig?.CfsInsList
+      ? {
+          CfsInsList: cloudCfsConfig.CfsInsList.map((i) => ({
+            LocalMountDir: i.LocalMountDir ?? null,
+            RemoteMountDir: i.RemoteMountDir ?? null,
+          })),
+        }
+      : null,
+    useGpu: info.UseGpu ?? null,
+    imageConfig: cloudImageConfig ? { ImageUri: cloudImageConfig.ImageUri ?? null } : null,
+  };
 };

--- a/src/stack/scfStack/tdsqlcPlanner.ts
+++ b/src/stack/scfStack/tdsqlcPlanner.ts
@@ -14,9 +14,11 @@ import {
   databaseToTdsqlcConfig,
   extractTdsqlcDefinition,
   tdsqlcTagsToOwnershipTags,
+  cloudTdsqlcToDefinition,
 } from './tdsqlcTypes';
 import { getAllResources, getResource } from '../../common/stateManager';
 import { attributesEqual } from '../../common/hashUtils';
+import { remoteDiffersFromDesired } from '../../common/planCompare';
 import { OWNERSHIP_TAG_KEY, isOwnedByStack } from '../ownershipTag';
 
 const planDatabaseDeletion = (logicalId: string, definition: ResourceAttributes): PlanItem => ({
@@ -112,7 +114,15 @@ export const generateDatabasePlan = async (
         const currentDefinition = currentState.definition || {};
         const definitionChanged = !attributesEqual(currentDefinition, desiredDefinition);
 
-        if (definitionChanged) {
+        // Issue #234 phase 2: live attribute drift (console edits to
+        // cu/version/storage/network). One-directional: only mapper-emitted
+        // keys the desired definition declares are compared.
+        const remoteDiffers = remoteDiffersFromDesired(
+          cloudTdsqlcToDefinition(remoteCluster),
+          desiredDefinition,
+        );
+
+        if (definitionChanged || remoteDiffers) {
           return {
             logicalId,
             action: 'update',

--- a/src/stack/scfStack/tdsqlcTypes.ts
+++ b/src/stack/scfStack/tdsqlcTypes.ts
@@ -186,3 +186,22 @@ export const extractTdsqlcDefinition = (config: TdsqlcClusterConfig): ResourceAt
     maxStorageSize: config.MaxStorageSize ?? null,
   };
 };
+
+// issue #234 phase 2: cloud-side counterpart of extractTdsqlcDefinition.
+// Mirrors the executor write shape key-for-key. Not refreshable (omitted so
+// they can never phantom-drift): autoPause/autoPauseDelay (DescribeClusters
+// does not report the configured idle-pause switch — the cloud field reflects
+// running state, see tdsqlcClusterMapper), port/projectId (not returned).
+export const cloudTdsqlcToDefinition = (info: TdsqlcClusterInfo): ResourceAttributes => ({
+  clusterName: info.ClusterName,
+  dbType: info.DbType ?? null,
+  dbVersion: info.DbVersion ?? null,
+  dbMode: info.DbMode ?? null,
+  minCpu: info.MinCpu ?? null,
+  maxCpu: info.MaxCpu ?? null,
+  storagePayMode: info.StoragePayMode ?? null,
+  vpcId: info.VpcId ?? null,
+  subnetId: info.SubnetId ?? null,
+  minStorageSize: info.MinStorageSize ?? null,
+  maxStorageSize: info.MaxStorageSize ?? null,
+});

--- a/src/stack/volcengineStack/apigwPlanner.ts
+++ b/src/stack/volcengineStack/apigwPlanner.ts
@@ -2,9 +2,16 @@ import { Context, EventDomain, Plan, PlanItem, StateFile } from '../../types';
 import { createVolcengineClient } from '../../common/volcengineClient';
 import { cachedRefreshRead } from '../../common/refreshCache';
 import { PLAN_READ_CONCURRENCY, mapWithConcurrency } from '../../common/concurrency';
-import { buildEventResourceDefinition, buildGatewayName } from './apigwTypes';
+import {
+  buildDesiredTriggerMap,
+  buildGatewayName,
+  buildEventResourceDefinition,
+  cloudTriggerDiffers,
+} from './apigwTypes';
 import { getAllResources, getResource } from '../../common/stateManager';
 import { attributesEqual } from '../../common/hashUtils';
+import { logger } from '../../common';
+import { lang } from '../../lang';
 import { OWNERSHIP_TAG_KEY, isOwnedByStack } from '../ownershipTag';
 
 const planEventDeletion = (logicalId: string, definition: Record<string, unknown>): PlanItem => ({
@@ -99,12 +106,53 @@ export const generateApigwPlan = async (
       const currentDefinition = currentState.definition || {};
       const definitionChanged = !attributesEqual(currentDefinition, desiredDefinition);
 
-      if (definitionChanged) {
+      // Issue #234 phase 2: live trigger drift. The service record alone can be
+      // untouched while console edits reroute a trigger (method/path/upstream).
+      // Routes and upstreams are matched by the derived names the executor
+      // writes; a probe failure stays noop (best-effort detection) instead of
+      // fabricating drift from a transient read error.
+      let triggersDiffer = false;
+      if (!definitionChanged && serviceInstance && event.triggers.length > 0) {
+        try {
+          const desiredTriggers = buildDesiredTriggerMap(event, context.stage);
+          const cloudRoutes = await cachedRefreshRead(
+            context,
+            `apigw.listRoutesByService:${serviceInstance.id}`,
+            () => client.apigw.listRoutesByService(serviceInstance.id),
+          );
+          const matched = (cloudRoutes ?? []).filter(
+            (route) => route.routeName && desiredTriggers.has(route.routeName),
+          );
+          const upstreamNameById = new Map<string, string | undefined>();
+          for (const route of matched) {
+            const upstreamId = route.upstreamIds?.[0];
+            if (upstreamId && !upstreamNameById.has(upstreamId)) {
+              const upstream = await cachedRefreshRead(
+                context,
+                `apigw.getUpstream:${upstreamId}`,
+                () => client.apigw.getUpstream(upstreamId),
+              );
+              upstreamNameById.set(upstreamId, upstream?.upstreamName);
+            }
+          }
+          triggersDiffer = cloudTriggerDiffers(matched, upstreamNameById, desiredTriggers);
+        } catch (error: unknown) {
+          logger.warn(
+            lang.__('PLAN_EVENT_TRIGGER_PROBE_FAILED', {
+              eventName: event.name,
+              error: String(error),
+            }),
+          );
+        }
+      }
+
+      if (definitionChanged || triggersDiffer) {
         return {
           logicalId,
           action: 'update',
           resourceType: 'VOLCENGINE_APIGW',
           changes: { before: currentDefinition, after: desiredDefinition },
+          drifted: true,
         };
       }
 

--- a/src/stack/volcengineStack/apigwTypes.ts
+++ b/src/stack/volcengineStack/apigwTypes.ts
@@ -187,4 +187,55 @@ export const buildEventResourceDefinition = (
   return extractEventDomainDefinition(event, logTopicOverride) as unknown as ResourceAttributes;
 };
 
+// issue #234 phase 2: live trigger drift against derived names. Routes and
+// upstreams are keyed by the deterministic names the executor writes
+// (buildRouteName / buildUpstreamName), so foreign or console-added routes are
+// ignored and only si-declared triggers are compared.
+export type DesiredTriggerKey = {
+  method: string;
+  path: string;
+  upstreamName: string;
+};
+
+export const buildDesiredTriggerMap = (
+  event: EventDomain,
+  stage: string,
+): Map<string, DesiredTriggerKey> =>
+  new Map(
+    event.triggers.map((trigger) => {
+      const method = String(trigger.method);
+      const path = String(trigger.path);
+      return [
+        buildRouteName(event, method, path),
+        { method, path, upstreamName: buildUpstreamName(event, String(trigger.backend), stage) },
+      ] as [string, DesiredTriggerKey];
+    }),
+  );
+
+export const cloudTriggerDiffers = (
+  cloudRoutes: Array<{
+    routeName?: string;
+    method?: string;
+    path?: string;
+    upstreamIds?: string[];
+  }>,
+  upstreamNameById: Map<string, string | undefined>,
+  desiredTriggers: Map<string, DesiredTriggerKey>,
+): boolean =>
+  [...desiredTriggers.keys()].some((routeName) => {
+    const desired = desiredTriggers.get(routeName);
+    const route = cloudRoutes.find((r) => r.routeName === routeName);
+    if (!desired || !route) {
+      return true;
+    }
+    if (desired.method !== route.method || desired.path !== route.path) {
+      return true;
+    }
+    const upstreamId = route.upstreamIds?.[0];
+    if (!upstreamId) {
+      return true;
+    }
+    return desired.upstreamName !== upstreamNameById.get(upstreamId);
+  });
+
 export { resolveFunctionReference };

--- a/src/stack/volcengineStack/tosPlanner.ts
+++ b/src/stack/volcengineStack/tosPlanner.ts
@@ -3,9 +3,10 @@ import { Context, BucketDomain, Plan, PlanItem, StateFile, ResourceAttributes } 
 import { createVolcengineClient } from '../../common/volcengineClient';
 import { cachedRefreshRead } from '../../common/refreshCache';
 import { PLAN_READ_CONCURRENCY, mapWithConcurrency } from '../../common/concurrency';
-import { bucketToTosConfig, extractTosBucketDefinition } from './tosTypes';
+import { bucketToTosConfig, cloudTosToDefinition, extractTosBucketDefinition } from './tosTypes';
 import { getAllResources, getResource } from '../../common/stateManager';
 import { attributesEqual, computeDirectoryHash } from '../../common';
+import { remoteDiffersFromDesired } from '../../common/planCompare';
 import { OWNERSHIP_TAG_KEY, isOwnedByStack } from '../ownershipTag';
 
 const planBucketDeletion = (logicalId: string, definition: ResourceAttributes): PlanItem => ({
@@ -92,7 +93,15 @@ export const generateBucketPlan = async (
         const currentDefinition = currentState.definition || {};
         const definitionChanged = !attributesEqual(currentDefinition, desiredDefinition);
 
-        if (definitionChanged) {
+        // Issue #234 phase 2: live attribute drift (console edits to
+        // acl/storage-class/website). One-directional: only mapper-emitted keys
+        // the desired definition declares are compared.
+        const remoteDiffers = remoteDiffersFromDesired(
+          cloudTosToDefinition(remoteBucket),
+          desiredDefinition,
+        );
+
+        if (definitionChanged || remoteDiffers) {
           return {
             logicalId,
             action: 'update',

--- a/src/stack/volcengineStack/tosTypes.ts
+++ b/src/stack/volcengineStack/tosTypes.ts
@@ -79,6 +79,23 @@ export const extractTosBucketDefinition = (
   };
 };
 
+// issue #234 phase 2: cloud-side counterpart of extractTosBucketDefinition.
+// Mirrors the executor write shape key-for-key: acl/storageClass/websiteConfig
+// are compared live; policy (GetBucket returns no bucket-policy document) and
+// websiteCodeHash (local-only) are not refreshable and stay omitted so they can
+// never trigger phantom drift.
+export const cloudTosToDefinition = (info: TosBucketInfo): ResourceAttributes => ({
+  bucketName: info.name,
+  acl: info.acl ?? null,
+  storageClass: info.storageClass ?? null,
+  websiteConfiguration: info.websiteConfig
+    ? {
+        indexDocument: info.websiteConfig.indexDocument ?? null,
+        errorDocument: info.websiteConfig.errorDocument ?? null,
+      }
+    : null,
+});
+
 export const buildTosInstanceFromProvider = (info: TosBucketInfo, sid: string) => {
   return {
     type: 'VOLCENGINE_TOS_BUCKET',

--- a/src/stack/volcengineStack/vefaasExecutor.ts
+++ b/src/stack/volcengineStack/vefaasExecutor.ts
@@ -29,9 +29,12 @@ const executeUpdateAction = async (
   context: Context,
   fn: FunctionDomain,
   currentState: StateFile,
+  drifted?: boolean,
 ): Promise<StateFile> => {
   logger.info(lang.__('UPDATING_RESOURCE', { resourceType: 'function', name: fn.name }));
-  const newState = await updateResource(context, fn, currentState);
+  // A drifted plan item means the cloud left the config: force the config
+  // re-push even when state-vs-desired sees no change.
+  const newState = await updateResource(context, fn, currentState, { force: drifted === true });
   logger.info(lang.__('RESOURCE_UPDATED', { resourceType: 'function', name: fn.name }));
   return newState;
 };
@@ -72,7 +75,7 @@ const executeSingleItem = async (
       if (!fn) {
         throw new Error(`Function not found for logical ID: ${item.logicalId}`);
       }
-      return executeUpdateAction(context, fn, currentState);
+      return executeUpdateAction(context, fn, currentState, item.drifted);
     }
 
     case 'delete': {

--- a/src/stack/volcengineStack/vefaasPlanner.ts
+++ b/src/stack/volcengineStack/vefaasPlanner.ts
@@ -152,6 +152,10 @@ export const generateFunctionPlan = async (
         // function's actual attributes (runtime/handler/memory/timeout/env)
         // against the desired definition. Console edits would otherwise go
         // undetected — definitionChanged only sees local-vs-desired.
+        // Not refreshable (issue #234 phase 2): the IAM custom policy document
+        // (volcengine IAM has no GetPolicy read) and dependent TLS topics
+        // (existence-only by design decision 5) stay covered by the executor's
+        // reconcile path instead of live plan comparison.
         const remoteAttributes: ResourceAttributes = {
           runtime: remoteFunction.runtime,
           handler: remoteFunction.handler,

--- a/src/stack/volcengineStack/vefaasResource.ts
+++ b/src/stack/volcengineStack/vefaasResource.ts
@@ -622,6 +622,7 @@ export const updateResource = async (
   context: Context,
   fn: FunctionDomain,
   state: StateFile,
+  options?: { force?: boolean },
 ): Promise<StateFile> => {
   const serviceName = `${context.app}-${context.service}`;
   const logicalId = `functions.${fn.key}`;
@@ -847,7 +848,10 @@ export const updateResource = async (
 
   let lastReleaseRecordId: string | undefined;
 
-  if (configChanged) {
+  // `force` carries the plan's drifted flag: a live-drift update (state
+  // matches config, cloud edited in console) must re-push the config even
+  // though state-vs-desired sees no change.
+  if (configChanged || options?.force) {
     const released = await client.vefaas.updateFunctionConfiguration(
       currentFunctionId ?? fn.name,
       config,

--- a/tests/fixtures/serverless-insight-tencent.yml
+++ b/tests/fixtures/serverless-insight-tencent.yml
@@ -11,6 +11,10 @@ stages:
   default:
     region: ${vars.region}
 
+backend:
+  state_manager:
+    type: LOCAL
+
 service: insight-poc-tencent
 
 functions:

--- a/tests/fixtures/serverless-insight-volcengine-tos.yml
+++ b/tests/fixtures/serverless-insight-volcengine-tos.yml
@@ -1,0 +1,17 @@
+version: 0.0.1
+app: insight-volc-app
+provider:
+  name: volcengine
+  region: cn-beijing
+
+service: insight-volc
+
+backend:
+  state_manager:
+    type: LOCAL
+
+buckets:
+  static_site:
+    name: insight-volc-static-bucket
+    security:
+      acl: PUBLIC_READ

--- a/tests/service/mockCloudClient.ts
+++ b/tests/service/mockCloudClient.ts
@@ -1,5 +1,7 @@
 import type { Context } from '../../src/types';
 import { ProviderEnum } from '../../src/common/providerEnum';
+import { buildFc3ExecutionPolicyDocument } from '../../src/common/aliyunClient/ramOperations';
+import type { IamStatement } from '../../src/common/iamStatements';
 
 export type MockAliyunClient = {
   fc3: {
@@ -62,6 +64,8 @@ export type MockAliyunClient = {
     updateRolePolicy: jest.Mock;
     updateRoleTrustPolicy: jest.Mock;
     updateExecutionPolicyDocument: jest.Mock;
+    getExecutionPolicyDocument: jest.Mock;
+    listAttachedRolePolicies: jest.Mock;
   };
   nas: {
     createFileSystem: jest.Mock;
@@ -112,24 +116,39 @@ export type MockAliyunClient = {
 
 export const createMockAliyunClient = (): MockAliyunClient => {
   const fc3GetFunction = jest.fn().mockResolvedValue(null);
+  // Echo contract: role-policy drift detection reads back what the executor
+  // last wrote via updateExecutionPolicyDocument (issue #234).
+  let lastExecutionPolicyDocument: string | undefined;
+  // Echo contract: after create/update, GetFunction returns the config the
+  // executor sent (a real provider echoes it back), so live attribute drift
+  // detection compares like-for-like instead of against a stale payload.
+  let fc3EchoedConfig: Record<string, unknown> | null = null;
+
+  const fc3EchoGetFunction = (config: Record<string, unknown>): void => {
+    fc3EchoedConfig = {
+      ...(fc3EchoedConfig ?? {}),
+      ...config,
+      state: 'Running',
+    };
+    fc3GetFunction.mockResolvedValue(fc3EchoedConfig);
+  };
 
   return {
     fc3: {
-      createFunction: jest.fn().mockImplementation(async () => {
-        // Simulate a real create: once created, the function is queryable, so the
-        // executor's post-create refresh (getFunction) sees it. The planner probe
-        // (before create) still sees null (nothing exists yet).
-        fc3GetFunction.mockResolvedValue({
-          functionName: 'test-function',
-          runtime: 'nodejs18',
-          handler: 'index.handler',
-          memorySize: 128,
-          timeout: 60,
-          state: 'Running',
-        });
+      createFunction: jest.fn().mockImplementation(async (config: Record<string, unknown>) => {
+        // Simulate a real create: once created, the function is queryable with
+        // the exact config the executor sent. The planner probe (before
+        // create) still sees null (nothing exists yet).
+        fc3EchoedConfig = null;
+        fc3EchoGetFunction(config);
       }),
       getFunction: fc3GetFunction,
-      updateFunctionConfiguration: jest.fn().mockResolvedValue({}),
+      updateFunctionConfiguration: jest
+        .fn()
+        .mockImplementation(async (config: Record<string, unknown>) => {
+          fc3EchoGetFunction(config);
+          return {};
+        }),
       updateFunctionCode: jest.fn().mockResolvedValue({}),
       deleteFunction: jest.fn().mockResolvedValue({}),
       createTrigger: jest.fn().mockResolvedValue({ body: { triggerName: 'http-trigger' } }),
@@ -184,12 +203,35 @@ export const createMockAliyunClient = (): MockAliyunClient => {
       applyHttpsRedirect: jest.fn().mockResolvedValue({}),
     },
     ram: {
-      createRole: jest.fn().mockResolvedValue({
-        roleName: 'test-role',
-        roleId: 'role-123',
-        arn: 'acs:ram::123456789012:role/test-role',
-        policyName: 'test-role-policy',
-      }),
+      // Simulate the real createRole: it writes the `<role>-policy` custom
+      // document from the granted statements (attachRolePolicyForFc), which
+      // role-policy drift detection later reads back.
+      createRole: jest
+        .fn()
+        .mockImplementation(
+          async (
+            roleName: string,
+            trustedServices: string[],
+            description?: string,
+            customStatements?: IamStatement[],
+            managedPolicies?: string[],
+            executionStatements?: IamStatement[],
+          ) => {
+            lastExecutionPolicyDocument = buildFc3ExecutionPolicyDocument(
+              executionStatements ?? [],
+              customStatements ?? [],
+            );
+            return {
+              roleName,
+              roleId: 'role-123',
+              arn: `acs:ram::123456789012:role/${roleName}`,
+              policyName: `${roleName}-policy`,
+              description,
+              managedPolicies,
+              trustedServices,
+            };
+          },
+        ),
       getRole: jest.fn().mockResolvedValue({
         roleName: 'test-role',
         roleId: 'role-123',
@@ -206,7 +248,12 @@ export const createMockAliyunClient = (): MockAliyunClient => {
       updateRoleTrustPolicy: jest
         .fn()
         .mockResolvedValue({ body: { Role: { RoleName: 'test-role' } } }),
-      updateExecutionPolicyDocument: jest.fn().mockResolvedValue(undefined),
+      updateExecutionPolicyDocument: jest.fn(async (_roleName: string, document: string) => {
+        lastExecutionPolicyDocument = document;
+        return undefined;
+      }),
+      getExecutionPolicyDocument: jest.fn(async () => lastExecutionPolicyDocument),
+      listAttachedRolePolicies: jest.fn().mockResolvedValue([]),
     },
     nas: {
       createFileSystem: jest.fn().mockResolvedValue({ body: { fileSystemId: 'fs-123' } }),

--- a/tests/service/tencent-plan-drift.spec.test.ts
+++ b/tests/service/tencent-plan-drift.spec.test.ts
@@ -1,0 +1,102 @@
+import path from 'node:path';
+import fs from 'node:fs/promises';
+import { deploy } from '../../src/commands/deploy';
+
+jest.mock('../../src/common/tencentClient', () => ({
+  createTencentClient: jest.fn(),
+}));
+
+jest.mock('../../src/common/logger', () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+jest.mock('../../src/lang', () => ({
+  lang: {
+    __: (key: string) => key,
+  },
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const mockCreateTencentClient = require('../../src/common/tencentClient')
+  .createTencentClient as jest.Mock;
+
+const mockScfOperations = {
+  createFunction: jest.fn().mockResolvedValue(undefined),
+  getFunction: jest.fn(),
+  updateFunctionConfiguration: jest.fn().mockResolvedValue(undefined),
+  updateFunctionCode: jest.fn().mockResolvedValue(undefined),
+  deleteFunction: jest.fn().mockResolvedValue(undefined),
+  createTrigger: jest.fn().mockResolvedValue(undefined),
+  deleteTrigger: jest.fn().mockResolvedValue(undefined),
+  createCustomDomain: jest.fn().mockResolvedValue(undefined),
+  getCustomDomain: jest.fn().mockResolvedValue(null),
+  deleteCustomDomain: jest.fn().mockResolvedValue(undefined),
+};
+
+const STATE_FILE_PATH = path.join(
+  process.cwd(),
+  '.serverlessinsight',
+  'state-insight-poc-app-insight-poc-tencent.json',
+);
+
+const remoteFunction = (memorySize: number) => ({
+  FunctionName: 'test-fn',
+  Runtime: 'Nodejs18.15',
+  Handler: 'index.handler',
+  MemorySize: memorySize,
+  Timeout: 10,
+  Status: 'Active',
+  Environment: { Variables: [] },
+  Tags: [],
+});
+
+describe('Tencent SCF live-drift deploy flow (issue #234 phase 2)', () => {
+  const fixtureFile = path.join(__dirname, '../fixtures/serverless-insight-tencent.yml');
+  const deployOptions = {
+    location: fixtureFile,
+    stage: 'default',
+    autoApprove: true,
+    region: 'ap-guangzhou',
+    provider: 'tencent',
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    mockCreateTencentClient.mockReturnValue({ scf: mockScfOperations });
+    await fs.rm(STATE_FILE_PATH, { force: true }).catch(() => {});
+  });
+
+  afterEach(async () => {
+    await fs.rm(STATE_FILE_PATH, { force: true }).catch(() => {});
+  });
+
+  it('deploys, reconciles a console edit on the second deploy, then stays noop', async () => {
+    // First deploy: nothing remote yet → create. The planner probe reads null;
+    // the executor's post-create state refresh reads the created function.
+    mockScfOperations.getFunction
+      .mockResolvedValueOnce(null)
+      .mockResolvedValue(remoteFunction(512));
+    await deploy(deployOptions);
+    expect(mockScfOperations.createFunction).toHaveBeenCalledTimes(1);
+    expect(mockScfOperations.updateFunctionConfiguration).not.toHaveBeenCalled();
+
+    // Second deploy: the console dropped memory to 256 while state/config still
+    // declare 512 — live drift must force the config re-push.
+    mockScfOperations.getFunction.mockResolvedValue(remoteFunction(256));
+    await deploy(deployOptions);
+    expect(mockScfOperations.updateFunctionConfiguration).toHaveBeenCalledWith(
+      expect.objectContaining({ MemorySize: 512 }),
+    );
+
+    // Third deploy: cloud matches config again → noop, no config re-push.
+    const updateCalls = mockScfOperations.updateFunctionConfiguration.mock.calls.length;
+    mockScfOperations.getFunction.mockResolvedValue(remoteFunction(512));
+    await deploy(deployOptions);
+    expect(mockScfOperations.updateFunctionConfiguration).toHaveBeenCalledTimes(updateCalls);
+  });
+});

--- a/tests/service/volcengine-plan-drift.spec.test.ts
+++ b/tests/service/volcengine-plan-drift.spec.test.ts
@@ -1,0 +1,94 @@
+import path from 'node:path';
+import fs from 'node:fs/promises';
+import { deploy } from '../../src/commands/deploy';
+import { createMockVolcengineClient, type MockVolcengineClient } from './mockCloudClient';
+
+jest.mock('../../src/common/volcengineClient', () => ({
+  createVolcengineClient: jest.fn(),
+}));
+
+jest.mock('../../src/common/logger', () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+jest.mock('../../src/lang', () => ({
+  lang: {
+    __: (key: string) => key,
+  },
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const mockCreateVolcengineClient = require('../../src/common/volcengineClient')
+  .createVolcengineClient as jest.Mock;
+
+const STATE_FILE_PATH = path.join(
+  process.cwd(),
+  '.serverlessinsight',
+  'state-insight-volc-app-insight-volc.json',
+);
+
+describe('Volcengine TOS live-drift deploy flow (issue #234 phase 2)', () => {
+  const fixtureFile = path.join(__dirname, '../fixtures/serverless-insight-volcengine-tos.yml');
+  const deployOptions = {
+    location: fixtureFile,
+    stage: 'default',
+    autoApprove: true,
+    region: 'cn-beijing',
+    provider: 'volcengine',
+  };
+  let mockClient: MockVolcengineClient;
+
+  const OWNERSHIP_TAGS = [
+    { Key: 'si-owned-by', Value: 'insight-volc-app-insight-volc:buckets.static_site' },
+  ];
+
+  const remoteBucket = (acl: string, tagged = false) => ({
+    name: 'insight-volc-static-bucket',
+    acl,
+    Tags: tagged ? OWNERSHIP_TAGS : [],
+  });
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    mockClient = createMockVolcengineClient();
+    mockCreateVolcengineClient.mockReturnValue(mockClient);
+    await fs.rm(STATE_FILE_PATH, { force: true }).catch(() => {});
+  });
+
+  afterEach(async () => {
+    await fs.rm(STATE_FILE_PATH, { force: true }).catch(() => {});
+  });
+
+  it('deploys, reconciles a console acl edit on the second deploy, then stays noop', async () => {
+    // First deploy: nothing remote yet → create. The planner probe reads null;
+    // the executor's post-create state refresh reads the created bucket, which
+    // now carries the ownership tag the executor wrote.
+    mockClient.tos.getBucket
+      .mockResolvedValueOnce(null)
+      .mockResolvedValue(remoteBucket('public-read', true));
+    await deploy(deployOptions);
+    expect(mockClient.tos.createBucket).toHaveBeenCalledTimes(1);
+    expect(mockClient.tos.updateBucketAcl).not.toHaveBeenCalled();
+
+    // Second deploy: the console flipped the acl to private while config still
+    // declares public-read — live drift must surface and the executor push the
+    // configured acl back.
+    mockClient.tos.getBucket.mockResolvedValue(remoteBucket('private'));
+    await deploy(deployOptions);
+    expect(mockClient.tos.updateBucketAcl).toHaveBeenCalledWith(
+      'insight-volc-static-bucket',
+      'public-read',
+    );
+
+    // Third deploy: cloud matches config again → noop, no acl re-push.
+    const updateCalls = mockClient.tos.updateBucketAcl.mock.calls.length;
+    mockClient.tos.getBucket.mockResolvedValue(remoteBucket('public-read'));
+    await deploy(deployOptions);
+    expect(mockClient.tos.updateBucketAcl).toHaveBeenCalledTimes(updateCalls);
+  });
+});

--- a/tests/unit/stack/aliyunStack/fc3Executor.test.ts
+++ b/tests/unit/stack/aliyunStack/fc3Executor.test.ts
@@ -175,11 +175,37 @@ describe('Fc3Executor', () => {
         mockContext,
         testFunction,
         initialState,
+        { force: false },
       );
       expect(logger.info).toHaveBeenCalledWith('Updating function: test-function');
       expect(logger.info).toHaveBeenCalledWith('Successfully updated function: test-function');
       expect(result.state).toEqual(newState);
       expect(result.partialFailure).toBeUndefined();
+    });
+
+    it('should force the config re-push when the plan item is drifted', async () => {
+      const plan: Plan = {
+        items: [
+          {
+            logicalId: 'functions.test_fn',
+            action: 'update',
+            resourceType: 'ALIYUN_FC3',
+            drifted: true,
+          },
+        ],
+      };
+
+      const newState = { ...initialState, resources: { 'functions.test_fn': {} } };
+      (fc3Resource.updateResource as jest.Mock).mockResolvedValue(newState);
+
+      await executeFunctionPlan(mockContext, plan, [testFunction], initialState);
+
+      expect(fc3Resource.updateResource).toHaveBeenCalledWith(
+        mockContext,
+        testFunction,
+        initialState,
+        { force: true },
+      );
     });
 
     it('should execute delete action successfully', async () => {

--- a/tests/unit/stack/scfStack/cosPlanner.test.ts
+++ b/tests/unit/stack/scfStack/cosPlanner.test.ts
@@ -74,6 +74,9 @@ describe('cosPlanner', () => {
     (cosTypes.extractCosBucketDefinition as jest.Mock).mockReturnValue({
       bucket: 'test-bucket',
     });
+    // Default: the live-probe mapper reports no comparable attributes, so the
+    // pre-existing intent-diff tests keep their semantics.
+    (cosTypes.cloudCosToDefinition as jest.Mock).mockReturnValue({});
     (hashUtils.attributesEqual as jest.Mock).mockReturnValue(true);
   });
 
@@ -231,6 +234,42 @@ describe('cosPlanner', () => {
 
       expect(plan.items).toHaveLength(1);
       expect(plan.items[0].action).toBe('noop');
+    });
+
+    it('flags update+drifted when the live acl drifted from config (issue #234 phase 2)', async () => {
+      const stateWithBucket: StateFile = {
+        ...initialState,
+        resources: {
+          'buckets.test_bucket': {
+            mode: 'managed' as ResourceMode,
+            region: 'ap-guangzhou',
+            definition: {
+              bucket: 'test-bucket',
+              acl: 'public-read',
+            },
+            instances: [],
+            lastUpdated: new Date().toISOString(),
+          },
+        },
+      };
+
+      (stateManager.getResource as jest.Mock).mockReturnValue({
+        definition: { bucket: 'test-bucket', acl: 'public-read' },
+      });
+      (stateManager.getAllResources as jest.Mock).mockReturnValue({});
+      (cosTypes.extractCosBucketDefinition as jest.Mock).mockReturnValue({
+        bucket: 'test-bucket',
+        acl: 'public-read',
+      });
+      (cosTypes.cloudCosToDefinition as jest.Mock).mockReturnValue({
+        bucket: 'test-bucket',
+        acl: 'private',
+      });
+      (hashUtils.attributesEqual as jest.Mock).mockReturnValue(false);
+
+      const plan = await generateBucketPlan(mockContext, stateWithBucket, [testBucket]);
+
+      expect(plan.items[0]).toMatchObject({ action: 'update', drifted: true });
     });
 
     it('should handle error when getting bucket from cloud', async () => {

--- a/tests/unit/stack/scfStack/cosTypes.test.ts
+++ b/tests/unit/stack/scfStack/cosTypes.test.ts
@@ -1,7 +1,10 @@
 import {
   bucketToCosBucketConfig,
   extractCosBucketDefinition,
+  cloudCosToDefinition,
 } from '../../../../src/stack/scfStack/cosTypes';
+import { remoteDiffersFromDesired } from '../../../../src/common/planCompare';
+import type { CosBucketInfo as TencentCosBucketInfo } from '../../../../src/common/tencentClient/types';
 import { BucketDomain, BucketAccessEnum } from '../../../../src/types';
 
 describe('CosTypes', () => {
@@ -363,6 +366,88 @@ describe('CosTypes', () => {
       const definition = extractCosBucketDefinition(config);
 
       expect(definition.policy).toBeNull();
+    });
+  });
+
+  describe('cloudCosToDefinition (issue #234 phase 2)', () => {
+    it('maps acl/website/versioning/encryption and omits non-refreshable keys', () => {
+      const attrs = cloudCosToDefinition({
+        Name: 'test-bucket',
+        Location: 'ap-guangzhou',
+        ACL: 'public-read',
+        WebsiteConfiguration: {
+          IndexDocument: { Suffix: 'index.html' },
+          ErrorDocument: { Key: 'error.html' },
+        },
+        VersioningConfiguration: { status: 'Enabled' },
+        SseConfiguration: { sseAlgorithm: 'AES256' },
+      });
+
+      expect(attrs).toEqual({
+        bucket: 'test-bucket',
+        acl: 'public-read',
+        websiteConfiguration: {
+          indexDocument: 'index.html',
+          errorDocument: 'error.html',
+        },
+        versioningStatus: 'Enabled',
+        sseAlgorithm: 'AES256',
+      });
+      expect(attrs).not.toHaveProperty('region');
+      expect(attrs).not.toHaveProperty('policy');
+      expect(attrs).not.toHaveProperty('domain');
+    });
+
+    it('drifts only when a declared website differs from the live one', () => {
+      expect(cloudCosToDefinition({ Name: 'test-bucket', Location: 'ap-guangzhou' })).toEqual({
+        bucket: 'test-bucket',
+      });
+      // Matching index + null errorDocument on both sides normalizes equal.
+      expect(
+        remoteDiffersFromDesired(
+          cloudCosToDefinition({
+            Name: 'test-bucket',
+            Location: 'ap-guangzhou',
+            WebsiteConfiguration: { IndexDocument: { Suffix: 'index.html' } },
+          }),
+          {
+            bucket: 'test-bucket',
+            websiteConfiguration: { indexDocument: 'index.html', errorDocument: null },
+          },
+        ),
+      ).toBe(false);
+      expect(
+        remoteDiffersFromDesired(
+          cloudCosToDefinition({
+            Name: 'test-bucket',
+            Location: 'ap-guangzhou',
+            WebsiteConfiguration: { IndexDocument: { Suffix: 'console.html' } },
+          }),
+          {
+            bucket: 'test-bucket',
+            websiteConfiguration: { indexDocument: 'index.html', errorDocument: null },
+          },
+        ),
+      ).toBe(true);
+    });
+
+    // Deployed-then-untouched must never drift: cloud side simulated as what
+    // the executor wrote (CosBucketConfig field names align with the info).
+    it('never drifts against its own config (roundtrip guard)', () => {
+      const bucket: BucketDomain = {
+        key: 'test_bucket',
+        name: 'test-bucket',
+        security: { acl: BucketAccessEnum.PUBLIC_READ, force_delete: false },
+      };
+
+      const desired = extractCosBucketDefinition(bucketToCosBucketConfig(bucket, 'ap-guangzhou'));
+      const cloudInfo: TencentCosBucketInfo = {
+        Name: 'test-bucket',
+        Location: 'ap-guangzhou',
+        ACL: 'public-read',
+      };
+
+      expect(remoteDiffersFromDesired(cloudCosToDefinition(cloudInfo), desired)).toBe(false);
     });
   });
 });

--- a/tests/unit/stack/scfStack/esServerlessPlanner.test.ts
+++ b/tests/unit/stack/scfStack/esServerlessPlanner.test.ts
@@ -81,6 +81,9 @@ describe('esServerlessPlanner', () => {
     (esTypes.extractTencentEsDefinition as jest.Mock).mockReturnValue({
       name: 'test-db',
     });
+    // Default: the live-probe mapper reports no comparable attributes, so the
+    // pre-existing intent-diff tests keep their semantics.
+    (esTypes.cloudTencentEsToDefinition as jest.Mock).mockReturnValue({});
     (hashUtils.attributesEqual as jest.Mock).mockReturnValue(true);
   });
 
@@ -335,6 +338,49 @@ describe('esServerlessPlanner', () => {
 
       expect(plan.items).toHaveLength(1);
       expect(plan.items[0].action).toBe('noop');
+    });
+
+    it('flags update+drifted when the live vpc drifted from config (issue #234 phase 2)', async () => {
+      const stateWithDb: StateFile = {
+        ...initialState,
+        resources: {
+          'databases.test_db': {
+            mode: 'managed' as ResourceMode,
+            region: 'ap-guangzhou',
+            definition: { name: 'test-db', vpcId: 'vpc-123', subnetId: 'subnet-123' },
+            instances: [{ sid: 'si:tencent:es', id: 'space-123' }],
+            lastUpdated: new Date().toISOString(),
+            metadata: { spaceId: 'space-123' },
+          },
+        },
+      };
+
+      (stateManager.getResource as jest.Mock).mockReturnValue({
+        definition: { name: 'test-db', vpcId: 'vpc-123', subnetId: 'subnet-123' },
+        metadata: { spaceId: 'space-123' },
+      });
+      (stateManager.getAllResources as jest.Mock).mockReturnValue({});
+      (mockEsOperations.getSpace as jest.Mock).mockResolvedValue({ SpaceName: 'test-db' });
+      (esTypes.cloudTencentEsToDefinition as jest.Mock).mockReturnValue({
+        spaceName: 'test-db',
+        vpcId: 'vpc-other',
+        subnetId: 'subnet-123',
+        zone: null,
+        kibanaWhiteIpList: null,
+      });
+      (esTypes.extractTencentEsDefinition as jest.Mock).mockReturnValue({
+        name: 'test-db',
+        vpcId: 'vpc-123',
+        subnetId: 'subnet-123',
+      });
+      (hashUtils.attributesEqual as jest.Mock).mockImplementation(
+        (a: unknown, b: unknown) => JSON.stringify(a) === JSON.stringify(b),
+      );
+
+      const plan = await generateEsPlan(mockContext, stateWithDb, [testDatabase]);
+
+      expect(plan.items).toHaveLength(1);
+      expect(plan.items[0]).toMatchObject({ action: 'update', drifted: true });
     });
 
     it('should handle error when getting ES space from cloud', async () => {

--- a/tests/unit/stack/scfStack/esServerlessTypes.test.ts
+++ b/tests/unit/stack/scfStack/esServerlessTypes.test.ts
@@ -1,7 +1,9 @@
 import {
   databaseToTencentEsConfig,
   extractTencentEsDefinition,
+  cloudTencentEsToDefinition,
 } from '../../../../src/stack/scfStack/esServerlessTypes';
+import { remoteDiffersFromDesired } from '../../../../src/common/planCompare';
 import { DatabaseDomain, DatabaseEnum, DatabaseVersionEnum } from '../../../../src/types';
 
 describe('TencentEsServerlessTypes', () => {
@@ -255,6 +257,53 @@ describe('TencentEsServerlessTypes', () => {
 
       expect(definition).not.toHaveProperty('password');
       expect(definition).not.toHaveProperty('Password');
+    });
+  });
+
+  describe('cloudTencentEsToDefinition (issue #234 phase 2)', () => {
+    it('maps network/whitelist from the space info and omits non-refreshable version', () => {
+      const attrs = cloudTencentEsToDefinition({
+        SpaceId: 'space-123',
+        SpaceName: 'test-db',
+        Status: 2,
+        VpcInfo: [{ VpcId: 'vpc-123', SubnetId: 'subnet-123' }],
+        Zone: 'ap-guangzhou-1',
+        KibanaPublicAcl: { WhiteIpList: ['0.0.0.0/0'] },
+      });
+
+      expect(attrs).toEqual({
+        spaceName: 'test-db',
+        vpcId: 'vpc-123',
+        subnetId: 'subnet-123',
+        zone: 'ap-guangzhou-1',
+        kibanaWhiteIpList: ['0.0.0.0/0'],
+      });
+      expect(attrs).not.toHaveProperty('version');
+    });
+
+    // Deployed-then-untouched must never drift: cloud side simulated as what
+    // the executor wrote, with the fields the read API reports back.
+    it('never drifts against its own config (roundtrip guard)', () => {
+      const database: DatabaseDomain = {
+        key: 'test_db',
+        name: 'test-db',
+        type: DatabaseEnum.ELASTICSEARCH_SERVERLESS,
+        version: DatabaseVersionEnum['ES_SEARCH_7.10'],
+        security: { basicAuth: { password: 'test-password' } },
+        network: { type: 'PRIVATE', ingressRules: [], vpcId: 'vpc-123', subnetId: 'subnet-123' },
+        cu: { min: 2, max: 2 },
+        storage: { min: 20 },
+      };
+
+      const desired = extractTencentEsDefinition(databaseToTencentEsConfig(database));
+      const cloudInfo = {
+        SpaceId: 'space-123',
+        SpaceName: 'test-db',
+        Status: 2,
+        VpcInfo: [{ VpcId: 'vpc-123', SubnetId: 'subnet-123' }],
+      };
+
+      expect(remoteDiffersFromDesired(cloudTencentEsToDefinition(cloudInfo), desired)).toBe(false);
     });
   });
 });

--- a/tests/unit/stack/scfStack/scfExecutor.test.ts
+++ b/tests/unit/stack/scfStack/scfExecutor.test.ts
@@ -174,11 +174,37 @@ describe('ScfExecutor', () => {
         mockContext,
         testFunction,
         initialState,
+        { force: false },
       );
       expect(logger.info).toHaveBeenCalledWith('Updating function: test-function');
       expect(logger.info).toHaveBeenCalledWith('Successfully updated function: test-function');
       expect(result.state).toEqual(newState);
       expect(result.partialFailure).toBeUndefined();
+    });
+
+    it('should force the config re-push when the plan item is drifted', async () => {
+      const plan: Plan = {
+        items: [
+          {
+            logicalId: 'functions.test_fn',
+            action: 'update',
+            resourceType: 'SCF',
+            drifted: true,
+          },
+        ],
+      };
+
+      const newState = { ...initialState, resources: { 'functions.test_fn': {} } };
+      (scfResource.updateResource as jest.Mock).mockResolvedValue(newState);
+
+      await executeFunctionPlan(mockContext, plan, [testFunction], initialState);
+
+      expect(scfResource.updateResource).toHaveBeenCalledWith(
+        mockContext,
+        testFunction,
+        initialState,
+        { force: true },
+      );
     });
 
     it('should return partial failure if function not found for update action', async () => {

--- a/tests/unit/stack/scfStack/scfPlanner.test.ts
+++ b/tests/unit/stack/scfStack/scfPlanner.test.ts
@@ -466,5 +466,99 @@ describe('SCF Planner', () => {
         resourceType: 'SCF',
       });
     });
+
+    it('flags update+drifted when the live memorySize drifted from config (issue #234 phase 2)', async () => {
+      mockScfOperations.getFunction.mockResolvedValue({
+        FunctionName: 'test-function',
+        Runtime: 'Nodejs18.15',
+        Handler: 'index.handler',
+        MemorySize: 256,
+        Timeout: 10,
+        Environment: {
+          Variables: [{ Key: 'NODE_ENV', Value: 'production' }],
+        },
+      });
+
+      const state = setResource(initalState, 'functions.test_fn', {
+        mode: 'managed',
+        region: 'ap-guangzhou',
+        definition: {
+          functionName: 'test-function',
+          runtime: 'Nodejs18.15',
+          handler: 'index.handler',
+          memorySize: 512,
+          timeout: 10,
+          environment: { NODE_ENV: 'production' },
+          codeHash: 'mock-code-hash',
+          vpcConfig: null,
+          diskSize: null,
+          cfsConfig: null,
+          useGpu: null,
+          imageConfig: null,
+        },
+        instances: [
+          {
+            sid: 'si:tencent:scf:default:test-function',
+            id: 'test-function',
+            functionName: 'test-function',
+          },
+        ],
+        lastUpdated: new Date().toISOString(),
+      });
+
+      const plan = await generateFunctionPlan(mockContext, state, [testFunction]);
+
+      expect(plan.items[0]).toMatchObject({ action: 'update', drifted: true });
+    });
+
+    it('stays noop when live function matches config despite cloud-only detail fields', async () => {
+      mockScfOperations.getFunction.mockResolvedValue({
+        FunctionName: 'test-function',
+        Runtime: 'Nodejs18.15',
+        Handler: 'index.handler',
+        MemorySize: 512,
+        Timeout: 10,
+        Environment: {
+          Variables: [{ Key: 'NODE_ENV', Value: 'production' }],
+        },
+        Status: 'Active',
+        CodeSize: 1024,
+        FunctionId: 'ln-abc',
+        ModTime: '2024-01-01T00:00:00Z',
+        Tags: [{ Key: 'x', Value: 'y' }],
+        Role: 'some-role',
+      });
+
+      const state = setResource(initalState, 'functions.test_fn', {
+        mode: 'managed',
+        region: 'ap-guangzhou',
+        definition: {
+          functionName: 'test-function',
+          runtime: 'Nodejs18.15',
+          handler: 'index.handler',
+          memorySize: 512,
+          timeout: 10,
+          environment: { NODE_ENV: 'production' },
+          codeHash: 'mock-code-hash',
+          vpcConfig: null,
+          diskSize: null,
+          cfsConfig: null,
+          useGpu: null,
+          imageConfig: null,
+        },
+        instances: [
+          {
+            sid: 'si:tencent:scf:default:test-function',
+            id: 'test-function',
+            functionName: 'test-function',
+          },
+        ],
+        lastUpdated: new Date().toISOString(),
+      });
+
+      const plan = await generateFunctionPlan(mockContext, state, [testFunction]);
+
+      expect(plan.items[0]).toMatchObject({ action: 'noop' });
+    });
   });
 });

--- a/tests/unit/stack/scfStack/scfTypes.test.ts
+++ b/tests/unit/stack/scfStack/scfTypes.test.ts
@@ -2,7 +2,9 @@ import {
   functionToScfConfig,
   extractFunctionDomainDefinition,
   extractScfDefinition,
+  cloudScfToDefinition,
 } from '../../../../src/stack/scfStack/scfTypes';
+import { remoteDiffersFromDesired } from '../../../../src/common/planCompare';
 import { FunctionDomain, FunctionGpuEnum, NasStorageClassEnum } from '../../../../src/types';
 
 describe('SCF Types', () => {
@@ -223,6 +225,54 @@ describe('SCF Types', () => {
           iam: { role: 'role-123' },
         }),
       );
+    });
+  });
+
+  describe('cloudScfToDefinition (issue #234 phase 2)', () => {
+    // functionToScfConfig field names align with the GetFunction info shape, so
+    // its output simulates the cloud as the executor wrote it. Deployed-then-
+    // untouched functions must never live-drift against their own config.
+    const expectNoRoundtripDrift = (fn: FunctionDomain): void => {
+      const desired = extractFunctionDomainDefinition(fn, 'hash-123');
+      const cloudInfo = functionToScfConfig(fn);
+
+      expect(remoteDiffersFromDesired(cloudScfToDefinition(cloudInfo), desired)).toBe(false);
+    };
+
+    it('plain code function', () => {
+      expectNoRoundtripDrift({
+        key: 'test_fn',
+        name: 'code-fn',
+        code: { runtime: 'nodejs18', handler: 'index.handler', path: 'test.zip' },
+        memory: 512,
+        timeout: 10,
+        environment: { NODE_ENV: 'production' },
+        storage: {},
+      });
+    });
+
+    it('code function with vpc, nas and gpu', () => {
+      expectNoRoundtripDrift({
+        key: 'test_fn',
+        name: 'full-fn',
+        code: { runtime: 'nodejs18', handler: 'index.handler', path: 'test.zip' },
+        memory: 512,
+        timeout: 10,
+        gpu: FunctionGpuEnum.TESLA_8,
+        network: {
+          vpc_id: 'vpc-12345',
+          subnet_ids: ['vsw-123', 'vsw-456'],
+          security_group: { name: 'sg-12345', ingress: [], egress: [] },
+        },
+        storage: {
+          nas: [
+            {
+              storage_class: NasStorageClassEnum.STANDARD_CAPACITY,
+              mount_path: '/mnt/data',
+            },
+          ],
+        },
+      });
     });
   });
 });

--- a/tests/unit/stack/scfStack/tdsqlcPlanner.test.ts
+++ b/tests/unit/stack/scfStack/tdsqlcPlanner.test.ts
@@ -281,6 +281,8 @@ describe('TdsqlcPlanner', () => {
 
       jest.spyOn(stateManager, 'getResource').mockReturnValue(existingState);
       jest.spyOn(stateManager, 'getAllResources').mockReturnValue({});
+      // Full read response: DescribeClusters reports every attribute the
+      // desired definition declares, so live-diff stays noop.
       jest.spyOn(mockTdsqlcOperations, 'getCluster').mockResolvedValue({
         ClusterId: 'cynosdbmysql-test123',
         ClusterName: 'test-tdsqlc',
@@ -288,6 +290,14 @@ describe('TdsqlcPlanner', () => {
         Region: 'ap-guangzhou',
         DbType: 'MYSQL' as const,
         DbVersion: '8.0',
+        DbMode: 'SERVERLESS',
+        MinCpu: 1,
+        MaxCpu: 8,
+        StoragePayMode: 0,
+        VpcId: 'vpc-12345',
+        SubnetId: 'subnet-67890',
+        MinStorageSize: 10,
+        MaxStorageSize: 1000,
       });
 
       const result = await generateDatabasePlan(mockContext, mockState, [mockDatabase]);
@@ -298,6 +308,46 @@ describe('TdsqlcPlanner', () => {
         action: 'noop',
         resourceType: 'TDSQL_C_SERVERLESS',
       });
+    });
+
+    it('flags update+drifted when the live maxCpu drifted from config (issue #234 phase 2)', async () => {
+      const existingState: ResourceState = {
+        mode: 'managed',
+        region: 'ap-guangzhou',
+        definition: expectedDefinition,
+        instances: [
+          {
+            sid: 'si:tencent:cynosdb:default:cynosdbmysql-test123',
+            id: 'cynosdbmysql-test123',
+            clusterName: 'test-tdsqlc',
+          },
+        ],
+        lastUpdated: '2024-01-01T00:00:00Z',
+        metadata: { clusterId: 'cynosdbmysql-test123' },
+      };
+
+      jest.spyOn(stateManager, 'getResource').mockReturnValue(existingState);
+      jest.spyOn(stateManager, 'getAllResources').mockReturnValue({});
+      jest.spyOn(mockTdsqlcOperations, 'getCluster').mockResolvedValue({
+        ClusterId: 'cynosdbmysql-test123',
+        ClusterName: 'test-tdsqlc',
+        Status: 'running',
+        Region: 'ap-guangzhou',
+        DbType: 'MYSQL' as const,
+        DbVersion: '8.0',
+        DbMode: 'SERVERLESS',
+        MinCpu: 1,
+        MaxCpu: 16,
+        StoragePayMode: 0,
+        VpcId: 'vpc-12345',
+        SubnetId: 'subnet-67890',
+        MinStorageSize: 10,
+        MaxStorageSize: 1000,
+      });
+
+      const result = await generateDatabasePlan(mockContext, mockState, [mockDatabase]);
+
+      expect(result.items[0]).toMatchObject({ action: 'update', drifted: true });
     });
 
     it('should generate a drifted create plan when the stored cluster is missing remotely', async () => {

--- a/tests/unit/stack/scfStack/tdsqlcTypes.test.ts
+++ b/tests/unit/stack/scfStack/tdsqlcTypes.test.ts
@@ -1,0 +1,102 @@
+import {
+  databaseToTdsqlcConfig,
+  extractTdsqlcDefinition,
+  cloudTdsqlcToDefinition,
+  type TdsqlcClusterInfo as ClusterInfo,
+} from '../../../../src/stack/scfStack/tdsqlcTypes';
+import { remoteDiffersFromDesired } from '../../../../src/common/planCompare';
+import type { DatabaseDomain } from '../../../../src/types';
+
+describe('tdsqlcTypes (issue #234 phase 2)', () => {
+  const database: DatabaseDomain = {
+    key: 'db_main',
+    name: 'db-main',
+    type: 'TDSQL_C_SERVERLESS' as DatabaseDomain['type'],
+    version: 'MYSQL_8.0' as DatabaseDomain['version'],
+    cu: { min: 0.5, max: 8 },
+    storage: { min: 10 },
+    network: { type: 'PRIVATE', ingressRules: [] },
+    security: { basicAuth: { username: 'root', password: 'pw' } },
+  } as unknown as DatabaseDomain;
+
+  it('maps live cluster attributes and omits non-refreshable keys', () => {
+    const info: ClusterInfo = {
+      ClusterId: 'c-1',
+      ClusterName: 'db-main',
+      Region: 'ap-guangzhou',
+      DbType: 'MYSQL',
+      DbVersion: '8.0',
+      DbMode: 'SERVERLESS',
+      Status: 'running',
+      MinCpu: 0.5,
+      MaxCpu: 8,
+      StoragePayMode: 0,
+      VpcId: 'vpc-1',
+      SubnetId: 'subnet-1',
+      MinStorageSize: 10,
+    };
+
+    const attrs = cloudTdsqlcToDefinition(info);
+
+    expect(attrs).toEqual({
+      clusterName: 'db-main',
+      dbType: 'MYSQL',
+      dbVersion: '8.0',
+      dbMode: 'SERVERLESS',
+      minCpu: 0.5,
+      maxCpu: 8,
+      storagePayMode: 0,
+      vpcId: 'vpc-1',
+      subnetId: 'subnet-1',
+      minStorageSize: 10,
+      maxStorageSize: null,
+    });
+    expect(attrs).not.toHaveProperty('autoPause');
+    expect(attrs).not.toHaveProperty('autoPauseDelay');
+    expect(attrs).not.toHaveProperty('port');
+    expect(attrs).not.toHaveProperty('projectId');
+  });
+
+  // Deployed-then-untouched must never drift: the cloud side simulates what
+  // the executor wrote, with the config values the read API reports back.
+  it('never drifts against its own config (roundtrip guard)', () => {
+    const config = databaseToTdsqlcConfig(database);
+    const desired = extractTdsqlcDefinition(config);
+
+    const cloudInfo: ClusterInfo = {
+      ClusterId: 'c-1',
+      ClusterName: config.ClusterName,
+      Region: 'ap-guangzhou',
+      DbType: config.DbType,
+      DbVersion: config.DbVersion,
+      DbMode: config.DbMode,
+      Status: 'running',
+      MinCpu: config.MinCpu,
+      MaxCpu: config.MaxCpu,
+      StoragePayMode: config.StoragePayMode,
+      VpcId: config.VpcId,
+      SubnetId: config.SubnetId,
+      MinStorageSize: config.MinStorageSize,
+      MaxStorageSize: config.MaxStorageSize,
+    };
+
+    expect(remoteDiffersFromDesired(cloudTdsqlcToDefinition(cloudInfo), desired)).toBe(false);
+  });
+
+  it('flags drifted cu bounds', () => {
+    const info = {
+      ClusterId: 'c-1',
+      ClusterName: 'db-main',
+      MinCpu: 2,
+      MaxCpu: 8,
+    } as ClusterInfo;
+
+    expect(
+      remoteDiffersFromDesired(cloudTdsqlcToDefinition(info), {
+        clusterName: 'db-main',
+        minCpu: 0.5,
+        maxCpu: 8,
+      }),
+    ).toBe(true);
+  });
+});

--- a/tests/unit/stack/volcengineStack/apigwPlanner.test.ts
+++ b/tests/unit/stack/volcengineStack/apigwPlanner.test.ts
@@ -1,10 +1,14 @@
 import { generateApigwPlan } from '../../../../src/stack/volcengineStack/apigwPlanner';
+import { buildDesiredTriggerMap } from '../../../../src/stack/volcengineStack/apigwTypes';
 import { getContext } from '../../../../src/common';
 import type { Context, EventDomain, StateFile } from '../../../../src/types';
 import { ProviderEnum } from '../../../../src/common';
 
 jest.mock('../../../../src/common', () => {
   const { ProviderEnum } = jest.requireActual('../../../../src/common/providerEnum');
+  const { buildVolcengineRouteName: realRouteName } = jest.requireActual(
+    '../../../../src/common/providerNames',
+  );
   return {
     ProviderEnum,
     getContext: jest.fn(),
@@ -12,6 +16,7 @@ jest.mock('../../../../src/common', () => {
       `${provider}:${service}:${stage}:${id}`,
     getIacDefinition: jest.fn(),
     isFunctionDomain: jest.fn(),
+    buildVolcengineRouteName: realRouteName,
     logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
   };
 });
@@ -21,6 +26,8 @@ const mockClient = {
     findGatewayByName: jest.fn(),
     findServerlessGateway: jest.fn(),
     getService: jest.fn(),
+    listRoutesByService: jest.fn(),
+    getUpstream: jest.fn(),
   },
 };
 
@@ -80,6 +87,33 @@ describe('apigwPlanner', () => {
     (getContext as jest.Mock).mockReturnValue(mockContext);
     mockClient.apigw.findGatewayByName.mockResolvedValue(null);
     mockClient.apigw.findServerlessGateway.mockResolvedValue(null);
+    mockClient.apigw.getService.mockResolvedValue({ serviceId: 'svc-1', serviceName: 'svc' });
+    // Default live-probe mocks: routes/upstreams exactly as the executor wrote
+    // them for mockEvent (derived via the same name builders the planner uses).
+    const desiredDefaults = buildDesiredTriggerMap(mockEvent, mockContext.stage);
+    const [defaultPostName, defaultGetName] = [...desiredDefaults.keys()];
+    mockClient.apigw.listRoutesByService.mockResolvedValue([
+      {
+        routeId: 'r-1',
+        routeName: defaultPostName,
+        method: desiredDefaults.get(defaultPostName as string)?.method,
+        path: desiredDefaults.get(defaultPostName as string)?.path,
+        upstreamIds: ['up-1'],
+      },
+      {
+        routeId: 'r-2',
+        routeName: defaultGetName,
+        method: desiredDefaults.get(defaultGetName as string)?.method,
+        path: desiredDefaults.get(defaultGetName as string)?.path,
+        upstreamIds: ['up-2'],
+      },
+    ]);
+    mockClient.apigw.getUpstream.mockImplementation(async (upstreamId: string) => ({
+      upstreamId,
+      upstreamName: desiredDefaults.get(
+        upstreamId === 'up-1' ? (defaultPostName as string) : (defaultGetName as string),
+      )?.upstreamName,
+    }));
   });
 
   it('plans create for a new event with no local state', async () => {
@@ -223,11 +257,224 @@ describe('apigwPlanner', () => {
     expect(plan.items[0]).toMatchObject({
       logicalId: 'events.api_gateway',
       action: 'update',
+      drifted: true,
       changes: {
         before: { gatewayName: 'old-gateway' },
         after: { gatewayName: 'test-gw' },
       },
     });
+  });
+
+  it('plans update+drifted when a live trigger route drifted (issue #234 phase 2)', async () => {
+    const stateWithEvent: StateFile = {
+      ...emptyState,
+      resources: {
+        'events.api_gateway': {
+          mode: 'managed',
+          region: 'cn-beijing',
+          definition: {
+            gatewayName: 'test-gw',
+            triggers: [
+              { method: 'POST', path: '/graphql', backend: '${functions.api_function}' },
+              { method: 'GET', path: '/health', backend: '${functions.api_function}' },
+            ],
+          },
+          instances: [
+            {
+              type: 'VOLCENGINE_APIGW_SERVICE',
+              sid: 's',
+              id: 'svc-1',
+              serviceId: 'svc-1',
+              gatewayId: 'gw-1',
+            },
+          ],
+          lastUpdated: '2024-01-01T00:00:00Z',
+          status: 'ready',
+        },
+      },
+    };
+    const { attributesEqual } = jest.requireMock('../../../../src/common/hashUtils');
+    (attributesEqual as jest.Mock).mockReturnValue(true);
+
+    const desired = buildDesiredTriggerMap(mockEvent, mockContext.stage);
+    const [postRouteName, getRouteName] = [...desired.keys()];
+    const getTrigger = desired.get(getRouteName as string);
+
+    mockClient.apigw.listRoutesByService.mockResolvedValue([
+      {
+        routeId: 'r-1',
+        routeName: postRouteName,
+        method: 'POST',
+        path: '/console-edit',
+        upstreamIds: ['up-1'],
+      },
+      {
+        routeId: 'r-2',
+        routeName: getRouteName,
+        method: 'GET',
+        path: '/health',
+        upstreamIds: ['up-2'],
+      },
+    ]);
+    mockClient.apigw.getUpstream.mockImplementation(async (upstreamId: string) => ({
+      upstreamId,
+      upstreamName: upstreamId === 'up-1' ? 'console-renamed-upstream' : getTrigger?.upstreamName,
+    }));
+
+    const plan = await generateApigwPlan(mockContext, stateWithEvent, [mockEvent], 'test-service');
+
+    expect(plan.items[0]).toMatchObject({ action: 'update', drifted: true });
+    expect(mockClient.apigw.listRoutesByService).toHaveBeenCalledWith('svc-1');
+  });
+
+  it('plans update+drifted when a declared trigger route is missing from the cloud', async () => {
+    const stateWithEvent: StateFile = {
+      ...emptyState,
+      resources: {
+        'events.api_gateway': {
+          mode: 'managed',
+          region: 'cn-beijing',
+          definition: {
+            gatewayName: 'test-gw',
+            triggers: [
+              { method: 'POST', path: '/graphql', backend: '${functions.api_function}' },
+              { method: 'GET', path: '/health', backend: '${functions.api_function}' },
+            ],
+          },
+          instances: [
+            {
+              type: 'VOLCENGINE_APIGW_SERVICE',
+              sid: 's',
+              id: 'svc-1',
+              serviceId: 'svc-1',
+              gatewayId: 'gw-1',
+            },
+          ],
+          lastUpdated: '2024-01-01T00:00:00Z',
+          status: 'ready',
+        },
+      },
+    };
+    const { attributesEqual } = jest.requireMock('../../../../src/common/hashUtils');
+    (attributesEqual as jest.Mock).mockReturnValue(true);
+
+    const desired = buildDesiredTriggerMap(mockEvent, mockContext.stage);
+    const [postRouteName] = [...desired.keys()];
+
+    mockClient.apigw.listRoutesByService.mockResolvedValue([
+      {
+        routeId: 'r-1',
+        routeName: postRouteName,
+        method: 'POST',
+        path: '/graphql',
+        upstreamIds: ['up-1'],
+      },
+    ]);
+    mockClient.apigw.getUpstream.mockResolvedValue({
+      upstreamId: 'up-1',
+      upstreamName: desired.get(postRouteName as string)?.upstreamName,
+    });
+
+    const plan = await generateApigwPlan(mockContext, stateWithEvent, [mockEvent], 'test-service');
+
+    expect(plan.items[0]).toMatchObject({ action: 'update', drifted: true });
+    expect(plan.items).toHaveLength(1);
+  });
+
+  it('stays noop when live routes and upstreams match the declared triggers', async () => {
+    const stateWithEvent: StateFile = {
+      ...emptyState,
+      resources: {
+        'events.api_gateway': {
+          mode: 'managed',
+          region: 'cn-beijing',
+          definition: {
+            gatewayName: 'test-gw',
+            triggers: [
+              { method: 'POST', path: '/graphql', backend: '${functions.api_function}' },
+              { method: 'GET', path: '/health', backend: '${functions.api_function}' },
+            ],
+          },
+          instances: [
+            {
+              type: 'VOLCENGINE_APIGW_SERVICE',
+              sid: 's',
+              id: 'svc-1',
+              serviceId: 'svc-1',
+              gatewayId: 'gw-1',
+            },
+          ],
+          lastUpdated: '2024-01-01T00:00:00Z',
+          status: 'ready',
+        },
+      },
+    };
+    const { attributesEqual } = jest.requireMock('../../../../src/common/hashUtils');
+    (attributesEqual as jest.Mock).mockReturnValue(true);
+
+    const desired = buildDesiredTriggerMap(mockEvent, mockContext.stage);
+    const [postRouteName, getRouteName] = [...desired.keys()];
+    const postTrigger = desired.get(postRouteName as string);
+    const getTrigger = desired.get(getRouteName as string);
+
+    mockClient.apigw.listRoutesByService.mockResolvedValue([
+      {
+        routeId: 'r-1',
+        routeName: postRouteName,
+        method: postTrigger?.method,
+        path: postTrigger?.path,
+        upstreamIds: ['up-1'],
+      },
+      {
+        routeId: 'r-2',
+        routeName: getRouteName,
+        method: getTrigger?.method,
+        path: getTrigger?.path,
+        upstreamIds: ['up-2'],
+      },
+    ]);
+    mockClient.apigw.getUpstream.mockImplementation(async (upstreamId: string) => ({
+      upstreamId,
+      upstreamName: upstreamId === 'up-1' ? postTrigger?.upstreamName : getTrigger?.upstreamName,
+    }));
+
+    const plan = await generateApigwPlan(mockContext, stateWithEvent, [mockEvent], 'test-service');
+
+    expect(plan.items[0]).toMatchObject({ action: 'noop' });
+  });
+
+  it('stays noop when the live trigger probe fails transiently (best-effort detection)', async () => {
+    const stateWithEvent: StateFile = {
+      ...emptyState,
+      resources: {
+        'events.api_gateway': {
+          mode: 'managed',
+          region: 'cn-beijing',
+          definition: {
+            gatewayName: 'test-gw',
+            triggers: [{ method: 'POST', path: '/graphql', backend: '${functions.api_function}' }],
+          },
+          instances: [
+            {
+              type: 'VOLCENGINE_APIGW_SERVICE',
+              sid: 's',
+              id: 'svc-1',
+              serviceId: 'svc-1',
+              gatewayId: 'gw-1',
+            },
+          ],
+          lastUpdated: '2024-01-01T00:00:00Z',
+          status: 'ready',
+        },
+      },
+    };
+    const { attributesEqual } = jest.requireMock('../../../../src/common/hashUtils');
+    (attributesEqual as jest.Mock).mockReturnValue(true);
+    mockClient.apigw.listRoutesByService.mockRejectedValue(new Error('FlowLimitExceeded'));
+
+    const plan = await generateApigwPlan(mockContext, stateWithEvent, [mockEvent], 'test-service');
+
+    expect(plan.items[0]).toMatchObject({ action: 'noop' });
   });
 
   it('deletes stale events while excluding non-event resources', async () => {

--- a/tests/unit/stack/volcengineStack/tosPlanner.test.ts
+++ b/tests/unit/stack/volcengineStack/tosPlanner.test.ts
@@ -316,6 +316,95 @@ describe('tosPlanner', () => {
       expect(result.items[0].action).toBe('noop');
     });
 
+    it('flags update+drifted when the live acl drifted from config (issue #234 phase 2)', async () => {
+      const buckets: Array<BucketDomain> = [
+        {
+          key: 'static_site',
+          name: 'test-bucket',
+          security: { acl: BucketAccessEnum.PUBLIC_READ, force_delete: false },
+        },
+      ];
+
+      const stateWithBucket: StateFile = {
+        ...mockState,
+        resources: {
+          'buckets.static_site': {
+            mode: 'managed',
+            region: 'cn-beijing',
+            definition: {
+              bucketName: 'test-bucket',
+              acl: 'public-read',
+              storageClass: null,
+              websiteConfiguration: null,
+              websiteCodeHash: null,
+              policy: null,
+            },
+            instances: [{ sid: 'test-sid', id: 'test-bucket', type: 'VOLCENGINE_TOS_BUCKET' }],
+            lastUpdated: '2024-01-01T00:00:00Z',
+          },
+        },
+      };
+
+      mockTosClient.tos.getBucket.mockResolvedValueOnce({
+        name: 'test-bucket',
+        acl: 'private',
+      });
+
+      jest
+        .spyOn(stateManager, 'getResource')
+        .mockReturnValue(stateWithBucket.resources['buckets.static_site']);
+
+      const result = await generateBucketPlan(mockContext, stateWithBucket, buckets);
+
+      expect(result.items[0]).toMatchObject({ action: 'update', drifted: true });
+    });
+
+    it('stays noop when live bucket matches config despite cloud-only detail fields', async () => {
+      const buckets: Array<BucketDomain> = [
+        {
+          key: 'static_site',
+          name: 'test-bucket',
+        },
+      ];
+
+      const stateWithBucket: StateFile = {
+        ...mockState,
+        resources: {
+          'buckets.static_site': {
+            mode: 'managed',
+            region: 'cn-beijing',
+            definition: {
+              bucketName: 'test-bucket',
+              acl: null,
+              storageClass: null,
+              websiteConfiguration: null,
+              websiteCodeHash: null,
+              policy: null,
+            },
+            instances: [{ sid: 'test-sid', id: 'test-bucket', type: 'VOLCENGINE_TOS_BUCKET' }],
+            lastUpdated: '2024-01-01T00:00:00Z',
+          },
+        },
+      };
+
+      mockTosClient.tos.getBucket.mockResolvedValueOnce({
+        name: 'test-bucket',
+        location: 'cn-beijing',
+        creationDate: '2024-01-01T00:00:00Z',
+        owner: { id: 'u', displayName: 'u' },
+        extranetEndpoint: 'tos-cn-beijing.volces.com',
+        Tags: [{ Key: 'si-owned-by', Value: 'test-app-test-service:buckets.static_site' }],
+      });
+
+      jest
+        .spyOn(stateManager, 'getResource')
+        .mockReturnValue(stateWithBucket.resources['buckets.static_site']);
+
+      const result = await generateBucketPlan(mockContext, stateWithBucket, buckets);
+
+      expect(result.items[0]).toMatchObject({ action: 'noop' });
+    });
+
     it('should generate delete plan for removed bucket', async () => {
       const stateWithBucket: StateFile = {
         ...mockState,

--- a/tests/unit/stack/volcengineStack/tosTypes.test.ts
+++ b/tests/unit/stack/volcengineStack/tosTypes.test.ts
@@ -2,8 +2,11 @@ import {
   bucketToTosConfig,
   extractTosBucketDefinition,
   buildTosInstanceFromProvider,
+  cloudTosToDefinition,
 } from '../../../../src/stack/volcengineStack/tosTypes';
+import { remoteDiffersFromDesired } from '../../../../src/common/planCompare';
 import type { BucketDomain } from '../../../../src/types';
+import type { TosBucketInfo } from '../../../../src/common/volcengineClient/types';
 
 describe('tosTypes', () => {
   describe('bucketToTosConfig', () => {
@@ -213,6 +216,55 @@ describe('tosTypes', () => {
         accessMonitor: null,
         serverSideEncryptionConfiguration: null,
       });
+    });
+  });
+
+  describe('cloudTosToDefinition (issue #234 phase 2)', () => {
+    it('maps acl/storageClass/website and omits non-refreshable keys', () => {
+      expect(
+        cloudTosToDefinition({
+          name: 'test-bucket',
+          acl: 'public-read',
+          storageClass: 'STANDARD',
+          websiteConfig: { indexDocument: 'index.html', errorDocument: 'error.html' },
+        }),
+      ).toEqual({
+        bucketName: 'test-bucket',
+        acl: 'public-read',
+        storageClass: 'STANDARD',
+        websiteConfiguration: {
+          indexDocument: 'index.html',
+          errorDocument: 'error.html',
+        },
+      });
+
+      const attrs = cloudTosToDefinition({ name: 'test-bucket' });
+      expect(attrs).toEqual({
+        bucketName: 'test-bucket',
+        acl: null,
+        storageClass: null,
+        websiteConfiguration: null,
+      });
+      expect(attrs).not.toHaveProperty('policy');
+      expect(attrs).not.toHaveProperty('websiteCodeHash');
+    });
+
+    // Deployed-then-untouched must never drift: cloud side simulated as what
+    // the executor wrote (bucketToTosConfig field names align with the info).
+    it('never drifts against its own config (roundtrip guard)', () => {
+      const bucket: BucketDomain = {
+        key: 'static_site',
+        name: 'test-bucket',
+        security: { acl: 'PUBLIC_READ' as never, force_delete: false },
+      };
+
+      const desired = extractTosBucketDefinition(bucketToTosConfig(bucket));
+      const cloudInfo: TosBucketInfo = {
+        name: 'test-bucket',
+        acl: 'public-read',
+      };
+
+      expect(remoteDiffersFromDesired(cloudTosToDefinition(cloudInfo), desired)).toBe(false);
     });
   });
 });

--- a/tests/unit/stack/volcengineStack/vefaasExecutor.test.ts
+++ b/tests/unit/stack/volcengineStack/vefaasExecutor.test.ts
@@ -113,7 +113,33 @@ describe('vefaasExecutor', () => {
 
       await executeFunctionPlan(mockContext, plan, [mockFunction], mockState);
 
-      expect(updateResource).toHaveBeenCalledWith(mockContext, mockFunction, mockState);
+      expect(updateResource).toHaveBeenCalledWith(mockContext, mockFunction, mockState, {
+        force: false,
+      });
+    });
+
+    it('should force the config re-push when the plan item is drifted', async () => {
+      const plan: Plan = {
+        items: [
+          {
+            logicalId: 'functions.test_fn',
+            action: 'update',
+            resourceType: 'VOLCENGINE_VEFAAS',
+            drifted: true,
+          },
+        ],
+      };
+
+      (updateResource as jest.Mock).mockResolvedValueOnce({
+        ...mockState,
+        resources: { 'functions.test_fn': {} },
+      });
+
+      await executeFunctionPlan(mockContext, plan, [mockFunction], mockState);
+
+      expect(updateResource).toHaveBeenCalledWith(mockContext, mockFunction, mockState, {
+        force: true,
+      });
     });
 
     it('should execute delete action', async () => {


### PR DESCRIPTION
## Summary

Issue #234 **Phase 2**: extends live drift detection to **Tencent (SCF / COS / TDSQL-C / ES serverless)** and **Volcengine (TOS / API Gateway)**, and closes the executor gap that would have left flagged drift unrepaired.

> Builds on #236 (phase 1, merged).

### Attribute-drift refresh (6 types)

All planners follow the phase-1 contract (`remoteDiffersFromDesired`, one-directional, mapper-contract comments marking not-refreshable dimensions):

| Resource | Compared live | Not refreshable (marked, omitted) |
|---|---|---|
| `VOLCENGINE_TOS_BUCKET` | acl, storage-class, website | policy (no read API), websiteCodeHash |
| `SCF` | runtime/handler/memory/timeout/env/vpc/cfs/gpu/image | logConfig (cloud ids vs desired names), diskSize, iam |
| `COS_BUCKET` | acl, website, versioning, encryption | region, domain/cert fields, policy |
| `TDSQL_C_SERVERLESS` | cu bounds, version, dbMode, storage, network | autoPause (cloud reports running state, not the switch), port, projectId |
| `TENCENT_ES_SERVERLESS` | vpc/subnet/zone/kibana whitelist | engine version |
| `VOLCENGINE_APIGW` | triggers (method/path/upstream, matched by executor-derived names — foreign routes ignored); local definition changes now also marked `drifted` | domain (no read API) |

Roundtrip no-drift guards (cloud-as-executor-wrote-it vs config) cover every mapper — the guard class that caught the phase-1 phantom-drift bug.

### Executor reconcile leg (the load-bearing fix)

Planners now flag console drift, but the fc3/scf/vefaas executors gated config pushes on state-vs-desired — a pure live-drift deploy planned `update + drifted` yet **never repaired**. The plan item's `drifted` flag now flows into `updateResource` as `force`, re-pushing config even when state==desired. Bucket/table/database executors re-apply unconditionally and were verified untouched.

### Rate limiting (epic acceptance)

No new batching layer needed: every refresh read already flows through the global concurrency gate (10), `withThrottleRetry` (throttling-code backoff for all three providers, incl. Tencent 20/s CAM/TDSQL-C/ES and volcengine `FlowLimitExceeded`), and command-lifetime read dedup — the largest burst per plan stays far below the tightest known quota.

### Epic incidental fixes

- `RESOURCE_TYPE_PREFIX_MAP` completed with volcengine + tencent-ES types
- vefaas planner explicitly marks IAM custom policy document + TLS topics as not refreshable (executor reconcile covers them)

## Test plan

- [x] `npm run build` + `npm run lint:check` clean
- [x] Full `npm run test:ci`: **164/164 suites, 3417/3417 tests**, coverage gates met
- [x] Per-type: mapper unit tests + roundtrip no-drift guards + planner drift/noop/transient-failure tests
- [x] Service-level drift→repair flows per provider (deploy → console edit → deploy repairs → deploy noop) for Tencent SCF and Volcengine TOS
- [x] Executor force-leg unit tests (drifted item ⇒ config re-push with state==desired)

Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-openagent)
