### PR TITLE
feat(nested): function-owned nested resource drift repair — M1-M5 (issue #234)

### DIFF
--- a/src/common/aliyunClient/ecsOperations.ts
+++ b/src/common/aliyunClient/ecsOperations.ts
@@ -24,6 +24,18 @@ const transformPortRange = (protocol: string, portRange: string): string => {
 
 const normalizeProtocol = (protocol: string): string => protocol.trim().toUpperCase();
 
+/**
+ * Canonical rule key for config-vs-live comparison (issue #234 M2): protocol
+ * normalized, ports in Aliyun wire format, CIDR verbatim — the exact tuple an
+ * AuthorizeSecurityGroup call writes and DescribeSecurityGroupAttribute
+ * returns.
+ */
+/* istanbul ignore next */ export const canonicalSecurityGroupRule = (
+  protocol: string,
+  portRange: string,
+  cidr: string,
+): string => `${protocol.toUpperCase()}|${transformPortRange(protocol, portRange)}|${cidr}`;
+
 /* istanbul ignore next */ export const parseSecurityGroupRule = (
   rule: string,
 ): { protocol: string; cidr: string; portRange: string } => {
@@ -154,6 +166,77 @@ const isDuplicateSecurityGroupRuleError = (error: unknown): boolean => {
         };
       }
       return sg;
+    },
+
+    authorizeSecurityGroupRules: async (
+      securityGroupId: string,
+      direction: 'ingress' | 'egress',
+      rules: Array<{ protocol: string; cidr: string; portRange: string }>,
+    ): Promise<void> => {
+      for (const parsed of rules) {
+        try {
+          if (direction === 'ingress') {
+            const request = new ecs.AuthorizeSecurityGroupRequest({
+              regionId: context.region,
+              securityGroupId,
+              ipProtocol: parsed.protocol.toLowerCase(),
+              sourceCidrIp: parsed.cidr,
+              portRange: transformPortRange(parsed.protocol, parsed.portRange),
+            });
+            await ecsClient.authorizeSecurityGroup(request);
+          } else {
+            const request = new ecs.AuthorizeSecurityGroupEgressRequest({
+              regionId: context.region,
+              securityGroupId,
+              ipProtocol: parsed.protocol.toLowerCase(),
+              destCidrIp: parsed.cidr,
+              portRange: transformPortRange(parsed.protocol, parsed.portRange),
+            });
+            await ecsClient.authorizeSecurityGroupEgress(request);
+          }
+        } catch (error) {
+          if (isDuplicateSecurityGroupRuleError(error)) {
+            continue;
+          }
+          logger.warn(
+            `Failed to authorize ${direction} rule for ${securityGroupId}: ${String(error)}`,
+          );
+        }
+      }
+    },
+
+    revokeSecurityGroupRules: async (
+      securityGroupId: string,
+      direction: 'ingress' | 'egress',
+      rules: Array<{ protocol: string; cidr: string; portRange: string }>,
+    ): Promise<void> => {
+      for (const parsed of rules) {
+        try {
+          if (direction === 'ingress') {
+            const request = new ecs.RevokeSecurityGroupRequest({
+              regionId: context.region,
+              securityGroupId,
+              ipProtocol: parsed.protocol.toLowerCase(),
+              sourceCidrIp: parsed.cidr,
+              portRange: transformPortRange(parsed.protocol, parsed.portRange),
+            });
+            await ecsClient.revokeSecurityGroup(request);
+          } else {
+            const request = new ecs.RevokeSecurityGroupEgressRequest({
+              regionId: context.region,
+              securityGroupId,
+              ipProtocol: parsed.protocol.toLowerCase(),
+              destCidrIp: parsed.cidr,
+              portRange: transformPortRange(parsed.protocol, parsed.portRange),
+            });
+            await ecsClient.revokeSecurityGroupEgress(request);
+          }
+        } catch (error) {
+          logger.warn(
+            `Failed to revoke ${direction} rule for ${securityGroupId}: ${String(error)}`,
+          );
+        }
+      }
     },
 
     getSecurityGroupRules: async (

--- a/src/common/aliyunClient/nasOperations.ts
+++ b/src/common/aliyunClient/nasOperations.ts
@@ -1,4 +1,5 @@
 import NasClient from '@alicloud/nas20170626';
+import { logger } from '../logger';
 import * as nas from '@alicloud/nas20170626';
 import { NasStorageClassEnum } from '../../types';
 import {
@@ -223,6 +224,27 @@ export const createNasOperations = (nasClient: NasSdkClient) => {
         vSwitchId,
         accessGroupName,
       };
+    },
+
+    listMountTargets: async (fileSystemId: string): Promise<NasMountTargetInfo[]> => {
+      try {
+        const request = new nas.DescribeMountTargetsRequest({
+          fileSystemId,
+        });
+        const response = await nasClient.describeMountTargets(request);
+        const raw =
+          (response?.body?.mountTargets?.mountTarget as Array<Record<string, unknown>>) ?? [];
+        return raw
+          .filter((mt) => mt.mountTargetDomain)
+          .map((mt) => ({
+            fileSystemId,
+            mountTargetDomain: mt.mountTargetDomain as string,
+            status: mt.status as string | undefined,
+          }));
+      } catch (error: unknown) {
+        logger.debug(`Failed to list mount targets: ${String(error)}`);
+        return [];
+      }
     },
 
     getMountTarget: async (

--- a/src/common/aliyunClient/slsOperations.ts
+++ b/src/common/aliyunClient/slsOperations.ts
@@ -6,6 +6,12 @@ import { pollUntil, PollingTimeoutError } from '../polling';
 
 type SlsSdkClient = SlsClient;
 
+// The logstore attributes si creates with (issue #234 M1): `fn.log` is a
+// boolean — these are stack constants, so live values differing from them are
+// out-of-band drift.
+export const SLS_LOGSTORE_TTL = 30;
+export const SLS_LOGSTORE_SHARDS = 2;
+
 const waitForSlsProject = async (
   getProject: (projectName: string) => Promise<SlsProjectInfo | null>,
   projectName: string,
@@ -140,12 +146,12 @@ export const createSlsOperations = (slsClient: SlsSdkClient) => {
     createLogstore: async (
       projectName: string,
       logstoreName: string,
-      ttl: number = 30,
+      ttl: number = SLS_LOGSTORE_TTL,
     ): Promise<SlsLogstoreInfo> => {
       const request = new sls.CreateLogStoreRequest({
         logstoreName,
         ttl,
-        shardCount: 2,
+        shardCount: SLS_LOGSTORE_SHARDS,
       });
 
       await slsClient.createLogStore(projectName, request);
@@ -184,6 +190,20 @@ export const createSlsOperations = (slsClient: SlsSdkClient) => {
         }
         throw error;
       }
+    },
+
+    updateLogstore: async (
+      projectName: string,
+      logstoreName: string,
+      ttl: number,
+      shardCount: number,
+    ): Promise<void> => {
+      const request = new sls.UpdateLogStoreRequest({
+        logstoreName,
+        ttl,
+        shardCount,
+      });
+      await slsClient.updateLogStore(projectName, logstoreName, request);
     },
 
     deleteLogstore: async (projectName: string, logstoreName: string): Promise<void> => {

--- a/src/common/tencentClient/clsOperations.ts
+++ b/src/common/tencentClient/clsOperations.ts
@@ -30,6 +30,12 @@ const isAlreadyExists = (error: unknown): boolean => {
 
 export type ClsTag = { key: string; value: string };
 
+// The topic attributes si creates with (issue #234 M3): `fn.log` is a
+// boolean — these are stack constants, so live values differing from them are
+// out-of-band drift.
+export const CLS_TOPIC_PERIOD = 30;
+export const CLS_TOPIC_STORAGE_TYPE = 'hot';
+
 export const createClsOperations = (clsClient: ClsSdkClient) => {
   const operations = {
     createLogset: async (
@@ -100,6 +106,31 @@ export const createClsOperations = (clsClient: ClsSdkClient) => {
       return response?.Topics?.find((t) => t.TopicName === topicName) ?? null;
     },
 
+    getTopicById: async (
+      topicId: string,
+    ): Promise<{
+      TopicId?: string;
+      TopicName?: string;
+      StorageType?: string;
+      Period?: number;
+    } | null> => {
+      const response = await clsClient.DescribeTopics({
+        Filters: [{ Key: 'topicId', Values: [topicId] }],
+      });
+      return response?.Topics?.find((t) => t.TopicId === topicId) ?? null;
+    },
+
+    modifyTopic: async (
+      topicId: string,
+      opts: { period: number; storageType: string },
+    ): Promise<void> => {
+      await clsClient.ModifyTopic({
+        TopicId: topicId,
+        Period: opts.period,
+        StorageType: opts.storageType,
+      });
+    },
+
     waitForTopic: async (
       logsetId: string,
       topicName: string,
@@ -122,8 +153,8 @@ export const createClsOperations = (clsClient: ClsSdkClient) => {
       await clsClient.CreateTopic({
         LogsetId: logsetId,
         TopicName: topicName,
-        StorageType: opts.storageType ?? 'hot',
-        Period: opts.period ?? 30,
+        StorageType: opts.storageType ?? CLS_TOPIC_STORAGE_TYPE,
+        Period: opts.period ?? CLS_TOPIC_PERIOD,
         Tags: opts.tags.map((t) => ({ Key: t.key, Value: t.value })),
       });
       const topic = await operations.waitForTopic(logsetId, topicName);

--- a/src/common/volcengineClient/tlsOperations.ts
+++ b/src/common/volcengineClient/tlsOperations.ts
@@ -17,6 +17,12 @@ type TlsSdkClient = TlsService;
 const WAIT_INTERVAL_MS = 5000;
 const MAX_WAIT_ATTEMPTS = 30;
 
+// The topic attributes si creates with (issue #234 M5): `fn.log` is a
+// boolean — these are stack constants, so live values differing from them are
+// out-of-band drift. ModifyTopic cannot change shard count (create-only).
+export const TLS_TOPIC_TTL = 30;
+export const TLS_TOPIC_SHARDS = 1;
+
 const waitForProjectReady = async (
   getProject: (projectName: string) => Promise<TlsProjectInfo | null>,
   projectName: string,
@@ -234,8 +240,8 @@ export const createTlsOperations = (tlsClient: TlsSdkClient) => {
           ProjectId: project.projectId,
           TopicName: config.topicName,
           Description: config.description,
-          Ttl: config.ttl ?? 30,
-          ShardCount: 1,
+          Ttl: config.ttl ?? TLS_TOPIC_TTL,
+          ShardCount: TLS_TOPIC_SHARDS,
         });
 
         logger.info(lang.__('TLS_TOPIC_CREATED', { topicName: config.topicName }));
@@ -245,7 +251,7 @@ export const createTlsOperations = (tlsClient: TlsSdkClient) => {
           topicName: config.topicName,
           projectName: config.projectName,
           description: config.description,
-          ttl: config.ttl ?? 30,
+          ttl: config.ttl ?? TLS_TOPIC_TTL,
           status: 'Active',
         };
       } catch (error: unknown) {
@@ -302,6 +308,10 @@ export const createTlsOperations = (tlsClient: TlsSdkClient) => {
         }
         throw error;
       }
+    },
+
+    modifyTopic: async (topicId: string, ttl: number): Promise<void> => {
+      await tlsClient.ModifyTopic({ TopicId: topicId, Ttl: ttl });
     },
 
     listTopics: async (projectName: string): Promise<TlsTopicInfo[]> => {

--- a/src/common/volcengineClient/types.ts
+++ b/src/common/volcengineClient/types.ts
@@ -658,6 +658,7 @@ export type VolcengineClient = {
     createTopic: (config: TlsTopicConfig) => Promise<TlsTopicInfo>;
     getTopic: (projectName: string, topicName: string) => Promise<TlsTopicInfo | null>;
     listTopics: (projectName: string) => Promise<TlsTopicInfo[]>;
+    modifyTopic: (topicId: string, ttl: number) => Promise<void>;
     deleteTopic: (projectName: string, topicName: string) => Promise<void>;
     createIndex: (config: TlsIndexConfig) => Promise<void>;
     deleteIndex: (projectName: string, topicName: string) => Promise<void>;

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -287,6 +287,8 @@ export const en = {
   NESTED_LOGSTORE_RECREATED: 'Logstore {{logstoreName}} was deleted out-of-band; recreating it',
   NESTED_LOGSTORE_UPDATED:
     'Logstore {{logstoreName}} attributes drifted; updating to match si defaults',
+  NESTED_SG_RULES_REPAIRED:
+    'Security group {{securityGroupId}} rule set drifted; authorizing {{added}} and revoking {{removed}} rules',
   NESTED_INDEX_RECREATED: 'Logstore index {{logstoreName}} was deleted out-of-band; recreating it',
   PLAN_EVENT_TRIGGER_PROBE_FAILED:
     'Live trigger check for API Gateway {{eventName}} failed: {{error}}; skipping trigger drift detection for this plan',

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -287,6 +287,9 @@ export const en = {
   NESTED_LOGSTORE_RECREATED: 'Logstore {{logstoreName}} was deleted out-of-band; recreating it',
   NESTED_LOGSTORE_UPDATED:
     'Logstore {{logstoreName}} attributes drifted; updating to match si defaults',
+  NESTED_TOPIC_RECREATED:
+    'CLS topic {{topicId}} was deleted out-of-band; recreating it under the shared logset',
+  NESTED_TOPIC_UPDATED: 'CLS topic {{topicId}} attributes drifted; updating to match si defaults',
   NESTED_SG_RULES_REPAIRED:
     'Security group {{securityGroupId}} rule set drifted; authorizing {{added}} and revoking {{removed}} rules',
   NESTED_INDEX_RECREATED: 'Logstore index {{logstoreName}} was deleted out-of-band; recreating it',

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -287,6 +287,9 @@ export const en = {
   NESTED_LOGSTORE_RECREATED: 'Logstore {{logstoreName}} was deleted out-of-band; recreating it',
   NESTED_LOGSTORE_UPDATED:
     'Logstore {{logstoreName}} attributes drifted; updating to match si defaults',
+  NESTED_TLS_TOPIC_UPDATED: 'TLS topic {{topicId}} ttl drifted; updating to match si defaults',
+  NESTED_MOUNT_TARGET_RECREATED:
+    'NAS mount target for file system {{fileSystemId}} was deleted out-of-band; recreating it',
   NESTED_TOPIC_RECREATED:
     'CLS topic {{topicId}} was deleted out-of-band; recreating it under the shared logset',
   NESTED_TOPIC_UPDATED: 'CLS topic {{topicId}} attributes drifted; updating to match si defaults',

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -282,6 +282,12 @@ export const en = {
     'Function {{functionName}} role {{roleName}} is missing in the provider; it will be recreated and rebound on deploy',
   PLAN_FUNCTION_ROLE_PROBE_FAILED:
     'Live role policy check for function {{functionName}} (role {{roleName}}) failed: {{error}}; skipping role drift detection for this plan',
+  PLAN_FUNCTION_NESTED_PROBE_FAILED:
+    'Nested resource probe for function {{functionName}} failed: {{error}}; skipping nested drift detection for this plan',
+  NESTED_LOGSTORE_RECREATED: 'Logstore {{logstoreName}} was deleted out-of-band; recreating it',
+  NESTED_LOGSTORE_UPDATED:
+    'Logstore {{logstoreName}} attributes drifted; updating to match si defaults',
+  NESTED_INDEX_RECREATED: 'Logstore index {{logstoreName}} was deleted out-of-band; recreating it',
   PLAN_EVENT_TRIGGER_PROBE_FAILED:
     'Live trigger check for API Gateway {{eventName}} failed: {{error}}; skipping trigger drift detection for this plan',
   RAM_ROLE_MISSING_RECREATE:

--- a/src/lang/zh-CN.ts
+++ b/src/lang/zh-CN.ts
@@ -265,6 +265,8 @@ export const zhCN = {
     '函数 {{functionName}} 的嵌套资源探测失败：{{error}}；本次计划跳过嵌套漂移检测',
   NESTED_LOGSTORE_RECREATED: '日志库 {{logstoreName}} 被带外删除，正在重建',
   NESTED_LOGSTORE_UPDATED: '日志库 {{logstoreName}} 属性已漂移，正在按 si 默认值更新',
+  NESTED_SG_RULES_REPAIRED:
+    '安全组 {{securityGroupId}} 规则集已漂移；新增 {{added}} 条、撤销 {{removed}} 条',
   NESTED_INDEX_RECREATED: '日志库 {{logstoreName}} 的索引被带外删除，正在重建',
   PLAN_EVENT_TRIGGER_PROBE_FAILED:
     'API 网关 {{eventName}} 的实时触发器检查失败：{{error}}；本次计划跳过触发器漂移检测',

--- a/src/lang/zh-CN.ts
+++ b/src/lang/zh-CN.ts
@@ -261,6 +261,11 @@ export const zhCN = {
     '函数 {{functionName}} 的角色 {{roleName}} 在云端不存在；部署时将重建并重新绑定',
   PLAN_FUNCTION_ROLE_PROBE_FAILED:
     '函数 {{functionName}}（角色 {{roleName}}）的实时角色策略检查失败：{{error}}；本次计划跳过角色漂移检测',
+  PLAN_FUNCTION_NESTED_PROBE_FAILED:
+    '函数 {{functionName}} 的嵌套资源探测失败：{{error}}；本次计划跳过嵌套漂移检测',
+  NESTED_LOGSTORE_RECREATED: '日志库 {{logstoreName}} 被带外删除，正在重建',
+  NESTED_LOGSTORE_UPDATED: '日志库 {{logstoreName}} 属性已漂移，正在按 si 默认值更新',
+  NESTED_INDEX_RECREATED: '日志库 {{logstoreName}} 的索引被带外删除，正在重建',
   PLAN_EVENT_TRIGGER_PROBE_FAILED:
     'API 网关 {{eventName}} 的实时触发器检查失败：{{error}}；本次计划跳过触发器漂移检测',
   RAM_ROLE_MISSING_RECREATE:

--- a/src/lang/zh-CN.ts
+++ b/src/lang/zh-CN.ts
@@ -265,6 +265,8 @@ export const zhCN = {
     '函数 {{functionName}} 的嵌套资源探测失败：{{error}}；本次计划跳过嵌套漂移检测',
   NESTED_LOGSTORE_RECREATED: '日志库 {{logstoreName}} 被带外删除，正在重建',
   NESTED_LOGSTORE_UPDATED: '日志库 {{logstoreName}} 属性已漂移，正在按 si 默认值更新',
+  NESTED_TLS_TOPIC_UPDATED: 'TLS 日志主题 {{topicId}} 的 ttl 已漂移，正在按 si 默认值更新',
+  NESTED_MOUNT_TARGET_RECREATED: '文件系统 {{fileSystemId}} 的 NAS 挂载点被带外删除，正在重建',
   NESTED_TOPIC_RECREATED: '日志主题 {{topicId}} 被带外删除，正在共享日志集下重建',
   NESTED_TOPIC_UPDATED: '日志主题 {{topicId}} 属性已漂移，正在按 si 默认值更新',
   NESTED_SG_RULES_REPAIRED:

--- a/src/lang/zh-CN.ts
+++ b/src/lang/zh-CN.ts
@@ -265,6 +265,8 @@ export const zhCN = {
     '函数 {{functionName}} 的嵌套资源探测失败：{{error}}；本次计划跳过嵌套漂移检测',
   NESTED_LOGSTORE_RECREATED: '日志库 {{logstoreName}} 被带外删除，正在重建',
   NESTED_LOGSTORE_UPDATED: '日志库 {{logstoreName}} 属性已漂移，正在按 si 默认值更新',
+  NESTED_TOPIC_RECREATED: '日志主题 {{topicId}} 被带外删除，正在共享日志集下重建',
+  NESTED_TOPIC_UPDATED: '日志主题 {{topicId}} 属性已漂移，正在按 si 默认值更新',
   NESTED_SG_RULES_REPAIRED:
     '安全组 {{securityGroupId}} 规则集已漂移；新增 {{added}} 条、撤销 {{removed}} 条',
   NESTED_INDEX_RECREATED: '日志库 {{logstoreName}} 的索引被带外删除，正在重建',

--- a/src/stack/aliyunStack/fc3Planner.ts
+++ b/src/stack/aliyunStack/fc3Planner.ts
@@ -8,6 +8,7 @@ import {
 } from '../../common';
 import { createAliyunClient } from '../../common/aliyunClient';
 import { buildFc3ExecutionPolicyDocument } from '../../common/aliyunClient/ramOperations';
+import { SLS_LOGSTORE_SHARDS, SLS_LOGSTORE_TTL } from '../../common/aliyunClient/slsOperations';
 import { cachedRefreshRead } from '../../common/refreshCache';
 import { remoteDiffersFromDesired } from '../../common/planCompare';
 import { PLAN_READ_CONCURRENCY, mapWithConcurrency } from '../../common/concurrency';
@@ -296,6 +297,55 @@ const detectRolePolicyDrift = async (
   return false;
 };
 
+/**
+ * Issue #234 M1: nested log-drift probe — logstore ttl/shards and index
+ * presence for functions that declare logging. The logstore is per-function
+ * (buildFunctionLogstoreName), so this lives in the function flow. Aliyun
+ * cannot shrink shards, so only a shard deficit counts as drift.
+ */
+const detectFunctionNestedLogDrift = async (
+  context: Context,
+  client: ReturnType<typeof createAliyunClient>,
+  fn: FunctionDomain,
+  currentState: ResourceState,
+): Promise<boolean> => {
+  const slsLogstoreInstance = currentState.instances?.find(
+    (i) => (i as { type?: string }).type === 'ALIYUN_SLS_LOGSTORE',
+  ) as { id?: string } | undefined;
+  if (!slsLogstoreInstance?.id) {
+    return false; // nothing recorded — the executor creates it on update
+  }
+  const [projectName, logstoreName] = slsLogstoreInstance.id.split('/');
+  if (!projectName || !logstoreName) {
+    return false;
+  }
+
+  const logstore = await cachedRefreshRead(
+    context,
+    `sls.getLogstore:${projectName}:${logstoreName}`,
+    () => client.sls.getLogstore(projectName, logstoreName),
+  );
+  if (!logstore) {
+    return true; // logstore deleted out-of-band
+  }
+  if (logstore.ttl !== SLS_LOGSTORE_TTL) {
+    return true;
+  }
+  if ((logstore.shardCount ?? 0) < SLS_LOGSTORE_SHARDS) {
+    return true;
+  }
+
+  const index = await cachedRefreshRead(
+    context,
+    `sls.getIndex:${projectName}:${logstoreName}`,
+    () => client.sls.getIndex(projectName, logstoreName),
+  );
+  if (!index) {
+    return true; // index deleted out-of-band
+  }
+  return false;
+};
+
 export const generateFunctionPlan = async (
   context: Context,
   state: StateFile,
@@ -446,6 +496,35 @@ export const generateFunctionPlan = async (
             logger.warn(
               lang.__('PLAN_FUNCTION_ROLE_PROBE_FAILED', {
                 roleName: roleProbe.roleName,
+                functionName: fn.name,
+                error: String(error),
+              }),
+            );
+          }
+        }
+
+        // Issue #234 M1: nested log drift — probed only when logging is
+        // declared in config.
+        if (fn.log) {
+          try {
+            const nestedDrifted = await detectFunctionNestedLogDrift(
+              context,
+              client,
+              fn,
+              currentState,
+            );
+            if (nestedDrifted) {
+              return {
+                logicalId,
+                action: 'update',
+                resourceType: 'ALIYUN_FC3',
+                changes: { before: normalizedCurrent, after: normalizedDesired },
+                drifted: true,
+              };
+            }
+          } catch (error: unknown) {
+            logger.warn(
+              lang.__('PLAN_FUNCTION_NESTED_PROBE_FAILED', {
                 functionName: fn.name,
                 error: String(error),
               }),

--- a/src/stack/aliyunStack/fc3Planner.ts
+++ b/src/stack/aliyunStack/fc3Planner.ts
@@ -399,6 +399,26 @@ const detectFunctionNestedDrift = async (
     }
   }
 
+  // Issue #234 M4: NAS mount targets are function-owned — a file system with
+  // no live mount targets means the console deleted it out-of-band.
+  if (fn.storage?.nas && fn.storage.nas.length > 0 && fn.network) {
+    const fsInstances = currentState.instances?.filter(
+      (i) => (i as { type?: string }).type === 'ALIYUN_NAS_FILE_SYSTEM',
+    ) as { id?: string }[];
+    for (const fs of fsInstances) {
+      const fsId = fs.id;
+      if (!fsId) {
+        continue;
+      }
+      const targets = await cachedRefreshRead(context, `nas.listMountTargets:${fsId}`, () =>
+        client.nas.listMountTargets(fsId),
+      );
+      if (!targets || targets.length === 0) {
+        return true; // mount target deleted out-of-band
+      }
+    }
+  }
+
   return false;
 };
 

--- a/src/stack/aliyunStack/fc3Planner.ts
+++ b/src/stack/aliyunStack/fc3Planner.ts
@@ -9,6 +9,10 @@ import {
 import { createAliyunClient } from '../../common/aliyunClient';
 import { buildFc3ExecutionPolicyDocument } from '../../common/aliyunClient/ramOperations';
 import { SLS_LOGSTORE_SHARDS, SLS_LOGSTORE_TTL } from '../../common/aliyunClient/slsOperations';
+import {
+  canonicalSecurityGroupRule,
+  parseSecurityGroupRule,
+} from '../../common/aliyunClient/ecsOperations';
 import { cachedRefreshRead } from '../../common/refreshCache';
 import { remoteDiffersFromDesired } from '../../common/planCompare';
 import { PLAN_READ_CONCURRENCY, mapWithConcurrency } from '../../common/concurrency';
@@ -303,46 +307,98 @@ const detectRolePolicyDrift = async (
  * (buildFunctionLogstoreName), so this lives in the function flow. Aliyun
  * cannot shrink shards, so only a shard deficit counts as drift.
  */
-const detectFunctionNestedLogDrift = async (
+const detectFunctionNestedDrift = async (
   context: Context,
   client: ReturnType<typeof createAliyunClient>,
   fn: FunctionDomain,
   currentState: ResourceState,
 ): Promise<boolean> => {
-  const slsLogstoreInstance = currentState.instances?.find(
-    (i) => (i as { type?: string }).type === 'ALIYUN_SLS_LOGSTORE',
-  ) as { id?: string } | undefined;
-  if (!slsLogstoreInstance?.id) {
-    return false; // nothing recorded — the executor creates it on update
-  }
-  const [projectName, logstoreName] = slsLogstoreInstance.id.split('/');
-  if (!projectName || !logstoreName) {
-    return false;
+  // Each declared dimension contributes its own probe; undeclared dimensions
+  // fall through so later dimensions still run.
+  if (fn.log) {
+    const slsLogstoreInstance = currentState.instances?.find(
+      (i) => (i as { type?: string }).type === 'ALIYUN_SLS_LOGSTORE',
+    ) as { id?: string } | undefined;
+    if (slsLogstoreInstance?.id) {
+      const [projectName, logstoreName] = slsLogstoreInstance.id.split('/');
+      if (projectName && logstoreName) {
+        const logstore = await cachedRefreshRead(
+          context,
+          `sls.getLogstore:${projectName}:${logstoreName}`,
+          () => client.sls.getLogstore(projectName, logstoreName),
+        );
+        if (!logstore) {
+          return true; // logstore deleted out-of-band
+        }
+        if (logstore.ttl !== SLS_LOGSTORE_TTL) {
+          return true;
+        }
+        // Aliyun cannot shrink shards — only a deficit counts as drift.
+        if ((logstore.shardCount ?? 0) < SLS_LOGSTORE_SHARDS) {
+          return true;
+        }
+
+        const index = await cachedRefreshRead(
+          context,
+          `sls.getIndex:${projectName}:${logstoreName}`,
+          () => client.sls.getIndex(projectName, logstoreName),
+        );
+        if (!index) {
+          return true; // index deleted out-of-band
+        }
+      }
+    }
   }
 
-  const logstore = await cachedRefreshRead(
-    context,
-    `sls.getLogstore:${projectName}:${logstoreName}`,
-    () => client.sls.getLogstore(projectName, logstoreName),
-  );
-  if (!logstore) {
-    return true; // logstore deleted out-of-band
-  }
-  if (logstore.ttl !== SLS_LOGSTORE_TTL) {
-    return true;
-  }
-  if ((logstore.shardCount ?? 0) < SLS_LOGSTORE_SHARDS) {
-    return true;
+  // SG rules are function-owned (created from fn.network.security_group) —
+  // console edits to the rule set are function drift (issue #234 M2).
+  if (fn.network) {
+    const sgInstance = currentState.instances?.find(
+      (i) => (i as { type?: string }).type === 'ALIYUN_ECS_SECURITY_GROUP',
+    ) as { id?: string } | undefined;
+    if (sgInstance?.id) {
+      const sgId = sgInstance.id;
+      const live = await cachedRefreshRead(context, `ecs.getSecurityGroupRules:${sgId}`, () =>
+        client.ecs.getSecurityGroupRules(sgId),
+      );
+      const desiredRules = (
+        ingress: string[],
+        egress: string[],
+      ): { ingress: string[]; egress: string[] } => {
+        const parse = (rule: string): string | null => {
+          try {
+            const parsed = parseSecurityGroupRule(rule);
+            return canonicalSecurityGroupRule(parsed.protocol, parsed.portRange, parsed.cidr);
+          } catch {
+            return null; // invalid rules are skipped at create time too
+          }
+        };
+        return {
+          ingress: (ingress ?? []).map(parse).filter((r): r is string => Boolean(r)),
+          egress: (egress ?? []).map(parse).filter((r): r is string => Boolean(r)),
+        };
+      };
+      const desired = desiredRules(
+        fn.network.security_group.ingress ?? [],
+        fn.network.security_group.egress ?? [],
+      );
+      const liveIngress = (live?.ingressRules ?? []).map((r) =>
+        canonicalSecurityGroupRule(r.ipProtocol ?? '', r.portRange ?? '', r.sourceCidrIp ?? ''),
+      );
+      const liveEgress = (live?.egressRules ?? []).map((r) =>
+        canonicalSecurityGroupRule(r.ipProtocol ?? '', r.portRange ?? '', r.destCidrIp ?? ''),
+      );
+      if (
+        desired.ingress.some((d) => !liveIngress.includes(d)) ||
+        liveIngress.some((l) => !desired.ingress.includes(l)) ||
+        desired.egress.some((d) => !liveEgress.includes(d)) ||
+        liveEgress.some((l) => !desired.egress.includes(l))
+      ) {
+        return true;
+      }
+    }
   }
 
-  const index = await cachedRefreshRead(
-    context,
-    `sls.getIndex:${projectName}:${logstoreName}`,
-    () => client.sls.getIndex(projectName, logstoreName),
-  );
-  if (!index) {
-    return true; // index deleted out-of-band
-  }
   return false;
 };
 
@@ -503,33 +559,26 @@ export const generateFunctionPlan = async (
           }
         }
 
-        // Issue #234 M1: nested log drift — probed only when logging is
-        // declared in config.
-        if (fn.log) {
-          try {
-            const nestedDrifted = await detectFunctionNestedLogDrift(
-              context,
-              client,
-              fn,
-              currentState,
-            );
-            if (nestedDrifted) {
-              return {
-                logicalId,
-                action: 'update',
-                resourceType: 'ALIYUN_FC3',
-                changes: { before: normalizedCurrent, after: normalizedDesired },
-                drifted: true,
-              };
-            }
-          } catch (error: unknown) {
-            logger.warn(
-              lang.__('PLAN_FUNCTION_NESTED_PROBE_FAILED', {
-                functionName: fn.name,
-                error: String(error),
-              }),
-            );
+        // Issue #234 M1/M2: nested drift probe — the probe itself skips
+        // dimensions the config does not declare.
+        try {
+          const nestedDrifted = await detectFunctionNestedDrift(context, client, fn, currentState);
+          if (nestedDrifted) {
+            return {
+              logicalId,
+              action: 'update',
+              resourceType: 'ALIYUN_FC3',
+              changes: { before: normalizedCurrent, after: normalizedDesired },
+              drifted: true,
+            };
           }
+        } catch (error: unknown) {
+          logger.warn(
+            lang.__('PLAN_FUNCTION_NESTED_PROBE_FAILED', {
+              functionName: fn.name,
+              error: String(error),
+            }),
+          );
         }
 
         return { logicalId, action: 'noop', resourceType: 'ALIYUN_FC3' };

--- a/src/stack/aliyunStack/fc3Resource.ts
+++ b/src/stack/aliyunStack/fc3Resource.ts
@@ -35,6 +35,7 @@ import {
   StateFile,
 } from '../../types';
 import { extractFc3Definition, Fc3FunctionInfo, functionToFc3Config } from './fc3Types';
+import { SLS_LOGSTORE_SHARDS, SLS_LOGSTORE_TTL } from '../../common/aliyunClient/slsOperations';
 import { logger } from '../../common/logger';
 import { unionPolicyStatements, type IamStatement } from '../../common/iamStatements';
 import { buildFc3ExecutionPolicyDocument } from '../../common/aliyunClient/ramOperations';
@@ -1130,6 +1131,33 @@ export const updateResource = async (
       if (slsLogstoreInstance) {
         const [projectName, logstoreName] = slsLogstoreInstance.id.split('/');
         logConfig = { project: projectName, logstore: logstoreName };
+
+        // Issue #234 M1: nested repair — only on a drifted plan item (force):
+        // reconcile logstore ttl/shards and index presence against what si
+        // creates. Shard deficits are repaired upward; Aliyun cannot shrink.
+        if (options?.force) {
+          const liveLogstore = await client.sls.getLogstore(projectName, logstoreName);
+          if (!liveLogstore) {
+            logger.warn(lang.__('NESTED_LOGSTORE_RECREATED', { logstoreName }));
+            await client.sls.createLogstore(projectName, logstoreName);
+          } else if (
+            liveLogstore.ttl !== SLS_LOGSTORE_TTL ||
+            (liveLogstore.shardCount ?? 0) < SLS_LOGSTORE_SHARDS
+          ) {
+            await client.sls.updateLogstore(
+              projectName,
+              logstoreName,
+              SLS_LOGSTORE_TTL,
+              Math.max(liveLogstore.shardCount ?? 0, SLS_LOGSTORE_SHARDS),
+            );
+            logger.info(lang.__('NESTED_LOGSTORE_UPDATED', { logstoreName }));
+          }
+          const liveIndex = await client.sls.getIndex(projectName, logstoreName);
+          if (!liveIndex) {
+            logger.warn(lang.__('NESTED_INDEX_RECREATED', { logstoreName }));
+            await client.sls.createIndex(projectName, logstoreName);
+          }
+        }
       }
     } else {
       // Logging disabled: the owned index + logstore are deleted from the

--- a/src/stack/aliyunStack/fc3Resource.ts
+++ b/src/stack/aliyunStack/fc3Resource.ts
@@ -1346,42 +1346,51 @@ export const updateResource = async (
           (d) =>
             !liveEgressKeys.includes(canonicalSecurityGroupRule(d.protocol, d.portRange, d.cidr)),
         );
-        const extraIngress = (live?.ingressRules ?? [])
-          .map((r) => ({
-            protocol: r.ipProtocol ?? '',
-            portRange: (r.portRange ?? '').split('/')[0] ?? '',
-            cidr: r.sourceCidrIp ?? '',
-          }))
-          .filter(
-            (r) =>
-              !desiredIngress.some(
-                (d) =>
-                  canonicalSecurityGroupRule(d.protocol, d.portRange, d.cidr) ===
-                  canonicalSecurityGroupRule(r.protocol, r.portRange, r.cidr),
-              ),
-          );
-        const extraEgress = (live?.egressRules ?? [])
-          .map((r) => ({
-            protocol: r.ipProtocol ?? '',
-            portRange: (r.portRange ?? '').split('/')[0] ?? '',
-            cidr: r.destCidrIp ?? '',
-          }))
-          .filter(
-            (r) =>
-              !desiredEgress.some(
-                (d) =>
-                  canonicalSecurityGroupRule(d.protocol, d.portRange, d.cidr) ===
-                  canonicalSecurityGroupRule(r.protocol, r.portRange, r.cidr),
-              ),
-          );
-
+        // The extra check reuses the raw live canonical keys — the same space
+        // the missing check uses. Reconstructing a parsed rule here would
+        // collapse port ranges (80/443 -> 80) and wrongly revoke matching
+        // range rules.
+        const desiredIngressKeys = desiredIngress.map((d) =>
+          canonicalSecurityGroupRule(d.protocol, d.portRange, d.cidr),
+        );
+        const desiredEgressKeys = desiredEgress.map((d) =>
+          canonicalSecurityGroupRule(d.protocol, d.portRange, d.cidr),
+        );
+        const extraIngress = (live?.ingressRules ?? []).filter((r, i) => {
+          const key = liveIngressKeys[i];
+          return !key || !desiredIngressKeys.includes(key);
+        });
+        const extraEgress = (live?.egressRules ?? []).filter((r, i) => {
+          const key = liveEgressKeys[i];
+          return !key || !desiredEgressKeys.includes(key);
+        });
         if (missingIngress.length > 0 || missingEgress.length > 0) {
           await client.ecs.authorizeSecurityGroupRules(sgInstance.id, 'ingress', missingIngress);
           await client.ecs.authorizeSecurityGroupRules(sgInstance.id, 'egress', missingEgress);
         }
         if (extraIngress.length > 0 || extraEgress.length > 0) {
-          await client.ecs.revokeSecurityGroupRules(sgInstance.id, 'ingress', extraIngress);
-          await client.ecs.revokeSecurityGroupRules(sgInstance.id, 'egress', extraEgress);
+          const toParsed = (r: {
+            ipProtocol?: string;
+            portRange?: string;
+            sourceCidrIp?: string;
+            destCidrIp?: string;
+          }): { protocol: string; cidr: string; portRange: string } => ({
+            // Live portRange is already in Aliyun wire format — pass verbatim
+            // so the revoke matches the rule exactly (ranges included).
+            protocol: r.ipProtocol ?? '',
+            cidr: r.sourceCidrIp ?? r.destCidrIp ?? '',
+            portRange: r.portRange ?? '',
+          });
+          await client.ecs.revokeSecurityGroupRules(
+            sgInstance.id,
+            'ingress',
+            extraIngress.map(toParsed),
+          );
+          await client.ecs.revokeSecurityGroupRules(
+            sgInstance.id,
+            'egress',
+            extraEgress.map(toParsed),
+          );
         }
         logger.info(
           lang.__('NESTED_SG_RULES_REPAIRED', {

--- a/src/stack/aliyunStack/fc3Resource.ts
+++ b/src/stack/aliyunStack/fc3Resource.ts
@@ -36,6 +36,10 @@ import {
 } from '../../types';
 import { extractFc3Definition, Fc3FunctionInfo, functionToFc3Config } from './fc3Types';
 import { SLS_LOGSTORE_SHARDS, SLS_LOGSTORE_TTL } from '../../common/aliyunClient/slsOperations';
+import {
+  canonicalSecurityGroupRule,
+  parseSecurityGroupRule,
+} from '../../common/aliyunClient/ecsOperations';
 import { logger } from '../../common/logger';
 import { unionPolicyStatements, type IamStatement } from '../../common/iamStatements';
 import { buildFc3ExecutionPolicyDocument } from '../../common/aliyunClient/ramOperations';
@@ -1308,6 +1312,85 @@ export const updateResource = async (
     const sgInstance = existingInstances.find((i) => i.type === 'ALIYUN_ECS_SECURITY_GROUP');
     if (sgInstance) {
       securityGroup = { securityGroupId: sgInstance.id };
+
+      // Issue #234 M2: SG rule reconcile — only on a drifted plan item
+      // (force): authorize rules missing from the live set, revoke rules the
+      // config no longer declares. Invalid config rules are skipped at create
+      // time too.
+      if (options?.force && fn.network) {
+        const parseRule = (rule: string) => {
+          try {
+            return parseSecurityGroupRule(rule);
+          } catch {
+            return null;
+          }
+        };
+        const desiredIngress = (fn.network.security_group.ingress ?? [])
+          .map(parseRule)
+          .filter((r): r is NonNullable<ReturnType<typeof parseRule>> => Boolean(r));
+        const desiredEgress = (fn.network.security_group.egress ?? [])
+          .map(parseRule)
+          .filter((r): r is NonNullable<ReturnType<typeof parseRule>> => Boolean(r));
+        const live = await client.ecs.getSecurityGroupRules(sgInstance.id);
+        const liveIngressKeys = (live?.ingressRules ?? []).map((r) =>
+          canonicalSecurityGroupRule(r.ipProtocol ?? '', r.portRange ?? '', r.sourceCidrIp ?? ''),
+        );
+        const liveEgressKeys = (live?.egressRules ?? []).map((r) =>
+          canonicalSecurityGroupRule(r.ipProtocol ?? '', r.portRange ?? '', r.destCidrIp ?? ''),
+        );
+        const missingIngress = desiredIngress.filter(
+          (d) =>
+            !liveIngressKeys.includes(canonicalSecurityGroupRule(d.protocol, d.portRange, d.cidr)),
+        );
+        const missingEgress = desiredEgress.filter(
+          (d) =>
+            !liveEgressKeys.includes(canonicalSecurityGroupRule(d.protocol, d.portRange, d.cidr)),
+        );
+        const extraIngress = (live?.ingressRules ?? [])
+          .map((r) => ({
+            protocol: r.ipProtocol ?? '',
+            portRange: (r.portRange ?? '').split('/')[0] ?? '',
+            cidr: r.sourceCidrIp ?? '',
+          }))
+          .filter(
+            (r) =>
+              !desiredIngress.some(
+                (d) =>
+                  canonicalSecurityGroupRule(d.protocol, d.portRange, d.cidr) ===
+                  canonicalSecurityGroupRule(r.protocol, r.portRange, r.cidr),
+              ),
+          );
+        const extraEgress = (live?.egressRules ?? [])
+          .map((r) => ({
+            protocol: r.ipProtocol ?? '',
+            portRange: (r.portRange ?? '').split('/')[0] ?? '',
+            cidr: r.destCidrIp ?? '',
+          }))
+          .filter(
+            (r) =>
+              !desiredEgress.some(
+                (d) =>
+                  canonicalSecurityGroupRule(d.protocol, d.portRange, d.cidr) ===
+                  canonicalSecurityGroupRule(r.protocol, r.portRange, r.cidr),
+              ),
+          );
+
+        if (missingIngress.length > 0 || missingEgress.length > 0) {
+          await client.ecs.authorizeSecurityGroupRules(sgInstance.id, 'ingress', missingIngress);
+          await client.ecs.authorizeSecurityGroupRules(sgInstance.id, 'egress', missingEgress);
+        }
+        if (extraIngress.length > 0 || extraEgress.length > 0) {
+          await client.ecs.revokeSecurityGroupRules(sgInstance.id, 'ingress', extraIngress);
+          await client.ecs.revokeSecurityGroupRules(sgInstance.id, 'egress', extraEgress);
+        }
+        logger.info(
+          lang.__('NESTED_SG_RULES_REPAIRED', {
+            securityGroupId: sgInstance.id,
+            added: String(missingIngress.length + missingEgress.length),
+            removed: String(extraIngress.length + extraEgress.length),
+          }),
+        );
+      }
     }
   }
 

--- a/src/stack/aliyunStack/fc3Resource.ts
+++ b/src/stack/aliyunStack/fc3Resource.ts
@@ -1421,6 +1421,29 @@ export const updateResource = async (
       (i) => i.type === 'ALIYUN_NAS_MOUNT_TARGET',
     );
     const nasStorageItems = fn.storage?.nas ?? [];
+
+    // Issue #234 M4: nested repair — only on a drifted plan item (force): a
+    // file system with no live mount targets gets its mount target recreated
+    // (console deletions); extra mount targets are left alone — deleting
+    // shared infrastructure on a reconcile is never safe.
+    if (options?.force && fn.network) {
+      const fsInstances = existingInstances.filter((i) => i.type === 'ALIYUN_NAS_FILE_SYSTEM');
+      for (const fs of fsInstances) {
+        const liveTargets = await client.nas.listMountTargets(fs.id);
+        if (!liveTargets || liveTargets.length === 0) {
+          const mountPath = nasStorageItems[0]?.mount_path ?? '/mnt/nas';
+          const accessGroupName = `${fn.name}-${context.stage}-nas-access-${mountPath}`;
+          await client.nas.createMountTarget(
+            fs.id,
+            accessGroupName,
+            fn.network.vpc_id,
+            fn.network.subnet_ids[0],
+          );
+          logger.warn(lang.__('NESTED_MOUNT_TARGET_RECREATED', { fileSystemId: fs.id }));
+        }
+      }
+    }
+
     if (mountTargetInstances.length > 0 && nasStorageItems.length > 0) {
       nasConfig = {
         mountPoints: mountTargetInstances.map((mt, idx) => ({

--- a/src/stack/scfStack/scfPlanner.ts
+++ b/src/stack/scfStack/scfPlanner.ts
@@ -7,7 +7,10 @@ import {
   ResourceAttributes,
 } from '../../types';
 import { createTencentClient } from '../../common/tencentClient';
+import { logger } from '../../common/logger';
+import { lang } from '../../lang';
 import { cachedRefreshRead } from '../../common/refreshCache';
+import { CLS_TOPIC_PERIOD, CLS_TOPIC_STORAGE_TYPE } from '../../common/tencentClient/clsOperations';
 import { PLAN_READ_CONCURRENCY, mapWithConcurrency } from '../../common/concurrency';
 import { functionToScfConfig, extractScfDefinition, cloudScfToDefinition } from './scfTypes';
 import { getAllResources, getResource } from '../../common/stateManager';
@@ -59,6 +62,47 @@ export const generateFunctionPlan = async (
       const desiredDefinition = extractScfDefinition(config, desiredCodeHash, fn.iam);
 
       const client = createTencentClient(context);
+
+      // Issue #234 M3: nested topic drift — probed only when logging is
+      // declared; unresolvable/unreadable topics are not drift.
+      if (
+        currentState &&
+        currentState.status !== 'tainted' &&
+        fn.log &&
+        context.refresh !== false
+      ) {
+        const topicInstance = currentState.instances?.find(
+          (i) => (i as { type?: string }).type === 'TENCENT_CLS_TOPIC',
+        ) as { id?: string } | undefined;
+        if (topicInstance?.id) {
+          const topicId = topicInstance.id;
+          try {
+            const liveTopic = await cachedRefreshRead(context, `cls.getTopicById:${topicId}`, () =>
+              client.cls.getTopicById(topicId),
+            );
+            const topicDrifted =
+              !liveTopic ||
+              liveTopic.StorageType !== CLS_TOPIC_STORAGE_TYPE ||
+              liveTopic.Period !== CLS_TOPIC_PERIOD;
+            if (topicDrifted) {
+              return {
+                logicalId,
+                action: 'update',
+                resourceType: 'SCF',
+                changes: { before: currentState.definition || {}, after: desiredDefinition },
+                drifted: true,
+              };
+            }
+          } catch (error: unknown) {
+            logger.warn(
+              lang.__('PLAN_FUNCTION_NESTED_PROBE_FAILED', {
+                functionName: fn.name,
+                error: String(error),
+              }),
+            );
+          }
+        }
+      }
 
       return planRefreshedResource({
         logicalId,

--- a/src/stack/scfStack/scfResource.ts
+++ b/src/stack/scfStack/scfResource.ts
@@ -41,6 +41,7 @@ import {
   ensureFunctionTopic,
   releaseSharedLogsetIfUnused,
 } from './sharedLogset';
+import { CLS_TOPIC_PERIOD, CLS_TOPIC_STORAGE_TYPE } from '../../common/tencentClient/clsOperations';
 
 /**
  * Build the Function URL trigger description for Tencent CreateTrigger
@@ -892,6 +893,46 @@ export const updateResource = async (
   );
   const hasCamRole = existingInstances.some((i) => i.type === ResourceTypeEnum.TENCENT_SCF_ROLE);
   const client = createTencentClient(context);
+
+  // Issue #234 M3: nested repair — only on a drifted plan item (force):
+  // reconcile topic attributes against si's creation defaults; a deleted
+  // topic is recreated under the shared logset when it is still recorded.
+  if (options?.force && fn.log && existingClsTopicInstance) {
+    const liveTopic = await client.cls.getTopicById(existingClsTopicInstance.id).catch(() => null);
+    if (!liveTopic) {
+      const sharedBefore = getSharedResource(state, context.stage, SHARED_LOGSET_KEY);
+      const sharedLogsetId =
+        (sharedBefore?.instances?.[0] as { id?: string } | undefined)?.id ??
+        (existingClsTopicInstance as { logsetId?: string }).logsetId;
+      if (sharedLogsetId) {
+        logger.warn(lang.__('NESTED_TOPIC_RECREATED', { topicId: existingClsTopicInstance.id }));
+        await client.cls.createTopic(
+          sharedLogsetId,
+          (existingFnInstance?.functionName as string) ??
+            existingClsTopicInstance.topicName ??
+            'fn-logs',
+          {
+            tags: [
+              {
+                key: OWNERSHIP_TAG_KEY,
+                value: buildOwnershipTagValue(context, `functions.${fn.key}`),
+              },
+            ],
+          },
+        );
+        await client.cls.createFulltextIndex(existingClsTopicInstance.id);
+      }
+    } else if (
+      liveTopic.StorageType !== CLS_TOPIC_STORAGE_TYPE ||
+      liveTopic.Period !== CLS_TOPIC_PERIOD
+    ) {
+      await client.cls.modifyTopic(existingClsTopicInstance.id, {
+        period: CLS_TOPIC_PERIOD,
+        storageType: CLS_TOPIC_STORAGE_TYPE,
+      });
+      logger.info(lang.__('NESTED_TOPIC_UPDATED', { topicId: existingClsTopicInstance.id }));
+    }
+  }
 
   const newIamRole = fn.iam?.role;
   let role: { roleName?: string; arn?: string } | undefined;

--- a/src/stack/scfStack/scfResource.ts
+++ b/src/stack/scfStack/scfResource.ts
@@ -906,20 +906,14 @@ export const updateResource = async (
         (existingClsTopicInstance as { logsetId?: string }).logsetId;
       if (sharedLogsetId) {
         logger.warn(lang.__('NESTED_TOPIC_RECREATED', { topicId: existingClsTopicInstance.id }));
-        await client.cls.createTopic(
-          sharedLogsetId,
-          (existingFnInstance?.functionName as string) ??
-            existingClsTopicInstance.topicName ??
-            'fn-logs',
-          {
-            tags: [
-              {
-                key: OWNERSHIP_TAG_KEY,
-                value: buildOwnershipTagValue(context, `functions.${fn.key}`),
-              },
-            ],
-          },
-        );
+        await client.cls.createTopic(sharedLogsetId, buildFunctionTopicName(context, fn.key), {
+          tags: [
+            {
+              key: OWNERSHIP_TAG_KEY,
+              value: buildOwnershipTagValue(context, `functions.${fn.key}`),
+            },
+          ],
+        });
         await client.cls.createFulltextIndex(existingClsTopicInstance.id);
       }
     } else if (

--- a/src/stack/scfStack/sharedLogset.ts
+++ b/src/stack/scfStack/sharedLogset.ts
@@ -4,6 +4,7 @@ import { ResourceTypeEnum } from '../../types';
 import { logger } from '../../common/logger';
 import { lang } from '../../lang';
 import { createClsOperations } from '../../common/tencentClient';
+import { CLS_TOPIC_PERIOD, CLS_TOPIC_STORAGE_TYPE } from '../../common/tencentClient/clsOperations';
 import {
   OWNERSHIP_TAG_KEY,
   buildOwnershipTagValue,
@@ -162,8 +163,8 @@ export const ensureFunctionTopic = async (
 
   logger.info(lang.__('CREATING_CLS_TOPIC', { topicName }));
   const topic = await client.cls.createTopic(logsetId, topicName, {
-    period: 30,
-    storageType: 'hot',
+    period: CLS_TOPIC_PERIOD,
+    storageType: CLS_TOPIC_STORAGE_TYPE,
     tags: [{ key: OWNERSHIP_TAG_KEY, value: buildOwnershipTagValue(context, logicalId) }],
   });
 

--- a/src/stack/volcengineStack/vefaasPlanner.ts
+++ b/src/stack/volcengineStack/vefaasPlanner.ts
@@ -17,6 +17,7 @@ import {
   functionToVefaasConfig,
 } from './vefaasTypes';
 import { resolveRoleGrant } from './vefaasResource';
+import { TLS_TOPIC_TTL } from '../../common/volcengineClient/tlsOperations';
 import { buildRolePolicyName } from '../../common/nameBuilder';
 import { buildSharedProjectName, buildFunctionLogTopicName } from './sharedLogProject';
 import { OWNERSHIP_TAG_KEY, isOwnedByStack } from '../ownershipTag';
@@ -277,6 +278,43 @@ export const generateFunctionPlan = async (
                 error: String(error),
               }),
             );
+          }
+        }
+
+        // Issue #234 M5: nested topic drift — ttl is the only ModifyTopic
+        // field si manages; probed only when logging is declared (the
+        // --no-refresh early return above already guarantees refresh is on).
+        if (fn.log) {
+          const tlsTopicInstance = currentState.instances.find(
+            (i) => (i as { type?: string }).type === 'VOLCENGINE_TLS_TOPIC',
+          ) as { id?: string } | undefined;
+          if (tlsTopicInstance?.id) {
+            try {
+              const [topicProject, topicName] = tlsTopicInstance.id.split('/');
+              if (topicProject && topicName) {
+                const liveTopic = await cachedRefreshRead(
+                  context,
+                  `tls.getTopic:${topicProject}:${topicName}`,
+                  () => client.tls.getTopic(topicProject, topicName),
+                );
+                if (!liveTopic || (liveTopic.ttl ?? TLS_TOPIC_TTL) !== TLS_TOPIC_TTL) {
+                  return {
+                    logicalId,
+                    action: 'update',
+                    resourceType: 'VOLCENGINE_VEFAAS',
+                    changes: { before: currentDefinition, after: desiredDefinition },
+                    drifted: true,
+                  };
+                }
+              }
+            } catch (error: unknown) {
+              logger.warn(
+                lang.__('PLAN_FUNCTION_NESTED_PROBE_FAILED', {
+                  functionName: fn.name,
+                  error: String(error),
+                }),
+              );
+            }
           }
         }
 

--- a/src/stack/volcengineStack/vefaasResource.ts
+++ b/src/stack/volcengineStack/vefaasResource.ts
@@ -806,6 +806,24 @@ export const updateResource = async (
     }
   }
 
+  // Issue #234 M5: nested repair — only on a drifted plan item (force):
+  // reconcile topic ttl via ModifyTopic (the only mutable field si manages).
+  if (options?.force && fn.log) {
+    const tlsTopicInstance = existingInstances.find(
+      (i) => (i as { type?: string }).type === 'VOLCENGINE_TLS_TOPIC',
+    ) as { id?: string } | undefined;
+    if (tlsTopicInstance?.id) {
+      const [topicProject, topicName] = tlsTopicInstance.id.split('/');
+      if (topicProject && topicName) {
+        const liveTopic = await client.tls.getTopic(topicProject, topicName);
+        if (liveTopic && (liveTopic.ttl ?? TLS_TOPIC_TTL) !== TLS_TOPIC_TTL) {
+          await client.tls.modifyTopic(liveTopic.topicId ?? '', TLS_TOPIC_TTL);
+          logger.info(lang.__('NESTED_TLS_TOPIC_UPDATED', { topicId: liveTopic.topicId ?? '' }));
+        }
+      }
+    }
+  }
+
   const config = functionToVefaasConfig(fn, {
     role: role?.trn,
     logConfig,

--- a/src/stack/volcengineStack/vefaasResource.ts
+++ b/src/stack/volcengineStack/vefaasResource.ts
@@ -13,6 +13,7 @@ import {
   buildFunctionRoleName,
 } from '../../common';
 import { unionPolicyStatements } from '../../common/iamStatements';
+import { TLS_TOPIC_TTL } from '../../common/volcengineClient/tlsOperations';
 import {
   Context,
   FunctionDomain,
@@ -751,6 +752,24 @@ export const updateResource = async (
         iamRoleInstance.id,
         buildDefaultTrustPolicy(roleGrant.trustedServices),
       );
+    }
+
+    // Issue #234 M5: nested repair — only on a drifted plan item (force):
+    // reconcile topic ttl via ModifyTopic (the only mutable field si manages).
+    if (options?.force && fn.log) {
+      const tlsTopicInstance = existingInstances.find(
+        (i) => (i as { type?: string }).type === 'VOLCENGINE_TLS_TOPIC',
+      ) as { id?: string } | undefined;
+      if (tlsTopicInstance?.id) {
+        const [topicProject, topicName] = tlsTopicInstance.id.split('/');
+        if (topicProject && topicName) {
+          const liveTopic = await client.tls.getTopic(topicProject, topicName);
+          if (liveTopic && (liveTopic.ttl ?? TLS_TOPIC_TTL) !== TLS_TOPIC_TTL) {
+            await client.tls.modifyTopic(liveTopic.topicId ?? '', TLS_TOPIC_TTL);
+            logger.info(lang.__('NESTED_TLS_TOPIC_UPDATED', { topicId: liveTopic.topicId ?? '' }));
+          }
+        }
+      }
     }
 
     // Check statement changes

--- a/tests/service/mockCloudClient.ts
+++ b/tests/service/mockCloudClient.ts
@@ -96,6 +96,8 @@ export type MockAliyunClient = {
     listLogStores: jest.Mock;
     createLogstore: jest.Mock;
     getLogstore: jest.Mock;
+    updateLogstore: jest.Mock;
+    getIndex: jest.Mock;
     createIndex: jest.Mock;
     waitForProject: jest.Mock;
     waitForLogstore: jest.Mock;
@@ -293,7 +295,12 @@ export const createMockAliyunClient = (): MockAliyunClient => {
       removeTags: jest.fn().mockResolvedValue(undefined),
       listLogStores: jest.fn().mockResolvedValue([]),
       createLogstore: jest.fn().mockResolvedValue({ logstoreName: 'test-logstore' }),
-      getLogstore: jest.fn().mockResolvedValue(null),
+      // Healthy echo: a created logstore reports si's constants (issue #234 M1).
+      getLogstore: jest
+        .fn()
+        .mockResolvedValue({ logstoreName: 'test-logstore', ttl: 30, shardCount: 2 }),
+      updateLogstore: jest.fn().mockResolvedValue(undefined),
+      getIndex: jest.fn().mockResolvedValue({ indexMode: 'line' }),
       createIndex: jest.fn().mockResolvedValue({}),
       waitForProject: jest.fn().mockResolvedValue({}),
       waitForLogstore: jest.fn().mockResolvedValue({}),

--- a/tests/service/role-reconcile-flow.spec.test.ts
+++ b/tests/service/role-reconcile-flow.spec.test.ts
@@ -123,6 +123,46 @@ describe('Role Reconciliation Deploy Flow (issue #234)', () => {
     expect(healedRoles).toHaveLength(1);
   });
 
+  it('repairs drifted nested log resources on the next deploy (issue #234 M1)', async () => {
+    await deploy(deployOptions);
+
+    // Console drift: logstore ttl changed and the index was deleted out-of-band.
+    mockClient.sls.getLogstore.mockResolvedValue({
+      logstoreName: 'role-reconcile-test-service-dev-role-reconcile-fn-fn-logs',
+      ttl: 999,
+      shardCount: 2,
+    });
+    mockClient.sls.getIndex.mockResolvedValue(null);
+    mockClient.sls.updateLogstore.mockClear();
+    mockClient.sls.createIndex.mockClear();
+    mockClient.fc3.updateFunctionConfiguration.mockClear();
+
+    await deploy(deployOptions);
+
+    expect(mockClient.sls.updateLogstore).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      30,
+      2,
+    );
+    expect(mockClient.sls.createIndex).toHaveBeenCalled();
+
+    // Healthy again → noop (no further repair writes).
+    mockClient.sls.getLogstore.mockResolvedValue({
+      logstoreName: 'role-reconcile-test-service-dev-role-reconcile-fn-fn-logs',
+      ttl: 30,
+      shardCount: 2,
+    });
+    mockClient.sls.getIndex.mockResolvedValue({ indexMode: 'line' });
+    mockClient.sls.updateLogstore.mockClear();
+    mockClient.sls.createIndex.mockClear();
+
+    await deploy(deployOptions);
+
+    expect(mockClient.sls.updateLogstore).not.toHaveBeenCalled();
+    expect(mockClient.sls.createIndex).not.toHaveBeenCalled();
+  });
+
   it('stays noop on redeploy when the role still exists in the provider', async () => {
     await deploy(deployOptions);
     mockClient.ram.createRole.mockClear();

--- a/tests/unit/common/aliyunClient/nasOperations.test.ts
+++ b/tests/unit/common/aliyunClient/nasOperations.test.ts
@@ -482,6 +482,42 @@ describe('nasOperations', () => {
     });
   });
 
+  describe('listMountTargets', () => {
+    it('lists mount targets for a file system', async () => {
+      mockDescribeMountTargets.mockResolvedValue({
+        body: {
+          mountTargets: {
+            mountTarget: [
+              { mountTargetDomain: 'mt-1.example.com', status: 'Active' },
+              { mountTargetDomain: 'mt-2.example.com', status: 'Pending' },
+            ],
+          },
+        },
+      });
+
+      const result = await operations.listMountTargets('fs-1');
+
+      expect(result).toHaveLength(2);
+      expect(result[0]).toMatchObject({
+        fileSystemId: 'fs-1',
+        mountTargetDomain: 'mt-1.example.com',
+        status: 'Active',
+      });
+    });
+
+    it('returns an empty list when the response has no mount targets', async () => {
+      mockDescribeMountTargets.mockResolvedValue({ body: { mountTargets: { mountTarget: [] } } });
+
+      expect(await operations.listMountTargets('fs-1')).toEqual([]);
+    });
+
+    it('returns an empty list on error instead of throwing', async () => {
+      mockDescribeMountTargets.mockRejectedValue(new Error('nas throttled'));
+
+      expect(await operations.listMountTargets('fs-1')).toEqual([]);
+    });
+  });
+
   describe('deleteMountTarget', () => {
     it('should delete mount target', async () => {
       mockDeleteMountTarget.mockResolvedValue({});

--- a/tests/unit/common/aliyunClient/slsOperations.test.ts
+++ b/tests/unit/common/aliyunClient/slsOperations.test.ts
@@ -6,6 +6,7 @@ const mockDeleteProject = jest.fn();
 const mockCreateLogStore = jest.fn();
 const mockGetLogStore = jest.fn();
 const mockDeleteLogStore = jest.fn();
+const mockUpdateLogStore = jest.fn();
 const mockCreateIndex = jest.fn();
 const mockGetIndex = jest.fn();
 const mockDeleteIndex = jest.fn();
@@ -20,6 +21,7 @@ const mockSlsClient = {
   deleteProject: mockDeleteProject,
   createLogStore: mockCreateLogStore,
   getLogStore: mockGetLogStore,
+  updateLogStore: mockUpdateLogStore,
   deleteLogStore: mockDeleteLogStore,
   createIndex: mockCreateIndex,
   getIndex: mockGetIndex,
@@ -527,6 +529,18 @@ describe('slsOperations', () => {
           resourceType: 'project',
           tags: [{ key: 'si-owned-by', value: 'v' }],
         }),
+      );
+    });
+  });
+
+  describe('updateLogstore', () => {
+    it('sends the ttl/shard update', async () => {
+      await operations.updateLogstore('proj', 'store', 30, 2);
+
+      expect(mockUpdateLogStore).toHaveBeenCalledWith(
+        'proj',
+        'store',
+        expect.objectContaining({ ttl: 30, shardCount: 2 }),
       );
     });
   });

--- a/tests/unit/common/tencentClient/clsOperations.test.ts
+++ b/tests/unit/common/tencentClient/clsOperations.test.ts
@@ -287,6 +287,44 @@ describe('clsOperations', () => {
     });
   });
 
+  describe('getTopicById', () => {
+    it('returns the matching topic for the id filter', async () => {
+      mockClsClient.DescribeTopics.mockResolvedValue({
+        Topics: [
+          { TopicId: 'topic-2', TopicName: 'other' },
+          { TopicId: 'topic-1', TopicName: 'fn-logs', StorageType: 'hot', Period: 30 },
+        ],
+      });
+
+      const result = await operations.getTopicById('topic-1');
+
+      expect(mockClsClient.DescribeTopics).toHaveBeenCalledWith(
+        expect.objectContaining({
+          Filters: [{ Key: 'topicId', Values: ['topic-1'] }],
+        }),
+      );
+      expect(result).toMatchObject({ TopicId: 'topic-1', StorageType: 'hot' });
+    });
+
+    it('returns null when the topic id is not found', async () => {
+      mockClsClient.DescribeTopics.mockResolvedValue({ Topics: [] });
+
+      expect(await operations.getTopicById('topic-x')).toBeNull();
+    });
+  });
+
+  describe('modifyTopic', () => {
+    it('sends the attribute update', async () => {
+      await operations.modifyTopic('topic-1', { period: 30, storageType: 'hot' });
+
+      expect(mockClsClient.ModifyTopic).toHaveBeenCalledWith({
+        TopicId: 'topic-1',
+        Period: 30,
+        StorageType: 'hot',
+      });
+    });
+  });
+
   describe('createFulltextIndex', () => {
     it('creates a full-text index for the topic', async () => {
       mockClsClient.CreateIndex.mockResolvedValue({});

--- a/tests/unit/common/volcengineClient/tlsOperations.test.ts
+++ b/tests/unit/common/volcengineClient/tlsOperations.test.ts
@@ -13,6 +13,7 @@ const createMockClient = () => ({
   DescribeProjects: jest.fn() as MockFn,
   DeleteProject: jest.fn() as MockFn,
   CreateTopic: jest.fn() as MockFn,
+  ModifyTopic: jest.fn() as MockFn,
   DescribeTopics: jest.fn() as MockFn,
   DeleteTopic: jest.fn() as MockFn,
   CreateIndex: jest.fn() as MockFn,
@@ -943,6 +944,19 @@ describe('tlsOperations', () => {
       await expect(operations.waitForTopic('test-project', 'missing-topic')).rejects.toThrow(
         'TLS_TOPIC_NOT_FOUND',
       );
+    });
+  });
+
+  describe('modifyTopic', () => {
+    it('sends the ttl update', async () => {
+      mockClient.ModifyTopic.mockResolvedValueOnce({});
+
+      await operations.modifyTopic('topic-1', 30);
+
+      expect(mockClient.ModifyTopic).toHaveBeenCalledWith({
+        TopicId: 'topic-1',
+        Ttl: 30,
+      });
     });
   });
 

--- a/tests/unit/stack/aliyunStack/fc3Planner.test.ts
+++ b/tests/unit/stack/aliyunStack/fc3Planner.test.ts
@@ -36,12 +36,20 @@ const mockRamOperations = {
   getExecutionPolicyDocument: jest.fn(),
   listAttachedRolePolicies: jest.fn(),
 };
+const mockSlsOperations = {
+  getLogstore: jest.fn(),
+  updateLogstore: jest.fn(),
+  getIndex: jest.fn(),
+  createIndex: jest.fn(),
+  createLogstore: jest.fn(),
+};
 
 jest.mock('../../../../src/common/aliyunClient', () => ({
   createAliyunClient: () => ({
     fc3: mockFc3Operations,
     ecs: mockEcsOperations,
     ram: mockRamOperations,
+    sls: mockSlsOperations,
   }),
 }));
 jest.mock('../../../../src/common/hashUtils', () => ({
@@ -956,6 +964,89 @@ describe('FC3 Planner', () => {
         logicalId: 'functions.test_fn',
         action: 'noop',
         resourceType: 'ALIYUN_FC3',
+      });
+    });
+
+    describe('nested log drift (issue #234 M1)', () => {
+      const fnWithLog: FunctionDomain = { ...testFunction, log: true };
+      const slsLogstoreInstance = {
+        sid: 'si:aliyun:sls:default:test-project',
+        id: 'test-project/test-function-fn-logs',
+        type: 'ALIYUN_SLS_LOGSTORE',
+      };
+
+      const buildLogState = (): StateFile =>
+        setResource(initalState, 'functions.test_fn', {
+          mode: 'managed',
+          region: 'cn-hangzhou',
+          definition: {
+            functionName: 'test-function',
+            runtime: 'nodejs20',
+            handler: 'index.handler',
+            memorySize: 512,
+            timeout: 10,
+            diskSize: null,
+            environment: { NODE_ENV: 'production' },
+            vpcConfig: null,
+            gpuConfig: null,
+            customContainerConfig: null,
+            nasConfig: null,
+            logConfig: { enableRequestMetrics: true, enableInstanceMetrics: true },
+            codeHash: 'mock-code-hash',
+          },
+          instances: [fc3Instance, slsLogstoreInstance],
+          lastUpdated: new Date().toISOString(),
+        });
+
+      beforeEach(() => {
+        // A log-enabled function's GetFunction response carries logConfig —
+        // without it the desired-declared logConfig would false-drift.
+        mockFc3Operations.getFunction.mockResolvedValue({
+          ...remoteFunctionMatch,
+          logConfig: { enableRequestMetrics: true, enableInstanceMetrics: true },
+        });
+        mockSlsOperations.getIndex.mockResolvedValue({ indexMode: 'line' });
+      });
+
+      it('flags update+drifted when the live logstore ttl drifted', async () => {
+        mockSlsOperations.getLogstore.mockResolvedValue({ ttl: 999, shardCount: 2 });
+
+        const plan = await generateFunctionPlan(mockContext, buildLogState(), [fnWithLog]);
+
+        expect(plan.items[0]).toMatchObject({ action: 'update', drifted: true });
+      });
+
+      it('ignores shard growth (aliyun cannot shrink shards)', async () => {
+        mockSlsOperations.getLogstore.mockResolvedValue({ ttl: 30, shardCount: 5 });
+
+        const plan = await generateFunctionPlan(mockContext, buildLogState(), [fnWithLog]);
+
+        expect(plan.items[0]).toMatchObject({ action: 'noop' });
+      });
+
+      it('flags update+drifted when the index was deleted out-of-band', async () => {
+        mockSlsOperations.getLogstore.mockResolvedValue({ ttl: 30, shardCount: 2 });
+        mockSlsOperations.getIndex.mockResolvedValue(null);
+
+        const plan = await generateFunctionPlan(mockContext, buildLogState(), [fnWithLog]);
+
+        expect(plan.items[0]).toMatchObject({ action: 'update', drifted: true });
+      });
+
+      it('stays noop when logstore and index match', async () => {
+        mockSlsOperations.getLogstore.mockResolvedValue({ ttl: 30, shardCount: 2 });
+
+        const plan = await generateFunctionPlan(mockContext, buildLogState(), [fnWithLog]);
+
+        expect(plan.items[0]).toMatchObject({ action: 'noop' });
+      });
+
+      it('warns and stays noop when the nested probe fails', async () => {
+        mockSlsOperations.getLogstore.mockRejectedValue(new Error('sls throttled'));
+
+        const plan = await generateFunctionPlan(mockContext, buildLogState(), [fnWithLog]);
+
+        expect(plan.items[0]).toMatchObject({ action: 'noop' });
       });
     });
 

--- a/tests/unit/stack/aliyunStack/fc3Planner.test.ts
+++ b/tests/unit/stack/aliyunStack/fc3Planner.test.ts
@@ -44,6 +44,10 @@ const mockSlsOperations = {
   createIndex: jest.fn(),
   createLogstore: jest.fn(),
 };
+const mockNasOperations = {
+  listMountTargets: jest.fn(),
+  createMountTarget: jest.fn(),
+};
 
 jest.mock('../../../../src/common/aliyunClient', () => ({
   createAliyunClient: () => ({
@@ -51,6 +55,7 @@ jest.mock('../../../../src/common/aliyunClient', () => ({
     ecs: mockEcsOperations,
     ram: mockRamOperations,
     sls: mockSlsOperations,
+    nas: mockNasOperations,
   }),
 }));
 jest.mock('../../../../src/common/hashUtils', () => ({
@@ -1149,6 +1154,117 @@ describe('FC3 Planner', () => {
         mockEcsOperations.getSecurityGroupRules.mockRejectedValue(new Error('ecs throttled'));
 
         const plan = await generateFunctionPlan(mockContext, buildNetworkState(), [fnWithNetwork]);
+
+        expect(plan.items[0]).toMatchObject({ action: 'noop' });
+      });
+    });
+
+    describe('nested NAS drift (issue #234 M4)', () => {
+      const fnWithNas: FunctionDomain = {
+        ...testFunction,
+        network: {
+          vpc_id: 'vpc-123',
+          subnet_ids: ['vsw-123'],
+          security_group: { name: 'app-sg', ingress: [], egress: [] },
+        },
+        storage: {
+          nas: [{ storage_class: NasStorageClassEnum.STANDARD_CAPACITY, mount_path: '/mnt/data' }],
+        },
+      };
+      const fsInstance = {
+        sid: 'si:aliyun:nas:default:fs-1',
+        id: 'fs-1',
+        type: 'ALIYUN_NAS_FILE_SYSTEM',
+      };
+
+      const buildNasState = (): StateFile =>
+        setResource(initalState, 'functions.test_fn', {
+          mode: 'managed',
+          region: 'cn-hangzhou',
+          definition: {
+            functionName: 'test-function',
+            runtime: 'nodejs20',
+            handler: 'index.handler',
+            memorySize: 512,
+            timeout: 10,
+            diskSize: null,
+            environment: { NODE_ENV: 'production' },
+            vpcConfig: {
+              vpcId: 'vpc-123',
+              vSwitchIds: ['vsw-123'],
+              securityGroupId: 'sg-resolved',
+            },
+            gpuConfig: null,
+            customContainerConfig: null,
+            nasConfig: {
+              userId: 10003,
+              groupId: 10003,
+              mountPoints: [
+                {
+                  serverAddr: NasStorageClassEnum.STANDARD_CAPACITY,
+                  mountDir: '/mnt/data',
+                  enableTls: false,
+                },
+              ],
+            },
+            logConfig: null,
+            codeHash: 'mock-code-hash',
+          },
+          instances: [
+            fc3Instance,
+            fsInstance,
+            { sid: 's2', id: 'fs-1/mt-domain', type: 'ALIYUN_NAS_MOUNT_TARGET' },
+          ],
+          lastUpdated: new Date().toISOString(),
+        });
+
+      beforeEach(() => {
+        mockFc3Operations.getFunction.mockResolvedValue({
+          ...remoteFunctionMatch,
+          vpcConfig: { vpcId: 'vpc-123', vSwitchIds: ['vsw-123'], securityGroupId: 'sg-resolved' },
+          nasConfig: {
+            userId: 10003,
+            groupId: 10003,
+            mountPoints: [
+              {
+                serverAddr: NasStorageClassEnum.STANDARD_CAPACITY,
+                mountDir: '/mnt/data',
+                enableTls: false,
+              },
+            ],
+          },
+        });
+        mockEcsOperations.getSecurityGroupByName.mockResolvedValue({
+          securityGroupId: 'sg-resolved',
+        });
+        mockEcsOperations.getSecurityGroupRules.mockResolvedValue({
+          ingressRules: [],
+          egressRules: [],
+        });
+      });
+
+      it('stays noop when the live mount targets match', async () => {
+        mockNasOperations.listMountTargets.mockResolvedValue([
+          { fileSystemId: 'fs-1', mountTargetDomain: 'mt-domain', status: 'Active' },
+        ]);
+
+        const plan = await generateFunctionPlan(mockContext, buildNasState(), [fnWithNas]);
+
+        expect(plan.items[0]).toMatchObject({ action: 'noop' });
+      });
+
+      it('flags update+drifted when the mount target was deleted out-of-band', async () => {
+        mockNasOperations.listMountTargets.mockResolvedValue([]);
+
+        const plan = await generateFunctionPlan(mockContext, buildNasState(), [fnWithNas]);
+
+        expect(plan.items[0]).toMatchObject({ action: 'update', drifted: true });
+      });
+
+      it('warns and stays noop when the NAS probe fails', async () => {
+        mockNasOperations.listMountTargets.mockRejectedValue(new Error('nas throttled'));
+
+        const plan = await generateFunctionPlan(mockContext, buildNasState(), [fnWithNas]);
 
         expect(plan.items[0]).toMatchObject({ action: 'noop' });
       });

--- a/tests/unit/stack/aliyunStack/fc3Planner.test.ts
+++ b/tests/unit/stack/aliyunStack/fc3Planner.test.ts
@@ -30,6 +30,7 @@ const mockFc3Operations = {
 };
 const mockEcsOperations = {
   getSecurityGroupByName: jest.fn(),
+  getSecurityGroupRules: jest.fn(),
 };
 const mockRamOperations = {
   getRole: jest.fn(),
@@ -1045,6 +1046,109 @@ describe('FC3 Planner', () => {
         mockSlsOperations.getLogstore.mockRejectedValue(new Error('sls throttled'));
 
         const plan = await generateFunctionPlan(mockContext, buildLogState(), [fnWithLog]);
+
+        expect(plan.items[0]).toMatchObject({ action: 'noop' });
+      });
+    });
+
+    describe('nested SG rule drift (issue #234 M2)', () => {
+      const fnWithNetwork: FunctionDomain = {
+        ...testFunction,
+        network: {
+          vpc_id: 'vpc-123',
+          subnet_ids: ['vsw-123'],
+          security_group: {
+            name: 'app-sg',
+            ingress: ['tcp:0.0.0.0/0:8080'],
+            egress: [],
+          },
+        },
+      };
+      const sgInstance = {
+        sid: 'si:aliyun:ecs:default:sg-resolved',
+        id: 'sg-resolved',
+        type: 'ALIYUN_ECS_SECURITY_GROUP',
+      };
+
+      const buildNetworkState = (): StateFile =>
+        setResource(initalState, 'functions.test_fn', {
+          mode: 'managed',
+          region: 'cn-hangzhou',
+          definition: {
+            functionName: 'test-function',
+            runtime: 'nodejs20',
+            handler: 'index.handler',
+            memorySize: 512,
+            timeout: 10,
+            diskSize: null,
+            environment: { NODE_ENV: 'production' },
+            vpcConfig: {
+              vpcId: 'vpc-123',
+              vSwitchIds: ['vsw-123'],
+              securityGroupId: 'sg-resolved',
+            },
+            gpuConfig: null,
+            customContainerConfig: null,
+            nasConfig: null,
+            logConfig: null,
+            codeHash: 'mock-code-hash',
+          },
+          instances: [fc3Instance, sgInstance],
+          lastUpdated: new Date().toISOString(),
+        });
+
+      beforeEach(() => {
+        // A networked function's GetFunction response carries the vpcConfig —
+        // without it the desired-declared vpcConfig would false-drift.
+        mockFc3Operations.getFunction.mockResolvedValue({
+          ...remoteFunctionMatch,
+          vpcConfig: { vpcId: 'vpc-123', vSwitchIds: ['vsw-123'], securityGroupId: 'sg-resolved' },
+        });
+        mockEcsOperations.getSecurityGroupByName.mockResolvedValue({
+          securityGroupId: 'sg-resolved',
+        });
+      });
+
+      it('stays noop when live SG rules match the declared set', async () => {
+        mockEcsOperations.getSecurityGroupRules.mockResolvedValue({
+          ingressRules: [{ ipProtocol: 'TCP', portRange: '8080/8080', sourceCidrIp: '0.0.0.0/0' }],
+          egressRules: [],
+        });
+
+        const plan = await generateFunctionPlan(mockContext, buildNetworkState(), [fnWithNetwork]);
+
+        expect(plan.items[0]).toMatchObject({ action: 'noop' });
+      });
+
+      it('flags update+drifted when a live SG rule is not declared (console-added)', async () => {
+        mockEcsOperations.getSecurityGroupRules.mockResolvedValue({
+          ingressRules: [
+            { ipProtocol: 'TCP', portRange: '8080/8080', sourceCidrIp: '0.0.0.0/0' },
+            { ipProtocol: 'TCP', portRange: '22/22', sourceCidrIp: '0.0.0.0/0' },
+          ],
+          egressRules: [],
+        });
+
+        const plan = await generateFunctionPlan(mockContext, buildNetworkState(), [fnWithNetwork]);
+
+        expect(plan.items[0]).toMatchObject({ action: 'update', drifted: true });
+      });
+
+      it('flags update+drifted when a declared SG rule is missing live', async () => {
+        mockEcsOperations.getSecurityGroupRules.mockResolvedValue({
+          ingressRules: [],
+          egressRules: [],
+        });
+
+        const plan = await generateFunctionPlan(mockContext, buildNetworkState(), [fnWithNetwork]);
+
+        expect(plan.items[0]).toMatchObject({ action: 'update', drifted: true });
+      });
+
+      it('warns and stays noop when the SG probe fails', async () => {
+        mockEcsOperations.getSecurityGroupRules.mockRejectedValue(new Error('ecs throttled'));
+
+        const plan = await generateFunctionPlan(mockContext, buildNetworkState(), [fnWithNetwork]);
 
         expect(plan.items[0]).toMatchObject({ action: 'noop' });
       });

--- a/tests/unit/stack/aliyunStack/fc3Resource.test.ts
+++ b/tests/unit/stack/aliyunStack/fc3Resource.test.ts
@@ -45,6 +45,8 @@ const mockedSlsOperations = {
   getLogstore: jest.fn(),
   createLogstore: jest.fn(),
   createIndex: jest.fn(),
+  updateLogstore: jest.fn(),
+  getIndex: jest.fn(),
   deleteProject: jest.fn(),
   deleteLogstore: jest.fn(),
   deleteIndex: jest.fn(),
@@ -66,12 +68,16 @@ const mockedRamOperations = {
 const mockedEcsOperations = {
   createSecurityGroup: jest.fn(),
   deleteSecurityGroup: jest.fn(),
+  getSecurityGroupRules: jest.fn(),
+  authorizeSecurityGroupRules: jest.fn(),
+  revokeSecurityGroupRules: jest.fn(),
 };
 const mockedNasOperations = {
   createAccessGroup: jest.fn(),
   createAccessRule: jest.fn(),
   createFileSystem: jest.fn(),
   createMountTarget: jest.fn(),
+  listMountTargets: jest.fn(),
   deleteAccessGroup: jest.fn(),
   deleteFileSystem: jest.fn(),
   deleteMountTarget: jest.fn(),
@@ -941,6 +947,178 @@ describe('Fc3Resource', () => {
         'mock-code-hash',
       );
       expect(result).toEqual(newState);
+    });
+
+    it('reconciles drifted nested log resources on force (issue #234 M1)', async () => {
+      const forceOptions = { force: true };
+      const logFn: FunctionDomain = { ...testFunction, log: true };
+      const stateWithSls = {
+        ...initialState,
+        resources: {
+          'functions.test_fn': {
+            mode: 'managed',
+            region: 'cn-hangzhou',
+            definition: mockDefinition,
+            instances: [
+              { sid: 's-fn', id: 'test-function', functionName: 'test-function' },
+              {
+                sid: 's-sls',
+                id: 'test-project/test-function-fn-logs',
+                type: 'ALIYUN_SLS_LOGSTORE',
+              },
+            ],
+            lastUpdated: new Date().toISOString(),
+          },
+        },
+      };
+
+      mockedSlsOperations.getLogstore.mockResolvedValue({ ttl: 999, shardCount: 2 });
+      mockedSlsOperations.updateLogstore.mockResolvedValue(undefined);
+      mockedSlsOperations.getIndex.mockResolvedValue(null);
+      mockedSlsOperations.createIndex.mockResolvedValue({});
+      mockedFc3Types.functionToFc3Config.mockReturnValue(mockConfig);
+      mockedFc3Types.extractFc3Definition.mockReturnValue(mockDefinition);
+      mockedFc3Operations.updateFunctionConfiguration.mockResolvedValue(undefined);
+      mockedStateManager.setResource.mockReturnValue(stateWithSls as unknown as StateFile);
+
+      const result = await updateResource(
+        mockContext,
+        logFn,
+        stateWithSls as StateFile,
+        forceOptions,
+      );
+
+      expect(mockedSlsOperations.updateLogstore).toHaveBeenCalledWith(
+        'test-project',
+        'test-function-fn-logs',
+        30,
+        2,
+      );
+      expect(mockedSlsOperations.createIndex).toHaveBeenCalledWith(
+        'test-project',
+        'test-function-fn-logs',
+      );
+      expect(result).toEqual(stateWithSls as unknown as StateFile);
+    });
+
+    it('reconciles drifted SG rules on force (issue #234 M2)', async () => {
+      const networkFn: FunctionDomain = {
+        ...testFunction,
+        network: {
+          vpc_id: 'vpc-123',
+          subnet_ids: ['vsw-123'],
+          security_group: { name: 'app-sg', ingress: ['tcp:0.0.0.0/0:8080'], egress: [] },
+        },
+      };
+      const stateWithSg = {
+        ...initialState,
+        resources: {
+          'functions.test_fn': {
+            mode: 'managed',
+            region: 'cn-hangzhou',
+            definition: mockDefinition,
+            instances: [
+              { sid: 's-fn', id: 'test-function', functionName: 'test-function' },
+              { sid: 's-sg', id: 'sg-resolved', type: 'ALIYUN_ECS_SECURITY_GROUP' },
+            ],
+            lastUpdated: new Date().toISOString(),
+          },
+        },
+      };
+
+      mockedEcsOperations.getSecurityGroupRules.mockResolvedValue({
+        ingressRules: [
+          { ipProtocol: 'TCP', portRange: '8080/8080', sourceCidrIp: '0.0.0.0/0' },
+          { ipProtocol: 'TCP', portRange: '22/22', sourceCidrIp: '10.0.0.0/8' },
+        ],
+        egressRules: [],
+      });
+
+      await updateResource(mockContext, networkFn, stateWithSg as StateFile, { force: true });
+
+      expect(mockedEcsOperations.revokeSecurityGroupRules).toHaveBeenCalledWith(
+        'sg-resolved',
+        'ingress',
+        [expect.objectContaining({ cidr: '10.0.0.0/8' })],
+      );
+      expect(mockedEcsOperations.authorizeSecurityGroupRules).not.toHaveBeenCalled();
+    });
+
+    it('recreates deleted NAS mount targets on force (issue #234 M4)', async () => {
+      const nasFn: FunctionDomain = {
+        ...testFunction,
+        network: {
+          vpc_id: 'vpc-123',
+          subnet_ids: ['vsw-123'],
+          security_group: { name: 'app-sg', ingress: [], egress: [] },
+        },
+        storage: {
+          nas: [{ storage_class: 'STANDARD_CAPACITY' as never, mount_path: '/mnt/data' }],
+        },
+      };
+      const stateWithNas = {
+        ...initialState,
+        resources: {
+          'functions.test_fn': {
+            mode: 'managed',
+            region: 'cn-hangzhou',
+            definition: mockDefinition,
+            instances: [
+              { sid: 's-fn', id: 'test-function', functionName: 'test-function' },
+              { sid: 's-fs', id: 'fs-1', type: 'ALIYUN_NAS_FILE_SYSTEM' },
+            ],
+            lastUpdated: new Date().toISOString(),
+          },
+        },
+      };
+
+      mockedNasOperations.listMountTargets.mockResolvedValue([]);
+      mockedNasOperations.createMountTarget.mockResolvedValue({
+        mountTargetDomain: 'mt-domain',
+        status: 'Active',
+      });
+
+      await updateResource(mockContext, nasFn, stateWithNas as StateFile, { force: true });
+
+      expect(mockedNasOperations.createMountTarget).toHaveBeenCalledWith(
+        'fs-1',
+        'test-function-default-nas-access-/mnt/data',
+        'vpc-123',
+        'vsw-123',
+      );
+    });
+
+    it('skips nested log reconcile without force (issue #234 M1)', async () => {
+      const logFn: FunctionDomain = { ...testFunction, log: true };
+      const stateWithSls = {
+        ...initialState,
+        resources: {
+          'functions.test_fn': {
+            mode: 'managed',
+            region: 'cn-hangzhou',
+            definition: mockDefinition,
+            instances: [
+              { sid: 's-fn', id: 'test-function', functionName: 'test-function' },
+              {
+                sid: 's-sls',
+                id: 'test-project/test-function-fn-logs',
+                type: 'ALIYUN_SLS_LOGSTORE',
+              },
+            ],
+            lastUpdated: new Date().toISOString(),
+          },
+        },
+      };
+
+      mockedSlsOperations.getLogstore.mockResolvedValue({ ttl: 999, shardCount: 2 });
+      mockedFc3Types.functionToFc3Config.mockReturnValue(mockConfig);
+      mockedFc3Types.extractFc3Definition.mockReturnValue(mockDefinition);
+      mockedFc3Operations.updateFunctionConfiguration.mockResolvedValue(undefined);
+      mockedStateManager.setResource.mockReturnValue(stateWithSls as unknown as StateFile);
+
+      await updateResource(mockContext, logFn, stateWithSls as StateFile);
+
+      expect(mockedSlsOperations.updateLogstore).not.toHaveBeenCalled();
     });
 
     it('should propagate errors from updateFc3FunctionConfiguration', async () => {

--- a/tests/unit/stack/scfStack/scfPlanner.test.ts
+++ b/tests/unit/stack/scfStack/scfPlanner.test.ts
@@ -1,6 +1,6 @@
 import { ProviderEnum, setResource } from '../../../../src/common';
 import { generateFunctionPlan } from '../../../../src/stack/scfStack/scfPlanner';
-import { Context, FunctionDomain } from '../../../../src/types';
+import { Context, FunctionDomain, StateFile } from '../../../../src/types';
 
 const initalState = {
   version: '1.0.0',
@@ -22,6 +22,8 @@ const mockScfOperations = {
 const mockClsOperations = {
   getLogsetNameById: jest.fn(),
   listTopicsByLogset: jest.fn(),
+  getTopicById: jest.fn(),
+  modifyTopic: jest.fn(),
 };
 
 jest.mock('../../../../src/common/tencentClient', () => ({
@@ -340,6 +342,108 @@ describe('SCF Planner', () => {
           },
         }),
       );
+    });
+
+    describe('nested topic drift (issue #234 M3)', () => {
+      const fnWithLog = { ...testFunction, log: true };
+      const topicInstance = {
+        sid: 'si:tencent:cls:default:topic-1',
+        id: 'topic-1',
+        type: 'TENCENT_CLS_TOPIC',
+        topicName: 'test-service-default-test_fn-fn-logs',
+      };
+
+      const buildLogState = (): StateFile =>
+        setResource(initalState, 'functions.test_fn', {
+          mode: 'managed',
+          region: 'ap-guangzhou',
+          definition: {
+            functionName: 'test-function',
+            runtime: 'Nodejs18.15',
+            handler: 'index.handler',
+            memorySize: 512,
+            timeout: 10,
+            environment: { NODE_ENV: 'production' },
+            codeHash: 'mock-code-hash',
+            vpcConfig: null,
+            diskSize: null,
+            cfsConfig: null,
+            useGpu: null,
+            imageConfig: null,
+            logConfig: {
+              logset: 'test-app-default-cls',
+              topic: 'test-service-default-test_fn-fn-logs',
+            },
+          },
+          instances: [
+            {
+              sid: 'si:tencent:scf:default:test-function',
+              id: 'test-function',
+              functionName: 'test-function',
+            },
+            topicInstance,
+          ],
+          lastUpdated: new Date().toISOString(),
+        });
+
+      const buildClient = (): void => {
+        mockScfOperations.getFunction.mockResolvedValue({
+          FunctionName: 'test-function',
+          Runtime: 'Nodejs18.15',
+          Handler: 'index.handler',
+          MemorySize: 512,
+          Timeout: 10,
+          Environment: {
+            Variables: [{ Key: 'NODE_ENV', Value: 'production' }],
+          },
+          ClsLogsetId: 'cls-1',
+          ClsTopicId: 'topic-1',
+        });
+      };
+
+      beforeEach(() => {
+        buildClient();
+      });
+
+      it('stays noop when the live topic attributes match', async () => {
+        mockClsOperations.getTopicById.mockResolvedValue({
+          TopicId: 'topic-1',
+          StorageType: 'hot',
+          Period: 30,
+        });
+
+        const plan = await generateFunctionPlan(mockContext, buildLogState(), [fnWithLog]);
+
+        expect(plan.items[0]).toMatchObject({ action: 'noop' });
+      });
+
+      it('flags update+drifted when the topic storage class drifted', async () => {
+        mockClsOperations.getTopicById.mockResolvedValue({
+          TopicId: 'topic-1',
+          StorageType: 'cold',
+          Period: 30,
+        });
+
+        const plan = await generateFunctionPlan(mockContext, buildLogState(), [fnWithLog]);
+
+        expect(plan.items[0]).toMatchObject({ action: 'update', drifted: true });
+      });
+
+      it('flags update+drifted when the topic was deleted out-of-band', async () => {
+        mockClsOperations.getTopicById.mockResolvedValue(null);
+
+        const plan = await generateFunctionPlan(mockContext, buildLogState(), [fnWithLog]);
+
+        expect(plan.items[0]).toMatchObject({ action: 'update', drifted: true });
+      });
+
+      it('warns and stays noop when the topic probe fails', async () => {
+        mockClsOperations.getTopicById.mockRejectedValue(new Error('cls throttled'));
+
+        const plan = await generateFunctionPlan(mockContext, buildLogState(), [fnWithLog]);
+
+        expect(plan.items[0]).toMatchObject({ action: 'noop' });
+      });
     });
 
     it('resolves live CLS ids to names and stays noop when they match (issue #234 phase 3)', async () => {

--- a/tests/unit/stack/scfStack/scfResource.test.ts
+++ b/tests/unit/stack/scfStack/scfResource.test.ts
@@ -44,6 +44,8 @@ const mockClsOperations = {
   getLogsetByName: jest.fn(),
   listTopicsByLogset: jest.fn(),
   getTopicByName: jest.fn(),
+  getTopicById: jest.fn(),
+  modifyTopic: jest.fn(),
   createTopic: jest.fn(),
   deleteTopic: jest.fn(),
   deleteLogset: jest.fn(),
@@ -1425,6 +1427,38 @@ describe('ScfResource', () => {
   });
 
   describe('updateResource', () => {
+    it('reconciles drifted CLS topic attributes on force (issue #234 M3)', async () => {
+      (mockScfOperations.updateFunctionConfiguration as jest.Mock).mockResolvedValue(undefined);
+      (mockScfOperations.updateFunctionCode as jest.Mock).mockResolvedValue(undefined);
+      (stateManager.setResource as jest.Mock).mockReturnValue(initialState);
+      (stateManager.getResource as jest.Mock).mockReturnValue({
+        mode: 'managed',
+        region: 'ap-guangzhou',
+        definition: { ...mockDefinition, logConfig: { logset: 'ls-1', topic: 'tp-1' } },
+        instances: [
+          { sid: 's-fn', id: 'test-function', functionName: 'test-function' },
+          { sid: 's-topic', id: 'topic-1', type: 'TENCENT_CLS_TOPIC', topicName: 'tp-1' },
+        ],
+        lastUpdated: '2025-01-01T00:00:00Z',
+      });
+      (mockScfOperations.getFunction as jest.Mock).mockResolvedValue(mockFunctionInfo);
+      (mockClsOperations.getTopicById as jest.Mock).mockResolvedValue({
+        TopicId: 'topic-1',
+        StorageType: 'cold',
+        Period: 10,
+      });
+      (mockClsOperations.modifyTopic as jest.Mock).mockResolvedValue(undefined);
+
+      const logFn = { ...testFunction, log: true };
+
+      await updateResource(mockContext, logFn, initialState, { force: true });
+
+      expect(mockClsOperations.modifyTopic).toHaveBeenCalledWith('topic-1', {
+        period: 30,
+        storageType: 'hot',
+      });
+    });
+
     it('should skip createTrigger when state lacks trigger record but provider already has it', async () => {
       const fnWithTrigger = {
         ...testFunction,

--- a/tests/unit/stack/volcengineStack/vefaasPlanner.test.ts
+++ b/tests/unit/stack/volcengineStack/vefaasPlanner.test.ts
@@ -48,6 +48,10 @@ describe('vefaasPlanner', () => {
     vefaas: {
       getFunction: jest.fn(),
     },
+    tls: {
+      getTopic: jest.fn(),
+      modifyTopic: jest.fn(),
+    },
   };
 
   const mockFunction: FunctionDomain = {
@@ -79,17 +83,28 @@ describe('vefaasPlanner', () => {
   });
 
   describe('generateFunctionPlan', () => {
-    let mockVefaasClient: { vefaas: { getFunction: jest.Mock } };
+    let mockVefaasClient: {
+      vefaas: { getFunction: jest.Mock };
+      tls: { getTopic: jest.Mock; modifyTopic: jest.Mock };
+    };
 
     beforeEach(() => {
       mockVefaasClient = {
         vefaas: {
           getFunction: jest.fn(),
         },
+        tls: {
+          getTopic: jest.fn(),
+          modifyTopic: jest.fn(),
+        },
       };
       (createVolcengineClient as jest.Mock).mockReturnValue(mockVefaasClient);
-      jest.spyOn(stateManager, 'getResource').mockReturnValue(undefined);
-      jest.spyOn(stateManager, 'getAllResources').mockReturnValue({});
+      jest
+        .spyOn(stateManager, 'getResource')
+        .mockImplementation((state, logicalId) => state.resources?.[logicalId] as never);
+      jest
+        .spyOn(stateManager, 'getAllResources')
+        .mockImplementation((state) => state.resources ?? {});
       jest
         .spyOn(hashUtils, 'attributesEqual')
         .mockImplementation((a, b) => JSON.stringify(a) === JSON.stringify(b));
@@ -674,6 +689,104 @@ describe('vefaasPlanner', () => {
           },
         },
       });
+    });
+
+    it('flags update+drifted when the live TLS topic ttl drifted (issue #234 M5)', async () => {
+      jest.spyOn(hashUtils, 'attributesEqual').mockReturnValue(true);
+
+      const stateWithLog: StateFile = {
+        ...mockState,
+        resources: {
+          'functions.test_fn': {
+            mode: 'managed',
+            region: 'cn-beijing',
+            definition: {
+              functionName: 'test-function',
+              runtime: 'node20/v1',
+              handler: 'index.handler',
+              memorySize: 128,
+              timeout: 30,
+              logConfig: { project: 'test-app-dev-tls', topic: 'test-service-dev-test_fn-fn-logs' },
+            },
+            instances: [
+              {
+                type: 'VOLCENGINE_TLS_TOPIC',
+                sid: 's',
+                id: 'test-app-dev-tls/test-service-dev-test_fn-fn-logs',
+              },
+            ],
+            lastUpdated: '2024-01-01T00:00:00Z',
+            status: 'ready',
+          },
+        },
+      };
+      mockVefaasClient.vefaas.getFunction.mockResolvedValue({
+        runtime: 'node20/v1',
+        handler: 'index.handler',
+        memoryMb: 128,
+        requestTimeout: 30,
+        logConfig: { project: 'test-app-dev-tls', topic: 'test-service-dev-test_fn-fn-logs' },
+      });
+      mockVefaasClient.tls.getTopic.mockResolvedValue({
+        topicId: 't-1',
+        topicName: 'test-service-dev-test_fn-fn-logs',
+        ttl: 999,
+      });
+
+      const plan = await generateFunctionPlan(mockContext, stateWithLog, [
+        { ...mockFunction, log: true },
+      ]);
+
+      expect(plan.items[0]).toMatchObject({ action: 'update', drifted: true });
+    });
+
+    it('stays noop when the live TLS topic ttl matches (issue #234 M5)', async () => {
+      jest.spyOn(hashUtils, 'attributesEqual').mockReturnValue(true);
+
+      const stateWithLog: StateFile = {
+        ...mockState,
+        resources: {
+          'functions.test_fn': {
+            mode: 'managed',
+            region: 'cn-beijing',
+            definition: {
+              functionName: 'test-function',
+              runtime: 'node20/v1',
+              handler: 'index.handler',
+              memorySize: 128,
+              timeout: 30,
+              logConfig: { project: 'test-app-dev-tls', topic: 'test-service-dev-test_fn-fn-logs' },
+            },
+            instances: [
+              {
+                type: 'VOLCENGINE_TLS_TOPIC',
+                sid: 's',
+                id: 'test-app-dev-tls/test-service-dev-test_fn-fn-logs',
+              },
+            ],
+            lastUpdated: '2024-01-01T00:00:00Z',
+            status: 'ready',
+          },
+        },
+      };
+      mockVefaasClient.vefaas.getFunction.mockResolvedValue({
+        runtime: 'node20/v1',
+        handler: 'index.handler',
+        memoryMb: 128,
+        requestTimeout: 30,
+        logConfig: { project: 'test-app-dev-tls', topic: 'test-service-dev-test_fn-fn-logs' },
+      });
+      mockVefaasClient.tls.getTopic.mockResolvedValue({
+        topicId: 't-1',
+        topicName: 'test-service-dev-test_fn-fn-logs',
+        ttl: 30,
+      });
+
+      const plan = await generateFunctionPlan(mockContext, stateWithLog, [
+        { ...mockFunction, log: true },
+      ]);
+
+      expect(plan.items[0]).toMatchObject({ action: 'noop' });
     });
   });
 });

--- a/tests/unit/stack/volcengineStack/vefaasResource.test.ts
+++ b/tests/unit/stack/volcengineStack/vefaasResource.test.ts
@@ -174,6 +174,7 @@ describe('vefaasResource', () => {
       deleteProject: jest.fn(),
       createTopic: jest.fn(),
       getTopic: jest.fn(),
+      modifyTopic: jest.fn(),
       deleteTopic: jest.fn(),
       createIndex: jest.fn(),
       deleteIndex: jest.fn(),
@@ -1165,6 +1166,76 @@ describe('vefaasResource', () => {
       await updateResource(mockContext, mockFunction, stateWithFunction);
 
       expect(mockVefaasClient.vefaas.updateFunctionConfiguration).toHaveBeenCalled();
+    });
+
+    it('reconciles drifted TLS topic ttl on force (issue #234 M5)', async () => {
+      const stateWithLogTls: StateFile = {
+        ...mockState,
+        resources: {
+          'functions.test_fn': {
+            mode: 'managed',
+            region: 'cn-beijing',
+            definition: {
+              functionName: 'test-function',
+              codeHash: 'old-hash',
+              runtime: 'nodejs16',
+              handler: 'index.handler',
+              memorySize: 128,
+              timeout: 30,
+              logConfig: {
+                project: 'test-app-test-service-dev-tls',
+                topic: 'test-service-dev-test_fn-fn-logs',
+              },
+            },
+            instances: [
+              {
+                type: 'VOLCENGINE_VEFAAS_FUNCTION',
+                sid: 's-fn',
+                id: 'test-function',
+                functionName: 'test-function',
+                functionId: 'func-123',
+              },
+              {
+                type: 'VOLCENGINE_TLS_TOPIC',
+                sid: 's-tls',
+                id: 'test-app-test-service-dev-tls/test-service-dev-test_fn-fn-logs',
+              },
+            ],
+            lastUpdated: '2024-01-01T00:00:00Z',
+          },
+        },
+      };
+
+      (getResource as jest.Mock).mockReturnValue(stateWithLogTls.resources['functions.test_fn']);
+      (attributesEqual as jest.Mock).mockReturnValue(true);
+      mockVefaasClient.vefaas.getFunction.mockResolvedValue({
+        functionName: 'test-function',
+        functionId: 'func-123',
+        runtime: 'nodejs18',
+        handler: 'index.handler',
+        memoryMb: 128,
+        requestTimeout: 30,
+        logConfig: {
+          project: 'test-app-test-service-dev-tls',
+          topic: 'test-service-dev-test_fn-fn-logs',
+        },
+      });
+      mockVefaasClient.tls.getTopic.mockResolvedValue({
+        topicId: 't-1',
+        topicName: 'test-service-dev-test_fn-fn-logs',
+        ttl: 999,
+      });
+      mockVefaasClient.tls.modifyTopic.mockResolvedValue(undefined);
+      mockVefaasClient.vefaas.updateFunctionCode.mockResolvedValue({
+        releaseRecordId: 'rel-code-1',
+      });
+      mockVefaasClient.vefaas.updateFunctionConfiguration.mockResolvedValue('rel-config-1');
+
+      await updateResource(mockContext, { ...mockFunction, log: true }, stateWithLogTls, {
+        force: true,
+      });
+
+      expect(mockVefaasClient.tls.modifyTopic).toHaveBeenCalledWith('t-1', 30);
     });
 
     it('should update function code when code changed', async () => {


### PR DESCRIPTION
## Summary

Issue #234 嵌套依赖资源修复策略 **M1-M5 全部落地**：函数所有的嵌套资源（按 Phase 3 评估结论的"检测跟随所有权"原则）获得属性级漂移探测与修复。承接 #240（Phase 3 骨架）。

### 架构（探测与修复分离）

- **planner（只读探测）**：函数 planner 的 exists-path 增加嵌套探测段——只在该维度被 config 声明时跑（fn.log → logstore/index/topic；fn.network → SG；fn.storage.nas → 挂载点），任一不符 → 函数 `update + drifted`（不新增 PlanItem）；探测失败 warn + skip
- **executor（修复）**：drifted/force 时 `updateDependents` 按 live→desired 增量修复（非重建）；失败进 partialFailure 语义

### 各里程碑

| 期 | 维度 | 读 | 修复 | 关键约束 |
|---|---|---|---|---|
| M1 | aliyun logstore TTL/shards + index | `getLogstore`/`getIndex` | 新 op `UpdateLogstore` + createIndex（upsert） | shards 只能增——仅赤字算漂移 |
| M2 | aliyun SG ingress/egress 规则 | `getSecurityGroupRules` | 新 op `authorize/revokeSecurityGroupRules` 差集 | 规则 canonical 化（protocol\|portRange\|cidr），与创建路径同构 |
| M3 | tencent CLS topic StorageType/Period | 新 op `getTopicById` | 新 op `ModifyTopic`；带外删除按共享 logset 重建 | 常量统一（Period 30 / StorageType hot） |
| M4 | aliyun NAS 挂载点 | 新 op `listMountTargets` | `createMountTarget` 重建 | 多余挂载点不删（共享基础设施不可在 reconcile 中删除） |
| M5 | volcengine TLS topic ttl | `getTopic` | 新 op `ModifyTopic`（仅 ttl 可变——shards 创建期定死） | --no-refresh 早退后探测天然跳过 |

全部新 op 挂到对应 client operations；`--no-refresh` 全覆盖；探测失败降级 warn+skip。

## Test plan

- [x] `npm run build` + `npm run lint:check` 干净
- [x] Full `npm run test:ci`: **165/165 suites, 3478/3478 tests**, coverage gates met
- [x] 每期：探测 drift/noop/降级单测；M1 三段流 service test（create → 控制台篡改 → deploy 修复 → noop）
- [x] 修复路径全部 force 门控（只在 drifted deploy 中执行）

Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-openagent)
