### PR TITLE
feat(plan): live drift detection phase 3 — skeleton, visibility, escape hatch, verified dimensions (issue #234)

### DIFF
--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -49,6 +49,7 @@ export const deploy = async (options: {
   securityToken?: string;
   autoApprove?: boolean;
   siApiKey?: string;
+  refresh?: boolean;
 }) => {
   logger.info(lang.__('VALIDATING_YAML'));
   const iacLocation = getIacLocation(options.location);
@@ -62,6 +63,7 @@ export const deploy = async (options: {
       service: rawIac.service,
       iacProvider: rawIac.provider,
       stages: rawIac.stages,
+      refresh: options.refresh ?? true,
     },
     true,
   );

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -162,10 +162,23 @@ program
   .option('-k, --accessKeyId <accessKeyId>', 'specify the AccessKeyId')
   .option('-x, --accessKeySecret <accessKeySecret>', 'specify the AccessKeySecret')
   .option('-n, --securityToken <securityToken>', 'specify the SecurityToken')
+  .option(
+    '--no-refresh',
+    'skip live cloud probing; diff config against state only (no drift detection)',
+  )
   .action(
     actionWrapper(
       'plan',
-      async ({ stage, file, region, provider, accessKeyId, accessKeySecret, securityToken }) => {
+      async ({
+        stage,
+        file,
+        region,
+        provider,
+        accessKeyId,
+        accessKeySecret,
+        securityToken,
+        refresh,
+      }) => {
         await plan({
           stage,
           location: file,
@@ -174,6 +187,7 @@ program
           accessKeyId,
           accessKeySecret,
           securityToken,
+          refresh,
         });
       },
     ),
@@ -191,6 +205,10 @@ program
   .option('-n, --securityToken <securityToken>', 'specify the SecurityToken')
   .option('--si-api-key <key>', 'ServerlessInsight API key (overrides SI_API_KEY env)')
   .option('-y, --auto-approve', 'skip interactive approval of plan before deploying')
+  .option(
+    '--no-refresh',
+    'skip live cloud probing; diff config against state only (no drift detection)',
+  )
   .option(
     '-p, --parameter <key=value>',
     'override parameters',
@@ -215,6 +233,7 @@ program
         securityToken,
         siApiKey,
         autoApprove,
+        refresh,
       }) => {
         await deploy({
           stage,
@@ -227,6 +246,7 @@ program
           securityToken,
           siApiKey,
           autoApprove,
+          refresh,
         });
       },
     ),

--- a/src/commands/plan.ts
+++ b/src/commands/plan.ts
@@ -14,6 +14,7 @@ export const plan = async (options: {
   accessKeyId?: string;
   accessKeySecret?: string;
   securityToken?: string;
+  refresh?: boolean;
 }) => {
   logger.info(lang.__('VALIDATING_YAML'));
   const iacLocation = getIacLocation(options.location);
@@ -27,6 +28,7 @@ export const plan = async (options: {
       service: rawIac.service,
       iacProvider: rawIac.provider,
       stages: rawIac.stages,
+      refresh: options.refresh ?? true,
     },
     true,
   );

--- a/src/common/context.ts
+++ b/src/common/context.ts
@@ -73,6 +73,7 @@ export const setContext = async (
     parameters?: { [key: string]: string };
     iacProvider?: ServerlessIac['provider'];
     stages?: ServerlessIac['stages'];
+    refresh?: boolean;
   },
   reaValToken = false,
 ): Promise<void> => {
@@ -121,6 +122,7 @@ export const setContext = async (
       {},
     ),
     refreshCache: createRefreshCache(),
+    refresh: config.refresh ?? true,
   };
 
   if (reaValToken) {

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -25,3 +25,5 @@ export * from './providerNames';
 export * from './refreshCache';
 export * from './concurrency';
 export * from './throttleRetry';
+export * from './planCompare';
+export * from './refreshPlanner';

--- a/src/common/planCompare.ts
+++ b/src/common/planCompare.ts
@@ -42,3 +42,24 @@ export const remoteDiffersFromDesired = (
     }
     return !attributesEqual({ [key]: remote[key] }, { [key]: desiredValue });
   });
+
+/**
+ * Canonical JSON document compare (issue #234 phase 3): providers return
+ * policy documents as parsed objects (or re-serialized strings) whose key
+ * order and formatting differ from what the config serialized, so byte-level
+ * string comparison false-drifts. Parses both sides and compares
+ * key-order-insensitively. Undeclared (null) desired or unreadable cloud
+ * values are not drift — only a parseable pair with different content is.
+ */
+export const jsonDocumentDiffers = (desired: string | null, cloud: unknown): boolean => {
+  if (desired === null || cloud === undefined || cloud === null) {
+    return false;
+  }
+  try {
+    const desiredObj = JSON.parse(desired) as unknown;
+    const cloudObj = typeof cloud === 'string' ? (JSON.parse(cloud) as unknown) : cloud;
+    return !attributesEqual({ doc: cloudObj }, { doc: desiredObj });
+  } catch {
+    return false;
+  }
+};

--- a/src/common/planFormatter.ts
+++ b/src/common/planFormatter.ts
@@ -267,8 +267,15 @@ export const formatPlanItem = (
   const symbolColor = ACTION_COLOR[item.action] ?? 'RESET';
   const resourceLine = colorize(`  ${symbol} ${item.logicalId}:`, symbolColor, config.colorize);
 
+  // A drifted update is caused by an out-of-config cloud edit — surface that
+  // so it doesn't read like an ordinary config change.
+  const driftedLine =
+    item.drifted && item.action !== 'delete'
+      ? [colorize(`      # ${lang.__('PLAN_DRIFTED_MARKER')}`, 'CYAN', config.colorize)]
+      : [];
+
   if (!item.changes) {
-    return [headerLine, resourceLine].join('\n');
+    return [headerLine, resourceLine, ...driftedLine].join('\n');
   }
 
   const { diffs, unchangedCount } = computeAttributeDiffs(item.changes.before, item.changes.after);
@@ -290,7 +297,7 @@ export const formatPlanItem = (
         ]
       : [];
 
-  return [headerLine, resourceLine, ...attrLines, ...hiddenLine].join('\n');
+  return [headerLine, resourceLine, ...driftedLine, ...attrLines, ...hiddenLine].join('\n');
 };
 
 /* istanbul ignore next */
@@ -326,13 +333,26 @@ export const formatPlan = (
 
   const itemLines = actionItems.flatMap((item) => [formatPlanItem(item, config), '']);
 
+  const driftedCount = items.filter((i) => i.drifted && i.action !== 'delete').length;
+  const driftedSummary =
+    driftedCount > 0
+      ? [
+          colorize(
+            lang.__('PLAN_DRIFTED_SUMMARY', { driftedCount: String(driftedCount) }),
+            'CYAN',
+            config.colorize,
+          ),
+          '',
+        ]
+      : [];
+
   const summary = lang.__('PLAN_SUMMARY', {
     createCount: String(createItems.length),
     updateCount: String(updateItems.length),
     deleteCount: String(deleteItems.length),
   });
 
-  return [...header, ...itemLines, summary].join('\n');
+  return [...header, ...itemLines, ...driftedSummary, summary].join('\n');
 };
 
 /* istanbul ignore next */

--- a/src/common/refreshPlanner.ts
+++ b/src/common/refreshPlanner.ts
@@ -16,6 +16,10 @@ export type RefreshExistsDecision =
 export type RefreshExistsArgs<T> = {
   read: () => Promise<T | null>;
   cloudToDefinition: (remote: T) => ResourceAttributes;
+  enrichRemoteAttributes?: (
+    remote: T,
+    attributes: ResourceAttributes,
+  ) => Promise<ResourceAttributes>;
   desiredDefinition: ResourceAttributes;
   /** intent diff — computed by the caller (normalization differs per planner) */
   definitionChanged: boolean;
@@ -34,10 +38,11 @@ export const decideRefreshedExistsAction = async <T>(
   if (!remote) {
     return { action: 'create', drifted: true };
   }
-  const remoteDiffers = remoteDiffersFromDesired(
-    args.cloudToDefinition(remote),
-    args.desiredDefinition,
-  );
+  let attributes = args.cloudToDefinition(remote);
+  if (args.enrichRemoteAttributes) {
+    attributes = await args.enrichRemoteAttributes(remote, attributes);
+  }
+  const remoteDiffers = remoteDiffersFromDesired(attributes, args.desiredDefinition);
   if (args.definitionChanged || remoteDiffers) {
     return { action: 'update', drifted: true };
   }
@@ -61,6 +66,11 @@ export type PlanRefreshedResourceArgs<T> = {
   /** thrown on the probe path when a same-named remote exists unowned */
   foreignError: (remote: T) => Error;
   cloudToDefinition: (remote: T) => ResourceAttributes;
+  /** Post-process mapped remote attributes with extra live reads (e.g. resolve cloud log-config ids to names). */
+  enrichRemoteAttributes?: (
+    remote: T,
+    attributes: ResourceAttributes,
+  ) => Promise<ResourceAttributes>;
   /** applied to both sides before the intent diff and in changes display */
   normalizeForDisplay?: (definition: ResourceAttributes) => ResourceAttributes;
   extraUpdate?: () => Promise<{ update: boolean; drifted: boolean }>;
@@ -123,6 +133,7 @@ export const planRefreshedResource = async <T>(
     const decision = await decideRefreshedExistsAction<T>({
       read: args.read,
       cloudToDefinition: args.cloudToDefinition,
+      enrichRemoteAttributes: args.enrichRemoteAttributes,
       desiredDefinition,
       definitionChanged,
       extraUpdate: args.extraUpdate,

--- a/src/common/refreshPlanner.ts
+++ b/src/common/refreshPlanner.ts
@@ -1,0 +1,140 @@
+import { PlanItem, ResourceAttributes, ResourceState } from '../types';
+import { attributesEqual } from './hashUtils';
+import { remoteDiffersFromDesired } from './planCompare';
+
+/**
+ * Exists-path decision for attribute-refresh planners (issue #234 Phase 3):
+ * remote missing → create+drifted; intent-diff or live-attribute drift →
+ * update+drifted; extra bookkeeping conditions → update (drifted per flag);
+ * otherwise noop. Read failures propagate — callers keep their catch → create
+ * fallback. Item construction stays with the caller: before/after
+ * normalization and resource-specific details differ per planner.
+ */
+export type RefreshExistsDecision =
+  { action: 'create'; drifted: true } | { action: 'update'; drifted: boolean } | { action: 'noop' };
+
+export type RefreshExistsArgs<T> = {
+  read: () => Promise<T | null>;
+  cloudToDefinition: (remote: T) => ResourceAttributes;
+  desiredDefinition: ResourceAttributes;
+  /** intent diff — computed by the caller (normalization differs per planner) */
+  definitionChanged: boolean;
+  /**
+   * Extra update sources beyond the two standard diffs (e.g. pending domain
+   * binding). `drifted` controls the flag: intent/live drift set it,
+   * bookkeeping-only conditions do not.
+   */
+  extraUpdate?: () => Promise<{ update: boolean; drifted: boolean }>;
+};
+
+export const decideRefreshedExistsAction = async <T>(
+  args: RefreshExistsArgs<T>,
+): Promise<RefreshExistsDecision> => {
+  const remote = await args.read();
+  if (!remote) {
+    return { action: 'create', drifted: true };
+  }
+  const remoteDiffers = remoteDiffersFromDesired(
+    args.cloudToDefinition(remote),
+    args.desiredDefinition,
+  );
+  if (args.definitionChanged || remoteDiffers) {
+    return { action: 'update', drifted: true };
+  }
+  const extra = await args.extraUpdate?.();
+  if (extra?.update) {
+    return { action: 'update', drifted: extra.drifted };
+  }
+  return { action: 'noop' };
+};
+
+export type PlanRefreshedResourceArgs<T> = {
+  logicalId: string;
+  resourceType: string;
+  /** undefined or tainted routes to the probe-create path (planner semantics) */
+  currentState: ResourceState | undefined;
+  desiredDefinition: ResourceAttributes;
+  /** no-state/tainted probe; defaults to `read` when both paths read alike */
+  probeRead?: () => Promise<T | null>;
+  read: () => Promise<T | null>;
+  isOwned: (remote: T) => boolean;
+  /** thrown on the probe path when a same-named remote exists unowned */
+  foreignError: (remote: T) => Error;
+  cloudToDefinition: (remote: T) => ResourceAttributes;
+  /** applied to both sides before the intent diff and in changes display */
+  normalizeForDisplay?: (definition: ResourceAttributes) => ResourceAttributes;
+  extraUpdate?: () => Promise<{ update: boolean; drifted: boolean }>;
+};
+
+/**
+ * Shared planner skeleton (issue #234 Phase 3): covers the uniform
+ * no-state-probe / exists-refresh decision chain of the simple planners
+ * (buckets, tables, databases). Function and gateway planners keep their
+ * custom flows (role probes, trigger reconciliation, config normalization).
+ * Read failures on the exists path degrade to a create plan — the pre-existing
+ * planner behavior, preserved verbatim.
+ */
+export const planRefreshedResource = async <T>(
+  args: PlanRefreshedResourceArgs<T>,
+): Promise<PlanItem> => {
+  const { logicalId, resourceType, currentState, desiredDefinition } = args;
+
+  if (!currentState || currentState.status === 'tainted') {
+    const probeRead = args.probeRead ?? args.read;
+    const remote = await probeRead();
+    if (remote && !args.isOwned(remote)) {
+      throw args.foreignError(remote);
+    }
+    return {
+      logicalId,
+      action: 'create',
+      resourceType,
+      changes: { after: desiredDefinition },
+    };
+  }
+
+  const normalize = args.normalizeForDisplay ?? ((d) => d);
+  const currentDefinition = currentState.definition || {};
+  const normalizedCurrent = normalize(currentDefinition);
+  const normalizedDesired = normalize(desiredDefinition);
+  const definitionChanged = !attributesEqual(normalizedCurrent, normalizedDesired);
+
+  try {
+    const decision = await decideRefreshedExistsAction<T>({
+      read: args.read,
+      cloudToDefinition: args.cloudToDefinition,
+      desiredDefinition,
+      definitionChanged,
+      extraUpdate: args.extraUpdate,
+    });
+
+    if (decision.action === 'noop') {
+      return { logicalId, action: 'noop', resourceType };
+    }
+
+    if (decision.action === 'create') {
+      return {
+        logicalId,
+        action: 'create',
+        resourceType,
+        changes: { before: normalize(currentDefinition), after: desiredDefinition },
+        drifted: true,
+      };
+    }
+
+    return {
+      logicalId,
+      action: 'update',
+      resourceType,
+      changes: { before: normalizedCurrent, after: normalizedDesired },
+      ...(decision.drifted ? { drifted: true } : {}),
+    };
+  } catch {
+    return {
+      logicalId,
+      action: 'create',
+      resourceType,
+      changes: { before: normalize(currentDefinition), after: desiredDefinition },
+    };
+  }
+};

--- a/src/common/refreshPlanner.ts
+++ b/src/common/refreshPlanner.ts
@@ -64,6 +64,12 @@ export type PlanRefreshedResourceArgs<T> = {
   /** applied to both sides before the intent diff and in changes display */
   normalizeForDisplay?: (definition: ResourceAttributes) => ResourceAttributes;
   extraUpdate?: () => Promise<{ update: boolean; drifted: boolean }>;
+  /**
+   * When false (CLI --no-refresh): skip the live read and the attribute-drift
+   * leg entirely — the decision degenerates to intent-diff only, with no
+   * drifted claims. The probe-create path still runs (ownership safety).
+   */
+  refresh?: boolean;
 };
 
 /**
@@ -98,8 +104,22 @@ export const planRefreshedResource = async <T>(
   const normalizedCurrent = normalize(currentDefinition);
   const normalizedDesired = normalize(desiredDefinition);
   const definitionChanged = !attributesEqual(normalizedCurrent, normalizedDesired);
+  const refreshEnabled = args.refresh ?? true;
 
   try {
+    // --no-refresh: no cloud knowledge, so no drift claims — intent-diff only.
+    if (!refreshEnabled) {
+      if (!definitionChanged) {
+        return { logicalId, action: 'noop', resourceType };
+      }
+      return {
+        logicalId,
+        action: 'update',
+        resourceType,
+        changes: { before: normalizedCurrent, after: normalizedDesired },
+      };
+    }
+
     const decision = await decideRefreshedExistsAction<T>({
       read: args.read,
       cloudToDefinition: args.cloudToDefinition,

--- a/src/common/tencentClient/clsOperations.ts
+++ b/src/common/tencentClient/clsOperations.ts
@@ -65,6 +65,13 @@ export const createClsOperations = (clsClient: ClsSdkClient) => {
       };
     },
 
+    getLogsetNameById: async (logsetId: string): Promise<string | null> => {
+      const response = await clsClient.DescribeLogsets({
+        Filters: [{ Key: 'logsetId', Values: [logsetId] }],
+      });
+      return response?.Logsets?.find((l) => l.LogsetId === logsetId)?.LogsetName ?? null;
+    },
+
     listTopicsByLogset: async (
       logsetId: string,
     ): Promise<Array<{ TopicId?: string; TopicName?: string }>> => {

--- a/src/common/tencentClient/tdsqlcOperations.ts
+++ b/src/common/tencentClient/tdsqlcOperations.ts
@@ -194,6 +194,34 @@ export const createTdsqlcOperations = (cynosdbClient: CynosdbSdkClient, context:
       }
     },
 
+    getServerlessStrategy: async (
+      clusterId: string,
+    ): Promise<{ autoPause?: boolean; autoPauseDelay?: number } | null> => {
+      // DescribeServerlessStrategy reports the CONFIGURED idle-pause switch
+      // (DescribeClusters only reports the running state). The dedicated API
+      // is recent — guard on SDK support and treat absence as "not readable".
+      const sdk = cynosdbClient as unknown as {
+        DescribeServerlessStrategy?: (params: {
+          ClusterId: string;
+        }) => Promise<{ AutoPause?: string; AutoPauseDelay?: number }>;
+      };
+      if (typeof sdk.DescribeServerlessStrategy !== 'function') {
+        return null;
+      }
+      try {
+        const response = await sdk.DescribeServerlessStrategy({ ClusterId: clusterId });
+        if (!response) {
+          return null;
+        }
+        return {
+          autoPause: response.AutoPause === undefined ? undefined : response.AutoPause === 'yes',
+          autoPauseDelay: response.AutoPauseDelay,
+        };
+      } catch {
+        return null;
+      }
+    },
+
     updateCluster: async (clusterId: string, config: TdsqlcClusterConfig): Promise<void> => {
       const params = {
         ClusterId: clusterId,

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -133,6 +133,9 @@ export const en = {
     'Plan: {{createCount}} to add, {{updateCount}} to change, {{deleteCount}} to destroy.',
   PLAN_UNCHANGED_ATTRS: '({{count}} unchanged attributes hidden)',
   PLAN_COMPUTED_VALUE: '(known after deploy)',
+  PLAN_DRIFTED_MARKER: '(drifted — cloud changed outside of this config, will be reconciled)',
+  PLAN_DRIFTED_SUMMARY:
+    'Drift: {{driftedCount}} resource(s) changed in the cloud outside of this config.',
 
   // TDSQL-C database messages
   TDSQL_CLUSTER_CREATION_INITIATED: 'TDSQL-C cluster creation initiated',

--- a/src/lang/zh-CN.ts
+++ b/src/lang/zh-CN.ts
@@ -129,6 +129,8 @@ export const zhCN = {
   PLAN_SUMMARY: '计划: 新增 {{createCount}} 个，变更 {{updateCount}} 个，销毁 {{deleteCount}} 个。',
   PLAN_UNCHANGED_ATTRS: '({{count}} 个未变更属性已隐藏)',
   PLAN_COMPUTED_VALUE: '(部署后可知)',
+  PLAN_DRIFTED_MARKER: '（云端已漂移——与本配置不一致，将按配置纠正）',
+  PLAN_DRIFTED_SUMMARY: '漂移: {{driftedCount}} 个资源在云端被本配置之外的变更修改。',
 
   // TDSQL-C 数据库消息
   TDSQL_CLUSTER_CREATION_INITIATED: 'TDSQL-C 集群创建已启动',

--- a/src/stack/aliyunStack/databasePlanner.ts
+++ b/src/stack/aliyunStack/databasePlanner.ts
@@ -12,9 +12,8 @@ import { cachedRefreshRead } from '../../common/refreshCache';
 import { PLAN_READ_CONCURRENCY, mapWithConcurrency } from '../../common/concurrency';
 import { databaseToRdsConfig, extractRdsDefinition, cloudRdsToDefinition } from './rdsTypes';
 import { databaseToEsConfig, extractEsDefinition, cloudEsToDefinition } from './esServerlessTypes';
-import { remoteDiffersFromDesired } from '../../common/planCompare';
 import { getAllResources, getResource } from '../../common/stateManager';
-import { attributesEqual } from '../../common/hashUtils';
+import { planRefreshedResource } from '../../common/refreshPlanner';
 import { OWNERSHIP_TAG_KEY, isOwnedByStack } from '../ownershipTag';
 
 const toOwnershipTagShape = (
@@ -112,93 +111,42 @@ export const generateDatabasePlan = async (
       const resourceType = getResourceType(database);
       const desiredDefinition = getDesiredDefinition(database);
 
-      if (!currentState || currentState.status === 'tainted') {
-        // No usable local state: probe the provider before planning create.
-        // If a same-named resource already exists WITHOUT our ownership tag it
-        // may belong to another project — fail fast in the plan instead of
-        // letting the executor discover it mid-deploy.
-        const remote =
-          resourceType === 'ALIYUN_ES_SERVERLESS'
-            ? await cachedRefreshRead(context, `es.getApp:${database.name}`, () =>
+      const instanceId =
+        (currentState?.metadata?.instanceId as string | undefined) ||
+        currentState?.instances?.[0]?.id;
+      const isEs = resourceType === 'ALIYUN_ES_SERVERLESS';
+
+      return planRefreshedResource({
+        logicalId,
+        resourceType,
+        currentState,
+        desiredDefinition,
+        probeRead: () =>
+          isEs
+            ? cachedRefreshRead(context, `es.getApp:${database.name}`, () =>
                 client.es.getApp(database.name),
               )
-            : await cachedRefreshRead(context, `rds.getInstanceByName:${database.name}`, () =>
+            : cachedRefreshRead(context, `rds.getInstanceByName:${database.name}`, () =>
                 client.rds.getInstanceByName(database.name),
-              );
-        if (remote && !isOwnedByStack(context, logicalId, toOwnershipTagShape(remote.tags))) {
-          throw new Error(
+              ),
+        read: () =>
+          !instanceId
+            ? Promise.resolve(null)
+            : isEs
+              ? cachedRefreshRead(context, `es.getApp:${instanceId}`, () =>
+                  client.es.getApp(instanceId),
+                )
+              : cachedRefreshRead(context, `rds.getInstance:${instanceId}`, () =>
+                  client.rds.getInstance(instanceId),
+                ),
+        isOwned: (remote) => isOwnedByStack(context, logicalId, toOwnershipTagShape(remote.tags)),
+        foreignError: () =>
+          new Error(
             `${resourceType} ${database.name} already exists in provider but is not owned by this stack (missing ${OWNERSHIP_TAG_KEY} tag). Refusing to create — resolve manually.`,
-          );
-        }
-
-        return {
-          logicalId,
-          action: 'create',
-          resourceType,
-          changes: { after: desiredDefinition },
-        };
-      }
-
-      const instanceId =
-        (currentState.metadata?.instanceId as string | undefined) ||
-        currentState.instances?.[0]?.id;
-
-      try {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        let remoteInstance: any = null;
-
-        if (resourceType === 'ALIYUN_ES_SERVERLESS') {
-          remoteInstance = instanceId
-            ? await cachedRefreshRead(context, `es.getApp:${instanceId}`, () =>
-                client.es.getApp(instanceId),
-              )
-            : null;
-        } else if (resourceType === 'ALIYUN_RDS_SERVERLESS') {
-          remoteInstance = instanceId
-            ? await cachedRefreshRead(context, `rds.getInstance:${instanceId}`, () =>
-                client.rds.getInstance(instanceId),
-              )
-            : null;
-        }
-
-        if (!remoteInstance) {
-          return {
-            logicalId,
-            action: 'create',
-            resourceType,
-            changes: { before: currentState.definition, after: desiredDefinition },
-            drifted: true,
-          };
-        }
-
-        const remoteAttributes =
-          resourceType === 'ALIYUN_ES_SERVERLESS'
-            ? cloudEsToDefinition(remoteInstance)
-            : cloudRdsToDefinition(remoteInstance);
-        const remoteDiffers = remoteDiffersFromDesired(remoteAttributes, desiredDefinition);
-
-        const currentDefinition = currentState.definition || {};
-        const definitionChanged = !attributesEqual(currentDefinition, desiredDefinition);
-
-        if (definitionChanged || remoteDiffers) {
-          return {
-            logicalId,
-            action: 'update',
-            resourceType,
-            changes: { before: currentDefinition, after: desiredDefinition },
-            drifted: true,
-          };
-        }
-
-        return { logicalId, action: 'noop', resourceType };
-      } catch {
-        return {
-          logicalId,
-          action: 'create',
-          resourceType,
-          changes: { before: currentState.definition, after: desiredDefinition },
-        };
-      }
+          ),
+        cloudToDefinition: (remote) =>
+          isEs ? cloudEsToDefinition(remote) : cloudRdsToDefinition(remote),
+      });
     },
   );
 

--- a/src/stack/aliyunStack/databasePlanner.ts
+++ b/src/stack/aliyunStack/databasePlanner.ts
@@ -146,6 +146,7 @@ export const generateDatabasePlan = async (
           ),
         cloudToDefinition: (remote) =>
           isEs ? cloudEsToDefinition(remote) : cloudRdsToDefinition(remote),
+        refresh: context.refresh,
       });
     },
   );

--- a/src/stack/aliyunStack/fc3Planner.ts
+++ b/src/stack/aliyunStack/fc3Planner.ts
@@ -350,6 +350,23 @@ export const generateFunctionPlan = async (
 
       try {
         const client = createAliyunClient(context);
+        const normalizedCurrent = normalizeDefinitionForComparison(currentState.definition || {});
+        const normalizedDesired = normalizeDefinitionForComparison(desiredDefinition);
+        const definitionChanged = !attributesEqual(normalizedCurrent, normalizedDesired);
+
+        // --no-refresh: no live read, no drift claims — intent-diff only.
+        if (context.refresh === false) {
+          if (!definitionChanged) {
+            return { logicalId, action: 'noop', resourceType: 'ALIYUN_FC3' };
+          }
+          return {
+            logicalId,
+            action: 'update',
+            resourceType: 'ALIYUN_FC3',
+            changes: { before: normalizedCurrent, after: normalizedDesired },
+          };
+        }
+
         const remoteFunction = await cachedRefreshRead(context, `fc3.getFunction:${fn.name}`, () =>
           client.fc3.getFunction(fn.name),
         );
@@ -366,11 +383,6 @@ export const generateFunctionPlan = async (
             drifted: true,
           };
         }
-
-        const currentDefinition = currentState.definition || {};
-        const normalizedCurrent = normalizeDefinitionForComparison(currentDefinition);
-        const normalizedDesired = normalizeDefinitionForComparison(desiredDefinition);
-        const definitionChanged = !attributesEqual(normalizedCurrent, normalizedDesired);
 
         // Issue #234 phase 1: live attribute drift. The stored definition can
         // be untouched while the console edited the deployed function

--- a/src/stack/aliyunStack/ossPlanner.ts
+++ b/src/stack/aliyunStack/ossPlanner.ts
@@ -85,6 +85,7 @@ export const generateBucketPlan = async (
         cloudToDefinition: cloudOssToDefinition,
         normalizeForDisplay: normalizeDefinitionForDisplay,
         extraUpdate: () => Promise.resolve({ update: domainBindingPending, drifted: false }),
+        refresh: context.refresh,
       });
     },
   );

--- a/src/stack/aliyunStack/ossPlanner.ts
+++ b/src/stack/aliyunStack/ossPlanner.ts
@@ -9,8 +9,8 @@ import {
   extractOssBucketDefinition,
 } from './ossTypes';
 import { getAllResources, getResource } from '../../common/stateManager';
-import { attributesEqual, computeDirectoryHash } from '../../common/hashUtils';
-import { remoteDiffersFromDesired } from '../../common/planCompare';
+import { computeDirectoryHash } from '../../common/hashUtils';
+import { planRefreshedResource } from '../../common/refreshPlanner';
 import { OWNERSHIP_TAG_KEY, isOwnedByStack } from '../ownershipTag';
 
 const planBucketDeletion = (logicalId: string, definition: ResourceAttributes): PlanItem => ({
@@ -63,83 +63,29 @@ export const generateBucketPlan = async (
         }
       })();
       const desiredDefinition = extractOssBucketDefinition(config, websiteCodeHash);
+      const client = createAliyunClient(context);
+      const domainBindingPending =
+        (currentState?.definition as { domainBound?: boolean | null } | undefined)?.domainBound ===
+        false;
 
-      if (!currentState || currentState.status === 'tainted') {
-        // No usable local state: probe the provider before planning create.
-        // If a same-named bucket already exists WITHOUT our ownership tag it
-        // may belong to another project — fail fast in the plan instead of
-        // letting the executor discover it mid-deploy.
-        const client = createAliyunClient(context);
-        const remoteBucket = await cachedRefreshRead(context, `oss.getBucket:${bucket.name}`, () =>
-          client.oss.getBucket(bucket.name),
-        );
-        if (
-          remoteBucket &&
-          !isOwnedByStack(context, logicalId, toOwnershipTags(remoteBucket.tags))
-        ) {
-          throw new Error(
+      return planRefreshedResource({
+        logicalId,
+        resourceType: 'ALIYUN_OSS_BUCKET',
+        currentState,
+        desiredDefinition,
+        read: () =>
+          cachedRefreshRead(context, `oss.getBucket:${bucket.name}`, () =>
+            client.oss.getBucket(bucket.name),
+          ),
+        isOwned: (remote) => isOwnedByStack(context, logicalId, toOwnershipTags(remote.tags)),
+        foreignError: () =>
+          new Error(
             `Bucket ${bucket.name} already exists in provider but is not owned by this stack (missing ${OWNERSHIP_TAG_KEY} tag). Refusing to create — resolve manually.`,
-          );
-        }
-
-        return {
-          logicalId,
-          action: 'create',
-          resourceType: 'ALIYUN_OSS_BUCKET',
-          changes: { after: desiredDefinition },
-        };
-      }
-
-      try {
-        const client = createAliyunClient(context);
-        const remoteBucket = await cachedRefreshRead(context, `oss.getBucket:${bucket.name}`, () =>
-          client.oss.getBucket(bucket.name),
-        );
-
-        if (!remoteBucket) {
-          return {
-            logicalId,
-            action: 'create',
-            resourceType: 'ALIYUN_OSS_BUCKET',
-            changes: {
-              before: normalizeDefinitionForDisplay(currentState.definition),
-              after: desiredDefinition,
-            },
-            drifted: true,
-          };
-        }
-
-        const currentDefinition = currentState.definition || {};
-        const normalizedCurrent = normalizeDefinitionForDisplay(currentDefinition);
-        const normalizedDesired = normalizeDefinitionForDisplay(desiredDefinition);
-        const { domainBound } = currentDefinition as { domainBound?: boolean | null };
-        const definitionChanged = !attributesEqual(normalizedCurrent, normalizedDesired);
-        const remoteAttributes = cloudOssToDefinition(remoteBucket);
-        const remoteDiffers = remoteDiffersFromDesired(remoteAttributes, desiredDefinition);
-        const domainBindingPending = domainBound === false;
-
-        if (definitionChanged || remoteDiffers || domainBindingPending) {
-          return {
-            logicalId,
-            action: 'update',
-            resourceType: 'ALIYUN_OSS_BUCKET',
-            changes: { before: normalizedCurrent, after: normalizedDesired },
-            ...(definitionChanged || remoteDiffers ? { drifted: true } : {}),
-          };
-        }
-
-        return { logicalId, action: 'noop', resourceType: 'ALIYUN_OSS_BUCKET' };
-      } catch {
-        return {
-          logicalId,
-          action: 'create',
-          resourceType: 'ALIYUN_OSS_BUCKET',
-          changes: {
-            before: normalizeDefinitionForDisplay(currentState.definition),
-            after: desiredDefinition,
-          },
-        };
-      }
+          ),
+        cloudToDefinition: cloudOssToDefinition,
+        normalizeForDisplay: normalizeDefinitionForDisplay,
+        extraUpdate: () => Promise.resolve({ update: domainBindingPending, drifted: false }),
+      });
     },
   );
 

--- a/src/stack/aliyunStack/tablestorePlanner.ts
+++ b/src/stack/aliyunStack/tablestorePlanner.ts
@@ -63,6 +63,7 @@ export const generateTablePlan = async (
             `Table ${config.tableName} already exists in provider but ownership cannot be verified (no table-level tags). Refusing to adopt — resolve manually.`,
           ),
         cloudToDefinition: cloudTableStoreToDefinition,
+        refresh: context.refresh,
       });
     },
   );

--- a/src/stack/aliyunStack/tablestorePlanner.ts
+++ b/src/stack/aliyunStack/tablestorePlanner.ts
@@ -7,9 +7,8 @@ import {
   extractTableStoreDefinition,
   cloudTableStoreToDefinition,
 } from './tablestoreTypes';
-import { remoteDiffersFromDesired } from '../../common/planCompare';
+import { planRefreshedResource } from '../../common/refreshPlanner';
 import { getAllResources, getResource } from '../../common/stateManager';
-import { attributesEqual } from '../../common/hashUtils';
 
 const planTableDeletion = (logicalId: string, definition: ResourceAttributes): PlanItem => ({
   logicalId,
@@ -42,97 +41,29 @@ export const generateTablePlan = async (
       const config = tableToTableStoreConfig(table);
       const desiredDefinition = extractTableStoreDefinition(config);
 
-      if (!currentState || currentState.status === 'tainted') {
-        // No usable local state: probe the provider before planning create.
-        // Aliyun Tablestore (OTS) supports only instance-level tags — table
-        // ownership cannot be verified, so tag-based adoption is IMPOSSIBLE.
-        // If a same-named table already exists it may belong to another
-        // project: fail fast in the plan instead of letting the executor
-        // discover the collision mid-deploy.
-        const client = createAliyunClient(context);
-        const tablestoreClient = client.tablestore(config.instanceName);
-        const remoteTable = await cachedRefreshRead(
-          context,
-          `tablestore.getTable:${config.instanceName}:${config.tableName}`,
-          () => tablestoreClient.getTable(config.tableName),
-        );
-        if (remoteTable) {
-          throw new Error(
+      const client = createAliyunClient(context);
+      const tablestoreClient = client.tablestore(config.instanceName);
+
+      return planRefreshedResource({
+        logicalId,
+        resourceType: 'ALIYUN_TABLESTORE_TABLE',
+        currentState,
+        desiredDefinition,
+        read: () =>
+          cachedRefreshRead(
+            context,
+            `tablestore.getTable:${config.instanceName}:${config.tableName}`,
+            () => tablestoreClient.getTable(config.tableName),
+          ),
+        // TableStore has no table-level tags: an existing same-named table can
+        // never be verified as ours, so it is always refused on the probe path.
+        isOwned: () => false,
+        foreignError: () =>
+          new Error(
             `Table ${config.tableName} already exists in provider but ownership cannot be verified (no table-level tags). Refusing to adopt — resolve manually.`,
-          );
-        }
-
-        return {
-          logicalId,
-          action: 'create',
-          resourceType: 'ALIYUN_TABLESTORE_TABLE',
-          changes: { after: desiredDefinition },
-        };
-      }
-
-      try {
-        const client = createAliyunClient(context);
-        const tablestoreClient = client.tablestore(config.instanceName);
-        const remoteTable = await cachedRefreshRead(
-          context,
-          `tablestore.getTable:${config.instanceName}:${config.tableName}`,
-          () => tablestoreClient.getTable(config.tableName),
-        );
-
-        if (!remoteTable) {
-          return {
-            logicalId,
-            action: 'create',
-            resourceType: 'ALIYUN_TABLESTORE_TABLE',
-            changes: { before: currentState.definition, after: desiredDefinition },
-            drifted: true,
-          };
-        }
-
-        const remoteAttributes = cloudTableStoreToDefinition(remoteTable);
-        const remoteDiffers = remoteDiffersFromDesired(remoteAttributes, desiredDefinition);
-
-        const currentDefinition = currentState.definition || {};
-        const definitionChanged = !attributesEqual(currentDefinition, desiredDefinition);
-
-        if (definitionChanged || remoteDiffers) {
-          // Check if primary keys changed (not updatable in TableStore)
-          const currentPrimaryKey = JSON.stringify(currentDefinition.primaryKey || []);
-          const desiredPrimaryKey = JSON.stringify(desiredDefinition.primaryKey || []);
-
-          if (currentPrimaryKey !== desiredPrimaryKey) {
-            // Primary key changes require table recreation (delete + create)
-            // For now, we plan it as an update action with drift detection
-            // The user should manually recreate the table if primary keys need to change
-            return {
-              logicalId,
-              action: 'update',
-              resourceType: 'ALIYUN_TABLESTORE_TABLE',
-              changes: { before: currentDefinition, after: desiredDefinition },
-              drifted: true,
-            };
-          }
-
-          // Only throughput and table options changes can be applied via update
-          return {
-            logicalId,
-            action: 'update',
-            resourceType: 'ALIYUN_TABLESTORE_TABLE',
-            changes: { before: currentDefinition, after: desiredDefinition },
-            drifted: true,
-          };
-        }
-
-        return { logicalId, action: 'noop', resourceType: 'ALIYUN_TABLESTORE_TABLE' };
-      } catch {
-        // If we can't check remote state, assume we need to create
-        return {
-          logicalId,
-          action: 'create',
-          resourceType: 'ALIYUN_TABLESTORE_TABLE',
-          changes: { before: currentState.definition, after: desiredDefinition },
-        };
-      }
+          ),
+        cloudToDefinition: cloudTableStoreToDefinition,
+      });
     },
   );
 

--- a/src/stack/scfStack/cosPlanner.ts
+++ b/src/stack/scfStack/cosPlanner.ts
@@ -8,8 +8,7 @@ import {
   extractCosBucketDefinition,
 } from './cosTypes';
 import { getAllResources, getResource } from '../../common/stateManager';
-import { attributesEqual } from '../../common/hashUtils';
-import { remoteDiffersFromDesired } from '../../common/planCompare';
+import { planRefreshedResource } from '../../common/refreshPlanner';
 import { OWNERSHIP_TAG_KEY, isOwnedByStack } from '../ownershipTag';
 
 const planBucketDeletion = (logicalId: string, definition: ResourceAttributes): PlanItem => ({
@@ -43,79 +42,24 @@ export const generateBucketPlan = async (
       const config = bucketToCosBucketConfig(bucket, context.region);
       const desiredDefinition = extractCosBucketDefinition(config);
 
-      if (!currentState || currentState.status === 'tainted') {
-        // No usable local state: probe the provider before planning create.
-        // If a same-named bucket already exists WITHOUT our ownership tag it
-        // may belong to another project — fail fast in the plan instead of
-        // letting the executor discover it mid-deploy.
-        const client = createTencentClient(context);
-        const remoteBucket = await cachedRefreshRead(
-          context,
-          `cos.getBucket:${context.region}:${bucket.name}`,
-          () => client.cos.getBucket(bucket.name, context.region),
-        );
-        if (remoteBucket && !isOwnedByStack(context, logicalId, remoteBucket.Tags)) {
-          throw new Error(
+      const client = createTencentClient(context);
+
+      return planRefreshedResource({
+        logicalId,
+        resourceType: 'COS_BUCKET',
+        currentState,
+        desiredDefinition,
+        read: () =>
+          cachedRefreshRead(context, `cos.getBucket:${context.region}:${bucket.name}`, () =>
+            client.cos.getBucket(bucket.name, context.region),
+          ),
+        isOwned: (remote) => isOwnedByStack(context, logicalId, remote.Tags),
+        foreignError: () =>
+          new Error(
             `Bucket ${bucket.name} already exists in provider but is not owned by this stack (missing ${OWNERSHIP_TAG_KEY} tag). Refusing to create — resolve manually.`,
-          );
-        }
-
-        return {
-          logicalId,
-          action: 'create',
-          resourceType: 'COS_BUCKET',
-          changes: { after: desiredDefinition },
-        };
-      }
-
-      try {
-        const client = createTencentClient(context);
-        const remoteBucket = await cachedRefreshRead(
-          context,
-          `cos.getBucket:${context.region}:${bucket.name}`,
-          () => client.cos.getBucket(bucket.name, context.region),
-        );
-
-        if (!remoteBucket) {
-          return {
-            logicalId,
-            action: 'create',
-            resourceType: 'COS_BUCKET',
-            changes: { before: currentState.definition, after: desiredDefinition },
-            drifted: true,
-          };
-        }
-
-        const currentDefinition = currentState.definition || {};
-        const definitionChanged = !attributesEqual(currentDefinition, desiredDefinition);
-
-        // Issue #234 phase 2: live attribute drift (console edits to
-        // acl/website/versioning/encryption). One-directional: only
-        // mapper-emitted keys the desired definition declares are compared.
-        const remoteDiffers = remoteDiffersFromDesired(
-          cloudCosToDefinition(remoteBucket),
-          desiredDefinition,
-        );
-
-        if (definitionChanged || remoteDiffers) {
-          return {
-            logicalId,
-            action: 'update',
-            resourceType: 'COS_BUCKET',
-            changes: { before: currentDefinition, after: desiredDefinition },
-            drifted: true,
-          };
-        }
-
-        return { logicalId, action: 'noop', resourceType: 'COS_BUCKET' };
-      } catch {
-        return {
-          logicalId,
-          action: 'create',
-          resourceType: 'COS_BUCKET',
-          changes: { before: currentState.definition, after: desiredDefinition },
-        };
-      }
+          ),
+        cloudToDefinition: cloudCosToDefinition,
+      });
     },
   );
 

--- a/src/stack/scfStack/cosPlanner.ts
+++ b/src/stack/scfStack/cosPlanner.ts
@@ -59,6 +59,7 @@ export const generateBucketPlan = async (
             `Bucket ${bucket.name} already exists in provider but is not owned by this stack (missing ${OWNERSHIP_TAG_KEY} tag). Refusing to create — resolve manually.`,
           ),
         cloudToDefinition: cloudCosToDefinition,
+        refresh: context.refresh,
       });
     },
   );

--- a/src/stack/scfStack/cosPlanner.ts
+++ b/src/stack/scfStack/cosPlanner.ts
@@ -9,6 +9,7 @@ import {
 } from './cosTypes';
 import { getAllResources, getResource } from '../../common/stateManager';
 import { planRefreshedResource } from '../../common/refreshPlanner';
+import { jsonDocumentDiffers } from '../../common/planCompare';
 import { OWNERSHIP_TAG_KEY, isOwnedByStack } from '../ownershipTag';
 
 const planBucketDeletion = (logicalId: string, definition: ResourceAttributes): PlanItem => ({
@@ -43,22 +44,37 @@ export const generateBucketPlan = async (
       const desiredDefinition = extractCosBucketDefinition(config);
 
       const client = createTencentClient(context);
+      const readBucket = () =>
+        cachedRefreshRead(context, `cos.getBucket:${context.region}:${bucket.name}`, () =>
+          client.cos.getBucket(bucket.name, context.region),
+        );
 
       return planRefreshedResource({
         logicalId,
         resourceType: 'COS_BUCKET',
         currentState,
         desiredDefinition,
-        read: () =>
-          cachedRefreshRead(context, `cos.getBucket:${context.region}:${bucket.name}`, () =>
-            client.cos.getBucket(bucket.name, context.region),
-          ),
+        read: readBucket,
         isOwned: (remote) => isOwnedByStack(context, logicalId, remote.Tags),
         foreignError: () =>
           new Error(
             `Bucket ${bucket.name} already exists in provider but is not owned by this stack (missing ${OWNERSHIP_TAG_KEY} tag). Refusing to create — resolve manually.`,
           ),
         cloudToDefinition: cloudCosToDefinition,
+        extraUpdate: async () => {
+          // Policy needs a canonical compare: the cloud returns a parsed
+          // object while the config serializes it — see jsonDocumentDiffers.
+          const desiredPolicy = (desiredDefinition as { policy?: string | null }).policy ?? null;
+          if (desiredPolicy === null) {
+            return { update: false, drifted: false };
+          }
+          const remote = await readBucket();
+          const cloudPolicy = (remote as { Policy?: unknown } | null)?.Policy;
+          return {
+            update: jsonDocumentDiffers(desiredPolicy, cloudPolicy),
+            drifted: true,
+          };
+        },
         refresh: context.refresh,
       });
     },

--- a/src/stack/scfStack/esServerlessPlanner.ts
+++ b/src/stack/scfStack/esServerlessPlanner.ts
@@ -16,8 +16,7 @@ import {
   cloudTencentEsToDefinition,
 } from './esServerlessTypes';
 import { getAllResources, getResource } from '../../common/stateManager';
-import { attributesEqual } from '../../common/hashUtils';
-import { remoteDiffersFromDesired } from '../../common/planCompare';
+import { planRefreshedResource } from '../../common/refreshPlanner';
 import { OWNERSHIP_TAG_KEY, isOwnedByStack } from '../ownershipTag';
 
 const planEsDeletion = (logicalId: string, definition: ResourceAttributes): PlanItem => ({
@@ -56,82 +55,32 @@ export const generateEsPlan = async (
       const config = databaseToTencentEsConfig(database);
       const desiredDefinition = extractTencentEsDefinition(config);
 
-      if (!currentState || currentState.status === 'tainted') {
-        // No usable local state: probe the provider before planning create.
-        // If a same-named space already exists WITHOUT our ownership tag it may
-        // belong to another project — fail fast in the plan instead of letting
-        // the executor discover it mid-deploy.
-        const client = createTencentClient(context);
-        const remoteSpace = await cachedRefreshRead(
-          context,
-          `es.getSpaceByName:${config.SpaceName}`,
-          () => client.es.getSpaceByName(config.SpaceName),
-        );
-        if (remoteSpace && !isOwnedByStack(context, logicalId, remoteSpace.Tags)) {
-          throw new Error(
-            `ES space ${config.SpaceName} already exists in provider but is not owned by this stack (missing ${OWNERSHIP_TAG_KEY} tag). Refusing to create — resolve manually.`,
-          );
-        }
-
-        return {
-          logicalId,
-          action: 'create',
-          resourceType: 'TENCENT_ES_SERVERLESS',
-          changes: { after: desiredDefinition },
-        };
-      }
-
+      const client = createTencentClient(context);
       const spaceId =
-        (currentState.metadata?.spaceId as string | undefined) || currentState.instances?.[0]?.id;
+        (currentState?.metadata?.spaceId as string | undefined) || currentState?.instances?.[0]?.id;
 
-      try {
-        const client = createTencentClient(context);
-        const remoteSpace = spaceId
-          ? await cachedRefreshRead(context, `es.getSpace:${spaceId}`, () =>
-              client.es.getSpace(spaceId),
-            )
-          : null;
-
-        if (!remoteSpace) {
-          return {
-            logicalId,
-            action: 'create',
-            resourceType: 'TENCENT_ES_SERVERLESS',
-            changes: { before: currentState.definition, after: desiredDefinition },
-            drifted: true,
-          };
-        }
-
-        const currentDefinition = currentState.definition || {};
-        const definitionChanged = !attributesEqual(currentDefinition, desiredDefinition);
-
-        // Issue #234 phase 2: live attribute drift (console edits to
-        // network/whitelist). One-directional: only mapper-emitted keys the
-        // desired definition declares are compared.
-        const remoteDiffers = remoteDiffersFromDesired(
-          cloudTencentEsToDefinition(remoteSpace),
-          desiredDefinition,
-        );
-
-        if (definitionChanged || remoteDiffers) {
-          return {
-            logicalId,
-            action: 'update',
-            resourceType: 'TENCENT_ES_SERVERLESS',
-            changes: { before: currentDefinition, after: desiredDefinition },
-            drifted: true,
-          };
-        }
-
-        return { logicalId, action: 'noop', resourceType: 'TENCENT_ES_SERVERLESS' };
-      } catch {
-        return {
-          logicalId,
-          action: 'create',
-          resourceType: 'TENCENT_ES_SERVERLESS',
-          changes: { before: currentState.definition, after: desiredDefinition },
-        };
-      }
+      return planRefreshedResource({
+        logicalId,
+        resourceType: 'TENCENT_ES_SERVERLESS',
+        currentState,
+        desiredDefinition,
+        probeRead: () =>
+          cachedRefreshRead(context, `es.getSpaceByName:${config.SpaceName}`, () =>
+            client.es.getSpaceByName(config.SpaceName),
+          ),
+        read: () =>
+          spaceId
+            ? cachedRefreshRead(context, `es.getSpace:${spaceId}`, () =>
+                client.es.getSpace(spaceId),
+              )
+            : Promise.resolve(null),
+        isOwned: (remote) => isOwnedByStack(context, logicalId, remote.Tags),
+        foreignError: () =>
+          new Error(
+            `ES space ${config.SpaceName} already exists in provider but is not owned by this stack (missing ${OWNERSHIP_TAG_KEY} tag). Refusing to create — resolve manually.`,
+          ),
+        cloudToDefinition: cloudTencentEsToDefinition,
+      });
     },
   );
 

--- a/src/stack/scfStack/esServerlessPlanner.ts
+++ b/src/stack/scfStack/esServerlessPlanner.ts
@@ -80,6 +80,7 @@ export const generateEsPlan = async (
             `ES space ${config.SpaceName} already exists in provider but is not owned by this stack (missing ${OWNERSHIP_TAG_KEY} tag). Refusing to create — resolve manually.`,
           ),
         cloudToDefinition: cloudTencentEsToDefinition,
+        refresh: context.refresh,
       });
     },
   );

--- a/src/stack/scfStack/scfPlanner.ts
+++ b/src/stack/scfStack/scfPlanner.ts
@@ -11,8 +11,8 @@ import { cachedRefreshRead } from '../../common/refreshCache';
 import { PLAN_READ_CONCURRENCY, mapWithConcurrency } from '../../common/concurrency';
 import { functionToScfConfig, extractScfDefinition, cloudScfToDefinition } from './scfTypes';
 import { getAllResources, getResource } from '../../common/stateManager';
-import { attributesEqual, computeZipContentHash } from '../../common/hashUtils';
-import { remoteDiffersFromDesired } from '../../common/planCompare';
+import { computeZipContentHash } from '../../common/hashUtils';
+import { planRefreshedResource } from '../../common/refreshPlanner';
 import { OWNERSHIP_TAG_KEY, isOwnedByStack } from '../ownershipTag';
 import { buildSharedLogsetName, buildFunctionTopicName } from './sharedLogset';
 
@@ -58,75 +58,54 @@ export const generateFunctionPlan = async (
       const desiredCodeHash = await computeZipContentHash(codePath);
       const desiredDefinition = extractScfDefinition(config, desiredCodeHash, fn.iam);
 
-      if (!currentState || currentState.status === 'tainted') {
-        // No usable local state: probe the provider before planning create.
-        // If a same-named function already exists WITHOUT our ownership tag it
-        // may belong to another project — fail fast in the plan instead of
-        // letting the executor discover it mid-deploy.
-        const client = createTencentClient(context);
-        const remoteFunction = await cachedRefreshRead(context, `scf.getFunction:${fn.name}`, () =>
-          client.scf.getFunction(fn.name),
-        );
-        if (remoteFunction && !isOwnedByStack(context, logicalId, remoteFunction.Tags)) {
-          throw new Error(
+      const client = createTencentClient(context);
+
+      return planRefreshedResource({
+        logicalId,
+        resourceType: 'SCF',
+        currentState,
+        desiredDefinition,
+        read: () =>
+          cachedRefreshRead(context, `scf.getFunction:${fn.name}`, () =>
+            client.scf.getFunction(fn.name),
+          ),
+        isOwned: (remote) => isOwnedByStack(context, logicalId, remote.Tags),
+        foreignError: () =>
+          new Error(
             `Function ${fn.name} already exists in provider but is not owned by this stack (missing ${OWNERSHIP_TAG_KEY} tag). Refusing to create — resolve manually.`,
-          );
-        }
-
-        return {
-          logicalId,
-          action: 'create',
-          resourceType: 'SCF',
-          changes: { after: desiredDefinition },
-        };
-      }
-
-      try {
-        const client = createTencentClient(context);
-        const remoteFunction = await cachedRefreshRead(context, `scf.getFunction:${fn.name}`, () =>
-          client.scf.getFunction(fn.name),
-        );
-
-        if (!remoteFunction) {
-          return {
-            logicalId,
-            action: 'create',
-            resourceType: 'SCF',
-            changes: { before: currentState.definition, after: desiredDefinition },
-            drifted: true,
-          };
-        }
-
-        const currentDefinition = currentState.definition || {};
-        const definitionChanged = !attributesEqual(currentDefinition, desiredDefinition);
-
-        // Issue #234 phase 2: live attribute drift (console edits to
-        // memory/timeout/env/vpc...). One-directional: only mapper-emitted keys
-        // the desired definition declares are compared.
-        const remoteDiffers = remoteDiffersFromDesired(
-          cloudScfToDefinition(remoteFunction),
-          desiredDefinition,
-        );
-
-        if (definitionChanged || remoteDiffers) {
-          return {
-            logicalId,
-            action: 'update',
-            resourceType: 'SCF',
-            changes: { before: currentDefinition, after: desiredDefinition },
-            drifted: true,
-          };
-        }
-
-        return { logicalId, action: 'noop', resourceType: 'SCF' };
-      } catch {
-        return {
-          logicalId,
-          action: 'create',
-          resourceType: 'SCF',
-          changes: { before: currentState.definition, after: desiredDefinition },
-        };
-      }
+          ),
+        cloudToDefinition: cloudScfToDefinition,
+        enrichRemoteAttributes: async (remote, attributes) => {
+          // Resolve cloud CLS ids back to the stable names the desired
+          // definition uses; unresolvable ids are skipped, not fabricated into
+          // drift.
+          const desiredLog = desiredDefinition.logConfig as
+            { logset: string; topic: string } | undefined;
+          if (!desiredLog || !remote.ClsLogsetId || !remote.ClsTopicId) {
+            return attributes;
+          }
+          try {
+            const logsetName = await cachedRefreshRead(
+              context,
+              `cls.getLogsetNameById:${remote.ClsLogsetId}`,
+              () => client.cls.getLogsetNameById(remote.ClsLogsetId as string),
+            );
+            const topics = await cachedRefreshRead(
+              context,
+              `cls.listTopicsByLogset:${remote.ClsLogsetId}`,
+              () => client.cls.listTopicsByLogset(remote.ClsLogsetId as string),
+            );
+            const topicName = topics?.find((t) => t.TopicId === remote.ClsTopicId)?.TopicName;
+            if (!logsetName || !topicName) {
+              return attributes;
+            }
+            return { ...attributes, logConfig: { logset: logsetName, topic: topicName } };
+          } catch {
+            return attributes;
+          }
+        },
+        refresh: context.refresh,
+      });
     },
   );
 

--- a/src/stack/scfStack/tdsqlcPlanner.ts
+++ b/src/stack/scfStack/tdsqlcPlanner.ts
@@ -88,6 +88,25 @@ export const generateDatabasePlan = async (
             `Cluster ${database.name} already exists in provider but is not owned by this stack (missing ${OWNERSHIP_TAG_KEY} tag). Refusing to create — resolve manually.`,
           ),
         cloudToDefinition: cloudTdsqlcToDefinition,
+        extraUpdate: async () => {
+          // AutoPause needs a dedicated read: DescribeClusters reports the
+          // running serverless state, not the configured idle-pause switch —
+          // DescribeServerlessStrategy does. Unreadable strategy is not drift.
+          const desiredAutoPause = (desiredDefinition as { autoPause?: boolean | null }).autoPause;
+          if (typeof desiredAutoPause !== 'boolean' || !clusterId) {
+            return { update: false, drifted: false };
+          }
+          const strategy = await cachedRefreshRead(
+            context,
+            `tdsqlc.getServerlessStrategy:${clusterId}`,
+            () => client.tdsqlc.getServerlessStrategy(clusterId),
+          );
+          if (!strategy || strategy.autoPause === undefined) {
+            return { update: false, drifted: false };
+          }
+          const drifted = strategy.autoPause !== desiredAutoPause;
+          return { update: drifted, drifted };
+        },
         refresh: context.refresh,
       });
     },

--- a/src/stack/scfStack/tdsqlcPlanner.ts
+++ b/src/stack/scfStack/tdsqlcPlanner.ts
@@ -17,8 +17,7 @@ import {
   cloudTdsqlcToDefinition,
 } from './tdsqlcTypes';
 import { getAllResources, getResource } from '../../common/stateManager';
-import { attributesEqual } from '../../common/hashUtils';
-import { remoteDiffersFromDesired } from '../../common/planCompare';
+import { planRefreshedResource } from '../../common/refreshPlanner';
 import { OWNERSHIP_TAG_KEY, isOwnedByStack } from '../ownershipTag';
 
 const planDatabaseDeletion = (logicalId: string, definition: ResourceAttributes): PlanItem => ({
@@ -62,85 +61,34 @@ export const generateDatabasePlan = async (
       const config = databaseToTdsqlcConfig(database);
       const desiredDefinition = extractTdsqlcDefinition(config);
 
-      if (!currentState || currentState.status === 'tainted') {
-        // No usable local state: probe the provider before planning create. If a
-        // same-named cluster already exists WITHOUT our ownership tag it may
-        // belong to another project — fail fast in the plan instead of letting
-        // the executor discover it mid-deploy.
-        const client = createTencentClient(context);
-        const remoteCluster = await cachedRefreshRead(
-          context,
-          `tdsqlc.getClusterByName:${database.name}`,
-          () => client.tdsqlc.getClusterByName(database.name),
-        );
-        if (
-          remoteCluster &&
-          !isOwnedByStack(context, logicalId, tdsqlcTagsToOwnershipTags(remoteCluster.ResourceTags))
-        ) {
-          throw new Error(
-            `Cluster ${database.name} already exists in provider but is not owned by this stack (missing ${OWNERSHIP_TAG_KEY} tag). Refusing to create — resolve manually.`,
-          );
-        }
-
-        return {
-          logicalId,
-          action: 'create',
-          resourceType: 'TDSQL_C_SERVERLESS',
-          changes: { after: desiredDefinition },
-        };
-      }
-
+      const client = createTencentClient(context);
       const clusterId =
-        (currentState.metadata?.clusterId as string | undefined) || currentState.instances?.[0]?.id;
+        (currentState?.metadata?.clusterId as string | undefined) ||
+        currentState?.instances?.[0]?.id;
 
-      try {
-        const client = createTencentClient(context);
-        const remoteCluster = clusterId
-          ? await cachedRefreshRead(context, `tdsqlc.getCluster:${clusterId}`, () =>
-              client.tdsqlc.getCluster(clusterId),
-            )
-          : null;
-
-        if (!remoteCluster) {
-          return {
-            logicalId,
-            action: 'create',
-            resourceType: 'TDSQL_C_SERVERLESS',
-            changes: { before: currentState.definition, after: desiredDefinition },
-            drifted: true,
-          };
-        }
-
-        const currentDefinition = currentState.definition || {};
-        const definitionChanged = !attributesEqual(currentDefinition, desiredDefinition);
-
-        // Issue #234 phase 2: live attribute drift (console edits to
-        // cu/version/storage/network). One-directional: only mapper-emitted
-        // keys the desired definition declares are compared.
-        const remoteDiffers = remoteDiffersFromDesired(
-          cloudTdsqlcToDefinition(remoteCluster),
-          desiredDefinition,
-        );
-
-        if (definitionChanged || remoteDiffers) {
-          return {
-            logicalId,
-            action: 'update',
-            resourceType: 'TDSQL_C_SERVERLESS',
-            changes: { before: currentDefinition, after: desiredDefinition },
-            drifted: true,
-          };
-        }
-
-        return { logicalId, action: 'noop', resourceType: 'TDSQL_C_SERVERLESS' };
-      } catch {
-        return {
-          logicalId,
-          action: 'create',
-          resourceType: 'TDSQL_C_SERVERLESS',
-          changes: { before: currentState.definition, after: desiredDefinition },
-        };
-      }
+      return planRefreshedResource({
+        logicalId,
+        resourceType: 'TDSQL_C_SERVERLESS',
+        currentState,
+        desiredDefinition,
+        probeRead: () =>
+          cachedRefreshRead(context, `tdsqlc.getClusterByName:${database.name}`, () =>
+            client.tdsqlc.getClusterByName(database.name),
+          ),
+        read: () =>
+          clusterId
+            ? cachedRefreshRead(context, `tdsqlc.getCluster:${clusterId}`, () =>
+                client.tdsqlc.getCluster(clusterId),
+              )
+            : Promise.resolve(null),
+        isOwned: (remote) =>
+          isOwnedByStack(context, logicalId, tdsqlcTagsToOwnershipTags(remote.ResourceTags)),
+        foreignError: () =>
+          new Error(
+            `Cluster ${database.name} already exists in provider but is not owned by this stack (missing ${OWNERSHIP_TAG_KEY} tag). Refusing to create — resolve manually.`,
+          ),
+        cloudToDefinition: cloudTdsqlcToDefinition,
+      });
     },
   );
 

--- a/src/stack/scfStack/tdsqlcPlanner.ts
+++ b/src/stack/scfStack/tdsqlcPlanner.ts
@@ -88,6 +88,7 @@ export const generateDatabasePlan = async (
             `Cluster ${database.name} already exists in provider but is not owned by this stack (missing ${OWNERSHIP_TAG_KEY} tag). Refusing to create — resolve manually.`,
           ),
         cloudToDefinition: cloudTdsqlcToDefinition,
+        refresh: context.refresh,
       });
     },
   );

--- a/src/stack/scfStack/tdsqlcTypes.ts
+++ b/src/stack/scfStack/tdsqlcTypes.ts
@@ -189,9 +189,10 @@ export const extractTdsqlcDefinition = (config: TdsqlcClusterConfig): ResourceAt
 
 // issue #234 phase 2: cloud-side counterpart of extractTdsqlcDefinition.
 // Mirrors the executor write shape key-for-key. Not refreshable (omitted so
-// they can never phantom-drift): autoPause/autoPauseDelay (DescribeClusters
-// does not report the configured idle-pause switch — the cloud field reflects
-// running state, see tdsqlcClusterMapper), port/projectId (not returned).
+// they can never phantom-drift): autoPause/autoPauseDelay — DescribeClusters
+// reports only the running serverless state; the configured switch is compared
+// separately in the planner via DescribeServerlessStrategy (extraUpdate).
+// port/projectId are not returned by any read API.
 export const cloudTdsqlcToDefinition = (info: TdsqlcClusterInfo): ResourceAttributes => ({
   clusterName: info.ClusterName,
   dbType: info.DbType ?? null,

--- a/src/stack/volcengineStack/apigwPlanner.ts
+++ b/src/stack/volcengineStack/apigwPlanner.ts
@@ -83,7 +83,10 @@ export const generateApigwPlan = async (
         (i) => i.type === 'VOLCENGINE_APIGW_SERVICE',
       );
 
-      if (serviceInstance) {
+      // --no-refresh: no live reads, no drift claims — intent-diff only.
+      const refreshEnabled = context.refresh !== false;
+
+      if (refreshEnabled && serviceInstance) {
         // Keep the not-found swallow OUTSIDE the cached read: a cached rejection
         // evicts its key so the next plan pass retries against the provider.
         const remoteService = await cachedRefreshRead(
@@ -112,7 +115,7 @@ export const generateApigwPlan = async (
       // writes; a probe failure stays noop (best-effort detection) instead of
       // fabricating drift from a transient read error.
       let triggersDiffer = false;
-      if (!definitionChanged && serviceInstance && event.triggers.length > 0) {
+      if (refreshEnabled && !definitionChanged && serviceInstance && event.triggers.length > 0) {
         try {
           const desiredTriggers = buildDesiredTriggerMap(event, context.stage);
           const cloudRoutes = await cachedRefreshRead(

--- a/src/stack/volcengineStack/apigwPlanner.ts
+++ b/src/stack/volcengineStack/apigwPlanner.ts
@@ -86,16 +86,17 @@ export const generateApigwPlan = async (
       // --no-refresh: no live reads, no drift claims — intent-diff only.
       const refreshEnabled = context.refresh !== false;
 
+      let cloudService: Awaited<ReturnType<typeof client.apigw.getService>> = null;
       if (refreshEnabled && serviceInstance) {
         // Keep the not-found swallow OUTSIDE the cached read: a cached rejection
         // evicts its key so the next plan pass retries against the provider.
-        const remoteService = await cachedRefreshRead(
+        cloudService = await cachedRefreshRead(
           context,
           `apigw.getService:${serviceInstance.id}`,
           () => client.apigw.getService(serviceInstance.id),
         ).catch(() => null);
 
-        if (!remoteService) {
+        if (!cloudService) {
           return {
             logicalId,
             action: 'create',
@@ -149,7 +150,17 @@ export const generateApigwPlan = async (
         }
       }
 
-      if (definitionChanged || triggersDiffer) {
+      // Issue #234 phase 3: declared custom-domain drift — the service read
+      // already carries customDomains, so this costs no extra API call.
+      const desiredDomainName = (desiredDefinition as { domain?: { domainName?: string } }).domain
+        ?.domainName;
+      let domainDiffers = false;
+      if (refreshEnabled && desiredDomainName) {
+        const cloudDomains = cloudService?.customDomains ?? [];
+        domainDiffers = !cloudDomains.some((d) => d.domain === desiredDomainName);
+      }
+
+      if (definitionChanged || triggersDiffer || domainDiffers) {
         return {
           logicalId,
           action: 'update',

--- a/src/stack/volcengineStack/tosPlanner.ts
+++ b/src/stack/volcengineStack/tosPlanner.ts
@@ -4,6 +4,7 @@ import { createVolcengineClient } from '../../common/volcengineClient';
 import { cachedRefreshRead } from '../../common/refreshCache';
 import { PLAN_READ_CONCURRENCY, mapWithConcurrency } from '../../common/concurrency';
 import { planRefreshedResource } from '../../common/refreshPlanner';
+import { jsonDocumentDiffers } from '../../common/planCompare';
 import { bucketToTosConfig, cloudTosToDefinition, extractTosBucketDefinition } from './tosTypes';
 import { getAllResources, getResource } from '../../common/stateManager';
 import { computeDirectoryHash } from '../../common';
@@ -64,6 +65,23 @@ export const generateBucketPlan = async (
             `Bucket ${bucket.name} already exists in provider but is not owned by this stack (missing ${OWNERSHIP_TAG_KEY} tag). Refusing to create — resolve manually.`,
           ),
         cloudToDefinition: cloudTosToDefinition,
+        extraUpdate: async () => {
+          // Policy needs a canonical compare: the cloud returns a parsed
+          // object while the config serializes it — see jsonDocumentDiffers.
+          const desiredPolicy = (desiredDefinition as { policy?: string | null }).policy ?? null;
+          if (desiredPolicy === null) {
+            return { update: false, drifted: false };
+          }
+          const cloudPolicy = await cachedRefreshRead(
+            context,
+            `tos.getBucketPolicy:${bucket.name}`,
+            () => client.tos.getBucketPolicy(bucket.name),
+          );
+          return {
+            update: jsonDocumentDiffers(desiredPolicy, cloudPolicy),
+            drifted: true,
+          };
+        },
         refresh: context.refresh,
       });
     },

--- a/src/stack/volcengineStack/tosPlanner.ts
+++ b/src/stack/volcengineStack/tosPlanner.ts
@@ -3,10 +3,10 @@ import { Context, BucketDomain, Plan, PlanItem, StateFile, ResourceAttributes } 
 import { createVolcengineClient } from '../../common/volcengineClient';
 import { cachedRefreshRead } from '../../common/refreshCache';
 import { PLAN_READ_CONCURRENCY, mapWithConcurrency } from '../../common/concurrency';
+import { planRefreshedResource } from '../../common/refreshPlanner';
 import { bucketToTosConfig, cloudTosToDefinition, extractTosBucketDefinition } from './tosTypes';
 import { getAllResources, getResource } from '../../common/stateManager';
-import { attributesEqual, computeDirectoryHash } from '../../common';
-import { remoteDiffersFromDesired } from '../../common/planCompare';
+import { computeDirectoryHash } from '../../common';
 import { OWNERSHIP_TAG_KEY, isOwnedByStack } from '../ownershipTag';
 
 const planBucketDeletion = (logicalId: string, definition: ResourceAttributes): PlanItem => ({
@@ -47,82 +47,24 @@ export const generateBucketPlan = async (
         }
       })();
       const desiredDefinition = extractTosBucketDefinition(config, websiteCodeHash);
+      const client = createVolcengineClient(context);
 
-      if (!currentState || currentState.status === 'tainted') {
-        // No usable local state: probe the provider before planning create.
-        // If a same-named bucket already exists WITHOUT our ownership tag it
-        // may belong to another project — fail fast in the plan instead of
-        // letting the executor discover it mid-deploy.
-        const client = createVolcengineClient(context);
-        const remoteBucket = await cachedRefreshRead(context, `tos.getBucket:${bucket.name}`, () =>
-          client.tos.getBucket(bucket.name),
-        );
-        if (remoteBucket && !isOwnedByStack(context, logicalId, remoteBucket.Tags)) {
-          throw new Error(
+      return planRefreshedResource({
+        logicalId,
+        resourceType: 'VOLCENGINE_TOS_BUCKET',
+        currentState,
+        desiredDefinition,
+        read: () =>
+          cachedRefreshRead(context, `tos.getBucket:${bucket.name}`, () =>
+            client.tos.getBucket(bucket.name),
+          ),
+        isOwned: (remote) => isOwnedByStack(context, logicalId, remote.Tags),
+        foreignError: () =>
+          new Error(
             `Bucket ${bucket.name} already exists in provider but is not owned by this stack (missing ${OWNERSHIP_TAG_KEY} tag). Refusing to create — resolve manually.`,
-          );
-        }
-
-        return {
-          logicalId,
-          action: 'create',
-          resourceType: 'VOLCENGINE_TOS_BUCKET',
-          changes: { after: desiredDefinition },
-        };
-      }
-
-      try {
-        const client = createVolcengineClient(context);
-        const remoteBucket = await cachedRefreshRead(context, `tos.getBucket:${bucket.name}`, () =>
-          client.tos.getBucket(bucket.name),
-        );
-
-        if (!remoteBucket) {
-          return {
-            logicalId,
-            action: 'create',
-            resourceType: 'VOLCENGINE_TOS_BUCKET',
-            changes: {
-              before: currentState.definition,
-              after: desiredDefinition,
-            },
-            drifted: true,
-          };
-        }
-
-        const currentDefinition = currentState.definition || {};
-        const definitionChanged = !attributesEqual(currentDefinition, desiredDefinition);
-
-        // Issue #234 phase 2: live attribute drift (console edits to
-        // acl/storage-class/website). One-directional: only mapper-emitted keys
-        // the desired definition declares are compared.
-        const remoteDiffers = remoteDiffersFromDesired(
-          cloudTosToDefinition(remoteBucket),
-          desiredDefinition,
-        );
-
-        if (definitionChanged || remoteDiffers) {
-          return {
-            logicalId,
-            action: 'update',
-            resourceType: 'VOLCENGINE_TOS_BUCKET',
-            changes: { before: currentDefinition, after: desiredDefinition },
-            drifted: true,
-          };
-        }
-
-        return { logicalId, action: 'noop', resourceType: 'VOLCENGINE_TOS_BUCKET' };
-      } catch {
-        return {
-          logicalId,
-          action: 'create',
-          resourceType: 'VOLCENGINE_TOS_BUCKET',
-          changes: {
-            before: currentState.definition,
-            after: desiredDefinition,
-          },
-        };
-      }
+          ),
+        cloudToDefinition: cloudTosToDefinition,
+      });
     },
   );
 

--- a/src/stack/volcengineStack/tosPlanner.ts
+++ b/src/stack/volcengineStack/tosPlanner.ts
@@ -64,6 +64,7 @@ export const generateBucketPlan = async (
             `Bucket ${bucket.name} already exists in provider but is not owned by this stack (missing ${OWNERSHIP_TAG_KEY} tag). Refusing to create — resolve manually.`,
           ),
         cloudToDefinition: cloudTosToDefinition,
+        refresh: context.refresh,
       });
     },
   );

--- a/src/stack/volcengineStack/vefaasPlanner.ts
+++ b/src/stack/volcengineStack/vefaasPlanner.ts
@@ -126,6 +126,22 @@ export const generateFunctionPlan = async (
 
       try {
         const client = createVolcengineClient(context);
+        const currentDefinition = currentState.definition || {};
+        const definitionChanged = !attributesEqual(currentDefinition, desiredDefinition);
+
+        // --no-refresh: no live read, no drift claims — intent-diff only.
+        if (context.refresh === false) {
+          if (!definitionChanged) {
+            return { logicalId, action: 'noop', resourceType: 'VOLCENGINE_VEFAAS' };
+          }
+          return {
+            logicalId,
+            action: 'update',
+            resourceType: 'VOLCENGINE_VEFAAS',
+            changes: { before: currentDefinition, after: desiredDefinition },
+          };
+        }
+
         const remoteFunction = await cachedRefreshRead(
           context,
           `vefaas.getFunction:${fn.name}`,
@@ -144,9 +160,6 @@ export const generateFunctionPlan = async (
             drifted: true,
           };
         }
-
-        const currentDefinition = currentState.definition || {};
-        const definitionChanged = !attributesEqual(currentDefinition, desiredDefinition);
 
         // Drift detection against the LIVE provider: compare the remote
         // function's actual attributes (runtime/handler/memory/timeout/env)

--- a/src/stack/volcengineStack/vefaasPlanner.ts
+++ b/src/stack/volcengineStack/vefaasPlanner.ts
@@ -1,4 +1,4 @@
-import { attributesEqual, computeZipContentHash, getResource } from '../../common';
+import { attributesEqual, computeZipContentHash, getResource, logger } from '../../common';
 import { getAllResources, getSharedResource } from '../../common/stateManager';
 import { createVolcengineClient } from '../../common/volcengineClient';
 import { cachedRefreshRead } from '../../common/refreshCache';
@@ -11,9 +11,16 @@ import {
   ResourceAttributes,
   StateFile,
 } from '../../types';
-import { extractVefaasDefinition, functionToVefaasConfig } from './vefaasTypes';
+import {
+  buildDefaultTrustPolicy,
+  extractVefaasDefinition,
+  functionToVefaasConfig,
+} from './vefaasTypes';
+import { resolveRoleGrant } from './vefaasResource';
+import { buildRolePolicyName } from '../../common/nameBuilder';
 import { buildSharedProjectName, buildFunctionLogTopicName } from './sharedLogProject';
 import { OWNERSHIP_TAG_KEY, isOwnedByStack } from '../ownershipTag';
+import { lang } from '../../lang';
 
 const planFunctionDeletion = (logicalId: string, definition: ResourceAttributes): PlanItem => ({
   logicalId,
@@ -195,6 +202,82 @@ export const generateFunctionPlan = async (
             changes: { before: currentDefinition, after: desiredDefinition },
             drifted: true,
           };
+        }
+
+        // Issue #234 phase 3: live role drift — trust policy and attached
+        // managed policies. The custom <role>-policy DOCUMENT has no read API
+        // (volcengine IAM has no GetPolicy), so it stays executor-reconciled.
+        const iamRoleInstance = currentState.instances.find(
+          (i) => (i as { type?: string }).type === 'VOLCENGINE_IAM_ROLE',
+        ) as { id?: string } | undefined;
+        if (iamRoleInstance?.id) {
+          try {
+            const roleId = iamRoleInstance.id;
+            const roleGrant = resolveRoleGrant(context, state, fn, roleId);
+            const cloudRole = await cachedRefreshRead(context, `iam.getRole:${roleId}`, () =>
+              client.iam.getRole(roleId),
+            );
+            if (!cloudRole) {
+              return {
+                logicalId,
+                action: 'update',
+                resourceType: 'VOLCENGINE_VEFAAS',
+                changes: { before: currentDefinition, after: desiredDefinition },
+                drifted: true,
+              };
+            }
+            let cloudTrust: unknown;
+            try {
+              cloudTrust = JSON.parse(cloudRole.trustPolicyDocument ?? '');
+            } catch {
+              cloudTrust = undefined;
+            }
+            if (
+              cloudTrust &&
+              !attributesEqual(
+                cloudTrust as Record<string, unknown>,
+                buildDefaultTrustPolicy(roleGrant.trustedServices) as unknown as Record<
+                  string,
+                  unknown
+                >,
+              )
+            ) {
+              return {
+                logicalId,
+                action: 'update',
+                resourceType: 'VOLCENGINE_VEFAAS',
+                changes: { before: currentDefinition, after: desiredDefinition },
+                drifted: true,
+              };
+            }
+            const desiredManaged = (
+              (fn.iam?.role as { managed_policies?: string[] } | undefined)?.managed_policies ?? []
+            ).map((arn) => arn.split('/').pop() ?? '');
+            const asSetKey = (names: string[]): string => [...names].sort().join(',');
+            const cloudManaged = await cachedRefreshRead(
+              context,
+              `iam.listAttachedRolePolicies:${roleId}`,
+              () => client.iam.listAttachedRolePolicies(roleId),
+            );
+            const desiredNames = asSetKey([...desiredManaged, buildRolePolicyName(roleId)]);
+            if (desiredNames !== asSetKey(cloudManaged ?? [])) {
+              return {
+                logicalId,
+                action: 'update',
+                resourceType: 'VOLCENGINE_VEFAAS',
+                changes: { before: currentDefinition, after: desiredDefinition },
+                drifted: true,
+              };
+            }
+          } catch (error: unknown) {
+            logger.warn(
+              lang.__('PLAN_FUNCTION_ROLE_PROBE_FAILED', {
+                roleName: iamRoleInstance.id,
+                functionName: fn.name,
+                error: String(error),
+              }),
+            );
+          }
         }
 
         return { logicalId, action: 'noop', resourceType: 'VOLCENGINE_VEFAAS' };

--- a/src/stack/volcengineStack/vefaasResource.ts
+++ b/src/stack/volcengineStack/vefaasResource.ts
@@ -243,7 +243,7 @@ const collectRolePeers = (state: StateFile, context: Context, roleId: string): R
  * and derived policy must be the union across those functions — a single
  * function's update would otherwise strip another function's requirements.
  */
-const resolveRoleGrant = (
+export const resolveRoleGrant = (
   context: Context,
   state: StateFile | undefined,
   fn: FunctionDomain,

--- a/src/types/domains/context.ts
+++ b/src/types/domains/context.ts
@@ -24,6 +24,13 @@ export type Context = {
   reportEvent?: (event: DeploymentEventRecord) => void;
   /** Command-lifecycle cache for planning/refresh reads (created by setContext); executor reads must not use it. */
   refreshCache?: RefreshCache;
+  /**
+   * When false (CLI `--no-refresh`), planners skip live attribute probing and
+   * diff intent-only — no drift claims. The no-state ownership probe still
+   * runs: it is a safety check against adopting foreign resources, not drift
+   * detection.
+   */
+  refresh?: boolean;
 };
 
 export enum TemplateFormat {

--- a/tests/unit/common/planCompare.test.ts
+++ b/tests/unit/common/planCompare.test.ts
@@ -1,4 +1,4 @@
-import { remoteDiffersFromDesired } from '../../../src/common/planCompare';
+import { remoteDiffersFromDesired, jsonDocumentDiffers } from '../../../src/common/planCompare';
 
 describe('remoteDiffersFromDesired', () => {
   it('returns false when every declared desired value matches the remote', () => {
@@ -72,5 +72,26 @@ describe('remoteDiffersFromDesired', () => {
     const desired = { mountPoints: [], handler: '' };
 
     expect(remoteDiffersFromDesired(remote, desired)).toBe(true);
+  });
+});
+
+describe('jsonDocumentDiffers', () => {
+  it('ignores key order and formatting between parsed objects and strings', () => {
+    expect(jsonDocumentDiffers('{"b":2,"a":1}', '{"a":1, "b": 2}')).toBe(false);
+    expect(jsonDocumentDiffers('{"a":1}', { a: 1 })).toBe(false);
+  });
+
+  it('flags real content differences', () => {
+    expect(jsonDocumentDiffers('{"a":1}', { a: 2 })).toBe(true);
+  });
+
+  it('treats undeclared desired or unreadable cloud values as not drift', () => {
+    expect(jsonDocumentDiffers(null, { a: 1 })).toBe(false);
+    expect(jsonDocumentDiffers('{"a":1}', undefined)).toBe(false);
+    expect(jsonDocumentDiffers('{"a":1}', null)).toBe(false);
+  });
+
+  it('returns false on unparseable input instead of fabricating drift', () => {
+    expect(jsonDocumentDiffers('not-json', { a: 1 })).toBe(false);
   });
 });

--- a/tests/unit/common/planFormatter.test.ts
+++ b/tests/unit/common/planFormatter.test.ts
@@ -277,5 +277,73 @@ describe('planFormatter', () => {
       expect(aIndex).toBeGreaterThan(-1);
       expect(bIndex).toBeGreaterThan(-1);
     });
+
+    it('marks drifted updates with the drift marker line', () => {
+      const items: PlanItem[] = [
+        {
+          logicalId: 'functions.a',
+          action: 'update',
+          resourceType: 'ALIYUN_FC3',
+          drifted: true,
+          changes: { before: { memory: 128 }, after: { memory: 256 } },
+        },
+      ];
+
+      const output = formatPlanItem(items[0], config);
+
+      expect(output).toContain('cloud changed outside of this config');
+    });
+
+    it('does not mark undrifted updates with the drift marker', () => {
+      const items: PlanItem[] = [
+        {
+          logicalId: 'functions.a',
+          action: 'update',
+          resourceType: 'ALIYUN_FC3',
+          changes: { before: { memory: 128 }, after: { memory: 256 } },
+        },
+      ];
+
+      const output = formatPlanItem(items[0], config);
+
+      expect(output).not.toContain('cloud changed outside of this config');
+    });
+
+    it('summarizes drifted resources when any item drifted', () => {
+      const items: PlanItem[] = [
+        {
+          logicalId: 'functions.a',
+          action: 'update',
+          resourceType: 'ALIYUN_FC3',
+          drifted: true,
+          changes: { before: { memory: 128 }, after: { memory: 256 } },
+        },
+        {
+          logicalId: 'functions.b',
+          action: 'create',
+          resourceType: 'ALIYUN_FC3',
+          changes: { after: { name: 'b' } },
+        },
+      ];
+
+      const output = formatPlan(items, config);
+
+      expect(output).toContain('Drift: 1 resource(s)');
+    });
+
+    it('omits the drift summary when nothing drifted', () => {
+      const items: PlanItem[] = [
+        {
+          logicalId: 'functions.b',
+          action: 'create',
+          resourceType: 'ALIYUN_FC3',
+          changes: { after: { name: 'b' } },
+        },
+      ];
+
+      const output = formatPlan(items, config);
+
+      expect(output).not.toContain('Drift:');
+    });
   });
 });

--- a/tests/unit/common/refreshPlanner.test.ts
+++ b/tests/unit/common/refreshPlanner.test.ts
@@ -1,0 +1,88 @@
+import { planRefreshedResource } from '../../../src/common/refreshPlanner';
+import type { PlanRefreshedResourceArgs } from '../../../src/common/refreshPlanner';
+import type { ResourceState } from '../../../src/types';
+
+type Remote = { name: string; memory: number };
+
+describe('planRefreshedResource', () => {
+  const currentState: ResourceState = {
+    mode: 'managed',
+    region: 'cn-hangzhou',
+    definition: { name: 'test', memory: 128 },
+    instances: [{ sid: 's', id: 'test' }],
+    lastUpdated: '2024-01-01T00:00:00Z',
+  };
+
+  const args = (
+    overrides?: Partial<PlanRefreshedResourceArgs<Remote>>,
+  ): PlanRefreshedResourceArgs<Remote> => ({
+    logicalId: 'buckets.test',
+    resourceType: 'ALIYUN_OSS_BUCKET',
+    currentState,
+    desiredDefinition: { name: 'test', memory: 128 },
+    read: jest.fn().mockResolvedValue({ name: 'test', memory: 128 }),
+    isOwned: () => true,
+    foreignError: () => new Error('foreign'),
+    cloudToDefinition: (remote) => ({ ...remote }),
+    ...overrides,
+  });
+
+  it('returns noop when the live cloud matches the intent', async () => {
+    const overrides = args();
+    const item = await planRefreshedResource(overrides);
+
+    expect(item).toMatchObject({ action: 'noop' });
+    expect(overrides.read).toHaveBeenCalledTimes(1);
+  });
+
+  it('flags update+drifted when the live attributes drifted', async () => {
+    const read = jest.fn().mockResolvedValue({ name: 'test', memory: 64 });
+    const item = await planRefreshedResource(args({ read }));
+
+    expect(item).toMatchObject({ action: 'update', drifted: true });
+  });
+
+  it('flags create+drifted when the remote is gone', async () => {
+    const read = jest.fn().mockResolvedValue(null);
+    const item = await planRefreshedResource(args({ read }));
+
+    expect(item).toMatchObject({ action: 'create', drifted: true });
+  });
+
+  it('throws on the probe path when a foreign same-named remote exists', async () => {
+    await expect(
+      planRefreshedResource(
+        args({
+          currentState: undefined,
+          read: jest.fn().mockResolvedValue({ name: 'test' }),
+          isOwned: () => false,
+        }),
+      ),
+    ).rejects.toThrow('foreign');
+  });
+
+  describe('--no-refresh', () => {
+    it('skips the live read and diffs intent only (no drifted claims)', async () => {
+      const read = jest.fn().mockResolvedValue({ name: 'test', memory: 64 });
+      const item = await planRefreshedResource(args({ read, refresh: false }));
+
+      expect(read).not.toHaveBeenCalled();
+      expect(item).toMatchObject({ action: 'noop' });
+    });
+
+    it('plans update without the drifted flag on intent changes', async () => {
+      const read = jest.fn().mockResolvedValue({ name: 'test', memory: 128 });
+      const item = await planRefreshedResource(
+        args({
+          read,
+          refresh: false,
+          desiredDefinition: { name: 'test', memory: 256 },
+        }),
+      );
+
+      expect(read).not.toHaveBeenCalled();
+      expect(item).toMatchObject({ action: 'update' });
+      expect(item).not.toHaveProperty('drifted');
+    });
+  });
+});

--- a/tests/unit/stack/scfStack/cosPlanner.test.ts
+++ b/tests/unit/stack/scfStack/cosPlanner.test.ts
@@ -236,6 +236,40 @@ describe('cosPlanner', () => {
       expect(plan.items[0].action).toBe('noop');
     });
 
+    it('compares the live bucket policy canonically (issue #234 phase 3)', async () => {
+      const stateWithBucket: StateFile = {
+        ...initialState,
+        resources: {
+          'buckets.test_bucket': {
+            mode: 'managed' as ResourceMode,
+            region: 'ap-guangzhou',
+            definition: { bucket: 'test-bucket' },
+            instances: [],
+            lastUpdated: new Date().toISOString(),
+          },
+        },
+      };
+      (stateManager.getResource as jest.Mock).mockReturnValue({
+        definition: { bucket: 'test-bucket', policy: '{"statement":[{"a":1}]}' },
+      });
+      (stateManager.getAllResources as jest.Mock).mockReturnValue({});
+      (cosTypes.extractCosBucketDefinition as jest.Mock).mockReturnValue({
+        bucket: 'test-bucket',
+        policy: '{"statement":[{"a":1}]}',
+      });
+      (cosTypes.cloudCosToDefinition as jest.Mock).mockReturnValue({});
+      // Cloud policy is key-order-reversed but semantically identical.
+      (mockCosOperations.getBucket as jest.Mock).mockResolvedValue({
+        Bucket: 'test-bucket',
+        Policy: { statement: [{ a: 1 }] },
+      });
+      (hashUtils.attributesEqual as jest.Mock).mockReturnValue(true);
+
+      const result = await generateBucketPlan(mockContext, stateWithBucket, [testBucket]);
+
+      expect(result.items[0]).toMatchObject({ action: 'noop' });
+    });
+
     it('flags update+drifted when the live acl drifted from config (issue #234 phase 2)', async () => {
       const stateWithBucket: StateFile = {
         ...initialState,

--- a/tests/unit/stack/scfStack/scfPlanner.test.ts
+++ b/tests/unit/stack/scfStack/scfPlanner.test.ts
@@ -19,11 +19,17 @@ const mockScfOperations = {
   deleteFunction: jest.fn(),
 };
 
+const mockClsOperations = {
+  getLogsetNameById: jest.fn(),
+  listTopicsByLogset: jest.fn(),
+};
+
 jest.mock('../../../../src/common/tencentClient', () => ({
   createTencentClient: () => ({
     scf: mockScfOperations,
     cos: {},
     tdsqlc: {},
+    cls: mockClsOperations,
   }),
 }));
 
@@ -334,6 +340,120 @@ describe('SCF Planner', () => {
           },
         }),
       );
+    });
+
+    it('resolves live CLS ids to names and stays noop when they match (issue #234 phase 3)', async () => {
+      mockClsOperations.getLogsetNameById.mockResolvedValue('test-app-default-cls');
+      mockClsOperations.listTopicsByLogset.mockResolvedValue([
+        { TopicId: 'topic-1', TopicName: 'test-service-default-test_fn-fn-logs' },
+      ]);
+
+      mockScfOperations.getFunction.mockResolvedValue({
+        FunctionName: 'test-function',
+        Runtime: 'Nodejs18.15',
+        Handler: 'index.handler',
+        MemorySize: 512,
+        Timeout: 10,
+        Environment: {
+          Variables: [{ Key: 'NODE_ENV', Value: 'production' }],
+        },
+        ClsLogsetId: 'cls-1',
+        ClsTopicId: 'topic-1',
+      });
+
+      const fnWithLog = { ...testFunction, log: true };
+
+      const state = setResource(initalState, 'functions.test_fn', {
+        mode: 'managed',
+        region: 'ap-guangzhou',
+        definition: {
+          functionName: 'test-function',
+          runtime: 'Nodejs18.15',
+          handler: 'index.handler',
+          memorySize: 512,
+          timeout: 10,
+          environment: { NODE_ENV: 'production' },
+          codeHash: 'mock-code-hash',
+          vpcConfig: null,
+          diskSize: null,
+          cfsConfig: null,
+          useGpu: null,
+          imageConfig: null,
+          logConfig: {
+            logset: 'test-app-default-cls',
+            topic: 'test-service-default-test_fn-fn-logs',
+          },
+        },
+        instances: [
+          {
+            sid: 'si:tencent:scf:default:test-function',
+            id: 'test-function',
+            functionName: 'test-function',
+          },
+        ],
+        lastUpdated: new Date().toISOString(),
+      });
+
+      const plan = await generateFunctionPlan(mockContext, state, [fnWithLog]);
+
+      expect(plan.items[0]).toMatchObject({ action: 'noop' });
+    });
+
+    it('flags update+drifted when the live topic id resolves to a different name (issue #234 phase 3)', async () => {
+      mockClsOperations.getLogsetNameById.mockResolvedValue('test-app-default-cls');
+      mockClsOperations.listTopicsByLogset.mockResolvedValue([
+        { TopicId: 'topic-1', TopicName: 'console-renamed-topic' },
+      ]);
+
+      mockScfOperations.getFunction.mockResolvedValue({
+        FunctionName: 'test-function',
+        Runtime: 'Nodejs18.15',
+        Handler: 'index.handler',
+        MemorySize: 512,
+        Timeout: 10,
+        Environment: {
+          Variables: [{ Key: 'NODE_ENV', Value: 'production' }],
+        },
+        ClsLogsetId: 'cls-1',
+        ClsTopicId: 'topic-1',
+      });
+
+      const fnWithLog = { ...testFunction, log: true };
+
+      const state = setResource(initalState, 'functions.test_fn', {
+        mode: 'managed',
+        region: 'ap-guangzhou',
+        definition: {
+          functionName: 'test-function',
+          runtime: 'Nodejs18.15',
+          handler: 'index.handler',
+          memorySize: 512,
+          timeout: 10,
+          environment: { NODE_ENV: 'production' },
+          codeHash: 'mock-code-hash',
+          vpcConfig: null,
+          diskSize: null,
+          cfsConfig: null,
+          useGpu: null,
+          imageConfig: null,
+          logConfig: {
+            logset: 'test-app-default-cls',
+            topic: 'test-service-default-test_fn-fn-logs',
+          },
+        },
+        instances: [
+          {
+            sid: 'si:tencent:scf:default:test-function',
+            id: 'test-function',
+            functionName: 'test-function',
+          },
+        ],
+        lastUpdated: new Date().toISOString(),
+      });
+
+      const plan = await generateFunctionPlan(mockContext, state, [fnWithLog]);
+
+      expect(plan.items[0]).toMatchObject({ action: 'update', drifted: true });
     });
 
     it('should plan to delete function when removed from config', async () => {

--- a/tests/unit/stack/scfStack/tdsqlcPlanner.test.ts
+++ b/tests/unit/stack/scfStack/tdsqlcPlanner.test.ts
@@ -15,6 +15,7 @@ const mockTdsqlcOperations = {
   createCluster: jest.fn(),
   getCluster: jest.fn(),
   getClusterByName: jest.fn(),
+  getServerlessStrategy: jest.fn().mockResolvedValue(null),
   updateCluster: jest.fn(),
   deleteCluster: jest.fn(),
 };
@@ -343,6 +344,51 @@ describe('TdsqlcPlanner', () => {
         SubnetId: 'subnet-67890',
         MinStorageSize: 10,
         MaxStorageSize: 1000,
+      });
+
+      const result = await generateDatabasePlan(mockContext, mockState, [mockDatabase]);
+
+      expect(result.items[0]).toMatchObject({ action: 'update', drifted: true });
+    });
+
+    it('flags update+drifted when the configured autoPause drifted (issue #234 phase 3)', async () => {
+      const existingState: ResourceState = {
+        mode: 'managed',
+        region: 'ap-guangzhou',
+        definition: expectedDefinition,
+        instances: [
+          {
+            sid: 'si:tencent:cynosdb:default:cynosdbmysql-test123',
+            id: 'cynosdbmysql-test123',
+            clusterName: 'test-tdsqlc',
+          },
+        ],
+        lastUpdated: '2024-01-01T00:00:00Z',
+        metadata: { clusterId: 'cynosdbmysql-test123' },
+      };
+
+      jest.spyOn(stateManager, 'getResource').mockReturnValue(existingState);
+      jest.spyOn(stateManager, 'getAllResources').mockReturnValue({});
+      jest.spyOn(mockTdsqlcOperations, 'getCluster').mockResolvedValue({
+        ClusterId: 'cynosdbmysql-test123',
+        ClusterName: 'test-tdsqlc',
+        Status: 'running',
+        Region: 'ap-guangzhou',
+        DbType: 'MYSQL' as const,
+        DbVersion: '8.0',
+        DbMode: 'SERVERLESS',
+        MinCpu: 1,
+        MaxCpu: 8,
+        StoragePayMode: 0,
+        VpcId: 'vpc-12345',
+        SubnetId: 'subnet-67890',
+        MinStorageSize: 10,
+        MaxStorageSize: 1000,
+      });
+      // The console enabled the idle-pause switch; config declares it off.
+      jest.spyOn(mockTdsqlcOperations, 'getServerlessStrategy').mockResolvedValue({
+        autoPause: true,
+        autoPauseDelay: 600,
       });
 
       const result = await generateDatabasePlan(mockContext, mockState, [mockDatabase]);

--- a/tests/unit/stack/volcengineStack/tosPlanner.test.ts
+++ b/tests/unit/stack/volcengineStack/tosPlanner.test.ts
@@ -46,12 +46,13 @@ describe('tosPlanner', () => {
     resources: {},
   };
 
-  let mockTosClient: { tos: { getBucket: jest.Mock } };
+  let mockTosClient: { tos: { getBucket: jest.Mock; getBucketPolicy: jest.Mock } };
 
   beforeEach(() => {
     mockTosClient = {
       tos: {
         getBucket: jest.fn(),
+        getBucketPolicy: jest.fn(),
       },
     };
     (createVolcengineClient as jest.Mock).mockReturnValue(mockTosClient);
@@ -357,6 +358,72 @@ describe('tosPlanner', () => {
       const result = await generateBucketPlan(mockContext, stateWithBucket, buckets);
 
       expect(result.items[0]).toMatchObject({ action: 'update', drifted: true });
+    });
+
+    it('compares the live bucket policy canonically (issue #234 phase 3)', async () => {
+      const buckets: Array<BucketDomain> = [
+        {
+          key: 'static_site',
+          name: 'test-bucket',
+          iam: {
+            resource: {
+              statements: [
+                {
+                  effect: 'Allow',
+                  principal: { AWS: ['*'] },
+                  action: ['tos:Get*'],
+                  resource: ['trn:tos:::*'],
+                },
+              ],
+            },
+          },
+        },
+      ];
+
+      const stateWithBucket: StateFile = {
+        ...mockState,
+        resources: {
+          'buckets.static_site': {
+            mode: 'managed',
+            region: 'cn-beijing',
+            definition: {
+              bucketName: 'test-bucket',
+              acl: null,
+              storageClass: null,
+              websiteConfiguration: null,
+              websiteCodeHash: null,
+              policy:
+                '{"resource":{"statements":[{"effect":"Allow","principal":{"AWS":["*"]},"action":["tos:Get*"],"resource":["trn:tos:::*"]}]}}',
+            },
+            instances: [{ sid: 'test-sid', id: 'test-bucket', type: 'VOLCENGINE_TOS_BUCKET' }],
+            lastUpdated: '2024-01-01T00:00:00Z',
+          },
+        },
+      };
+
+      // Cloud returns the same policy parsed as an object with reversed key
+      // order — canonical compare must treat it as equal.
+      mockTosClient.tos.getBucket.mockResolvedValueOnce({ name: 'test-bucket' });
+      mockTosClient.tos.getBucketPolicy.mockResolvedValueOnce({
+        resource: {
+          statements: [
+            {
+              effect: 'Allow',
+              principal: { AWS: ['*'] },
+              action: ['tos:Get*'],
+              resource: ['trn:tos:::*'],
+            },
+          ],
+        },
+      });
+
+      jest
+        .spyOn(stateManager, 'getResource')
+        .mockReturnValue(stateWithBucket.resources['buckets.static_site']);
+
+      const result = await generateBucketPlan(mockContext, stateWithBucket, buckets);
+
+      expect(result.items[0]).toMatchObject({ action: 'noop' });
     });
 
     it('skips the live read and drops drift claims under --no-refresh (issue #234 phase 3)', async () => {

--- a/tests/unit/stack/volcengineStack/tosPlanner.test.ts
+++ b/tests/unit/stack/volcengineStack/tosPlanner.test.ts
@@ -359,6 +359,80 @@ describe('tosPlanner', () => {
       expect(result.items[0]).toMatchObject({ action: 'update', drifted: true });
     });
 
+    it('skips the live read and drops drift claims under --no-refresh (issue #234 phase 3)', async () => {
+      const buckets: Array<BucketDomain> = [
+        {
+          key: 'static_site',
+          name: 'test-bucket',
+          security: { acl: BucketAccessEnum.PUBLIC_READ, force_delete: false },
+        },
+      ];
+
+      const stateWithBucket: StateFile = {
+        ...mockState,
+        resources: {
+          'buckets.static_site': {
+            mode: 'managed',
+            region: 'cn-beijing',
+            definition: {
+              bucketName: 'test-bucket',
+              acl: 'public-read',
+              storageClass: null,
+              websiteConfiguration: null,
+              websiteCodeHash: null,
+              policy: null,
+            },
+            instances: [{ sid: 'test-sid', id: 'test-bucket', type: 'VOLCENGINE_TOS_BUCKET' }],
+            lastUpdated: '2024-01-01T00:00:00Z',
+          },
+        },
+      };
+
+      // The live value is drifted on purpose: --no-refresh must never read it.
+      mockTosClient.tos.getBucket.mockResolvedValueOnce({
+        name: 'test-bucket',
+        acl: 'private',
+      });
+
+      jest
+        .spyOn(stateManager, 'getResource')
+        .mockReturnValue(stateWithBucket.resources['buckets.static_site']);
+
+      const result = await generateBucketPlan(
+        { ...mockContext, refresh: false },
+        stateWithBucket,
+        buckets,
+      );
+
+      expect(mockTosClient.tos.getBucket).not.toHaveBeenCalled();
+      expect(result.items[0]).toMatchObject({ action: 'noop' });
+
+      const changedState: StateFile = {
+        ...stateWithBucket,
+        resources: {
+          'buckets.static_site': {
+            ...stateWithBucket.resources['buckets.static_site'],
+            definition: {
+              ...stateWithBucket.resources['buckets.static_site'].definition,
+              acl: 'private',
+            },
+          },
+        },
+      };
+      jest
+        .spyOn(stateManager, 'getResource')
+        .mockReturnValue(changedState.resources['buckets.static_site']);
+
+      const changedResult = await generateBucketPlan(
+        { ...mockContext, refresh: false },
+        changedState,
+        buckets,
+      );
+
+      expect(changedResult.items[0]).toMatchObject({ action: 'update' });
+      expect(changedResult.items[0]).not.toHaveProperty('drifted');
+    });
+
     it('stays noop when live bucket matches config despite cloud-only detail fields', async () => {
       const buckets: Array<BucketDomain> = [
         {


### PR DESCRIPTION
## Summary

Issue #234 **Phase 3 — 收尾**: shared refresh skeleton, drift visualization, the `--no-refresh` escape hatch, and the API-verified drift dimensions from the epic's not-refreshable survey.

### Shared refresh skeleton (先行项)

New `src/common/refreshPlanner.ts`: `planRefreshedResource` covers the uniform no-state-probe / exists-refresh decision chain (probe → ownership → create; missing → create+drifted; intent-diff or live-attribute drift → update+drifted; extra bookkeeping conditions → update per drift flag; read failure → create fallback). **7 uniform planners migrated** (aliyun oss/tablestore/database, tencent cos/tdsqlc/es, volcengine tos) — fc3/vefaas/apigw keep their custom flows (role probes, trigger reconciliation, config normalization) and are documented as such.

### Drift visualization (refresh-only semantics)

Drifted plan items now render a marker line ("cloud changed outside of this config, will be reconciled") plus a drift summary count — the item-level before→after attribute diff already existed; only the drift provenance was invisible.

### `--no-refresh` flag (plan & deploy)

Aligns with Terraform `-refresh=false`: the diff baseline degenerates to intent-only (config vs state) with **no drift claims**. The no-state ownership probe still runs — it is a safety check against adopting foreign resources, not drift detection. Implemented via `Context.refresh` through the shared skeleton plus explicit guards in fc3/vefaas/apigw.

### API-verified drift dimensions (Phase 3 checklist)

All external APIs verified against official provider docs + generated SDK models before implementation:

| Dimension | Verdict | Basis |
|---|---|---|
| COS/TOS bucket **policy** | ✅ implemented | canonical compare (`jsonDocumentDiffers`) — parse both sides, key-order-insensitive; TOS `GetBucketPolicy` confirmed to exist |
| volcengine veFaaS role **trust + attached policies** | ✅ implemented | IAM `GetRole` → `TrustPolicyDocument`, `ListAttachedRolePolicies`; desired grant derived via the executor's own `resolveRoleGrant`; custom `<role>-policy` document has no read API (stays executor-reconciled) |
| VOLCENGINE_APIGW declared **custom domain** | ✅ implemented | presence compared against the service read's `customDomains` — zero extra API calls |
| SCF **logConfig** id→name resolution | ⏳ remaining | reads verified: `DescribeLogsets` (LogsetId+LogsetName), `DescribeTopics` (TopicId+TopicName, filterable); needs a by-id cls read op |
| TDSQL-C **autoPause** | ⏳ remaining — **correction to earlier conclusion**: the configured switch IS readable via the dedicated `DescribeServerlessStrategy` API (`AutoPause`: yes/no) — `DescribeClusters` only reports running state |
| TENCENT_ES **version** | ⛔ permanent | no ES serverless describe API reports the engine version; `DescribeServerlessSpaceVCU` does not exist |

### Follow-up issues

- #238 — user-facing `ignore_changes` escape hatch (feature-sized)
- #239 — fc3 container-only function deploy crash (`fn.code!` in the executor; planner already fixed)

## Test plan

- [x] `npm run build` + `npm run lint:check` clean
- [x] Full `npm run test:ci`: **165/165 suites, 3456/3456 tests**, coverage gates met
- [x] Skeleton: behavior-preserving migration (all planner suites green verbatim), helper unit tests incl. `--no-refresh`
- [x] New drift dimensions: canonical policy tests (COS+TOS), role trust/attached tests, domain presence test
- [x] Drift display: marker + summary tests

Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-openagent)
