### PR TITLE
test(service): nested drift repair three-stage flows for M2-M5 + NAS repair-path fix (issue #234)

### DIFF
--- a/src/common/nameBuilder.ts
+++ b/src/common/nameBuilder.ts
@@ -114,3 +114,16 @@ export const buildFunctionRoleName = (serviceName: string, stage: string, fnKey:
 
 /** Single source of truth for the execution policy name attached to a role. */
 export const buildRolePolicyName = (roleName: string): string => `${roleName}-policy`;
+
+/**
+ * Single source of truth for function-owned NAS access-group names. The raw
+ * mount path is flattened (slashes folded, leading dash trimmed) so every
+ * derivation site — create and update/repair alike — produces the identical
+ * group for the same config; deriving it inline is what caused the recreated
+ * target to bind to a never-created group (issue #234 M4).
+ *
+ * Deliberately not routed through buildConstrainedName: existing deployments
+ * must keep byte-identical names (stored-first on rename).
+ */
+export const buildNasAccessGroupName = (fnName: string, stage: string, mountPath: string): string =>
+  `${fnName}-${stage}-nas-access-${mountPath.replace(/\//g, '-').replace(/^-/, '')}`;

--- a/src/stack/aliyunStack/fc3Resource.ts
+++ b/src/stack/aliyunStack/fc3Resource.ts
@@ -15,6 +15,7 @@ import {
   getContext,
   buildSid,
   buildFunctionRoleName,
+  buildNasAccessGroupName,
   attributesEqual,
   mapAuthType,
   mapAliyunAccess,
@@ -638,8 +639,7 @@ const createDependentResources = async (
       }> = [];
 
       for (const nasItem of fn.storage.nas) {
-        const mountPath = nasItem.mount_path.replace(/\//g, '-').replace(/^-/, '');
-        const accessGroupName = `${fn.name}-${context.stage}-nas-access-${mountPath}`;
+        const accessGroupName = buildNasAccessGroupName(fn.name, context.stage, nasItem.mount_path);
 
         logger.info(lang.__('CREATING_NAS_ACCESS_GROUP', { accessGroupName }));
         const accessGroup = await client.nas.createAccessGroup(accessGroupName);
@@ -1075,6 +1075,22 @@ export const readResource = async (context: Context, functionName: string) => {
   return await client.fc3.getFunction(functionName);
 };
 
+/** Rewrite mount-target instance ids recorded before the M4 repair recreated
+ * their targets, so the returned state (and later destroy) tracks the live
+ * domains. */
+const withRecreatedMountTargets = <T extends { type: string; id: string }>(
+  instances: Array<T>,
+  recreated: Record<string, string>,
+): Array<T> =>
+  instances.map((instance) => {
+    if (instance.type !== 'ALIYUN_NAS_MOUNT_TARGET') {
+      return instance;
+    }
+    const fileSystemId = instance.id.split('/')[0];
+    const liveDomain = recreated[fileSystemId];
+    return liveDomain ? { ...instance, id: `${fileSystemId}/${liveDomain}` } : instance;
+  });
+
 export const updateResource = async (
   context: Context,
   fn: FunctionDomain,
@@ -1111,6 +1127,11 @@ export const updateResource = async (
         }>;
       }
     | undefined;
+
+  // File system id -> live mount target domain, captured by the M4 nested
+  // repair below; applied to the function config and the returned state so
+  // both track the target that actually exists after recreation.
+  const recreatedMountTargets: Record<string, string> = {};
 
   // SLS dependent-instance types to drop from the resulting state when
   // function logging is disabled (true -> false).
@@ -1465,18 +1486,19 @@ export const updateResource = async (
           failingFsId = fsEntry.id;
           const liveTargets = await client.nas.listMountTargets(fsEntry.id);
           if (!liveTargets || liveTargets.length === 0) {
-            // Same derivation as the create path — a raw mount path would bind
-            // the recreated target to an access group that was never created.
-            const mountPath = (nasStorageItems[0]?.mount_path ?? '/mnt/nas')
-              .replace(/\//g, '-')
-              .replace(/^-/, '');
-            const accessGroupName = `${fn.name}-${context.stage}-nas-access-${mountPath}`;
-            await client.nas.createMountTarget(
+            const mountTarget = await client.nas.createMountTarget(
               fsEntry.id,
-              accessGroupName,
+              buildNasAccessGroupName(
+                fn.name,
+                context.stage,
+                nasStorageItems[0]?.mount_path ?? '/mnt/nas',
+              ),
               fn.network.vpc_id,
               fn.network.subnet_ids[0],
             );
+            if (mountTarget?.mountTargetDomain) {
+              recreatedMountTargets[fsEntry.id] = mountTarget.mountTargetDomain;
+            }
             logger.warn(lang.__('NESTED_MOUNT_TARGET_RECREATED', { fileSystemId: fsEntry.id }));
           }
         }
@@ -1489,10 +1511,16 @@ export const updateResource = async (
 
     if (mountTargetInstances.length > 0 && nasStorageItems.length > 0) {
       nasConfig = {
-        mountPoints: mountTargetInstances.map((mt, idx) => ({
-          serverAddr: `${mt.id.split('/')[1]}:/`,
-          mountDir: nasStorageItems[idx]?.mount_path ?? '/mnt/nas',
-        })),
+        mountPoints: mountTargetInstances.map((mt, idx) => {
+          const [fileSystemId, recordedDomain] = mt.id.split('/');
+          // Mount the target that now exists — a just-recreated domain replaces
+          // the stale one recorded in state.
+          const liveDomain = recreatedMountTargets[fileSystemId] ?? recordedDomain;
+          return {
+            serverAddr: `${liveDomain}:/`,
+            mountDir: nasStorageItems[idx]?.mount_path ?? '/mnt/nas',
+          };
+        }),
       };
     }
   }
@@ -1800,7 +1828,7 @@ export const updateResource = async (
     instances: [
       fcInstance,
       ...lifecycleInstances,
-      ...existingDependentInstances,
+      ...withRecreatedMountTargets(existingDependentInstances, recreatedMountTargets),
       ...newDependentInstancesMapped,
     ],
     lastUpdated: new Date().toISOString(),

--- a/src/stack/aliyunStack/fc3Resource.ts
+++ b/src/stack/aliyunStack/fc3Resource.ts
@@ -1465,7 +1465,11 @@ export const updateResource = async (
           failingFsId = fsEntry.id;
           const liveTargets = await client.nas.listMountTargets(fsEntry.id);
           if (!liveTargets || liveTargets.length === 0) {
-            const mountPath = nasStorageItems[0]?.mount_path ?? '/mnt/nas';
+            // Same derivation as the create path — a raw mount path would bind
+            // the recreated target to an access group that was never created.
+            const mountPath = (nasStorageItems[0]?.mount_path ?? '/mnt/nas')
+              .replace(/\//g, '-')
+              .replace(/^-/, '');
             const accessGroupName = `${fn.name}-${context.stage}-nas-access-${mountPath}`;
             await client.nas.createMountTarget(
               fsEntry.id,

--- a/tests/fixtures/serverless-insight-aliyun-nested.yml
+++ b/tests/fixtures/serverless-insight-aliyun-nested.yml
@@ -1,0 +1,35 @@
+version: 0.0.1
+app: nested-drift-app
+provider:
+  name: aliyun
+  region: cn-hangzhou
+
+service: nested-drift-service
+
+backend:
+  state_manager:
+    type: LOCAL
+
+functions:
+  nested_fn:
+    name: nested-drift-fn
+    code:
+      runtime: nodejs18
+      handler: index.handler
+      path: tests/fixtures/artifacts/artifact.zip
+    memory: 128
+    timeout: 10
+    network:
+      vpc_id: vpc-123
+      subnet_ids:
+        - vsw-123
+      security_group:
+        name: nested-drift-sg
+        ingress:
+          - tcp:0.0.0.0/0:8080
+        egress:
+          - tcp:0.0.0.0/0:443
+    storage:
+      nas:
+        - mount_path: /mnt/data
+          storage_class: STANDARD_PERFORMANCE

--- a/tests/fixtures/serverless-insight-tencent-log.yml
+++ b/tests/fixtures/serverless-insight-tencent-log.yml
@@ -1,0 +1,29 @@
+version: 0.0.1
+app: insight-poc-app-log
+provider:
+  name: tencent
+  region: ap-guangzhou
+
+vars:
+  region: ap-guangzhou
+
+stages:
+  default:
+    region: ${vars.region}
+
+backend:
+  state_manager:
+    type: LOCAL
+
+service: insight-poc-tencent-log
+
+functions:
+  log_fn:
+    name: test-log-fn
+    code:
+      runtime: nodejs18
+      handler: index.handler
+      path: tests/fixtures/artifacts/artifact.zip
+    memory: 512
+    timeout: 10
+    log: true

--- a/tests/fixtures/serverless-insight-volcengine-nested.yml
+++ b/tests/fixtures/serverless-insight-volcengine-nested.yml
@@ -1,0 +1,24 @@
+version: 0.0.1
+app: insight-volc-nested-app
+provider:
+  name: volcengine
+  region: cn-beijing
+
+service: insight-volc-nested
+
+backend:
+  state_manager:
+    type: LOCAL
+
+functions:
+  insight_poc_fn:
+    name: insight-poc-fn
+    code:
+      runtime: node20/v1
+      handler: index.handler
+      path: tests/fixtures/artifacts/artifact.zip
+    memory: 128
+    timeout: 30
+    environment:
+      NODE_ENV: production
+    log: true

--- a/tests/service/mockCloudClient.ts
+++ b/tests/service/mockCloudClient.ts
@@ -75,6 +75,8 @@ export type MockAliyunClient = {
     deleteMountTarget: jest.Mock;
     createAccessGroup: jest.Mock;
     deleteAccessGroup: jest.Mock;
+    createAccessRule: jest.Mock;
+    listMountTargets: jest.Mock;
   };
   rds: {
     createDBInstance: jest.Mock;
@@ -86,6 +88,9 @@ export type MockAliyunClient = {
     describeSecurityGroups: jest.Mock;
     deleteSecurityGroup: jest.Mock;
     getSecurityGroupByName: jest.Mock;
+    getSecurityGroupRules: jest.Mock;
+    authorizeSecurityGroupRules: jest.Mock;
+    revokeSecurityGroupRules: jest.Mock;
   };
   sls: {
     createProject: jest.Mock;
@@ -267,6 +272,11 @@ export const createMockAliyunClient = (): MockAliyunClient => {
       deleteMountTarget: jest.fn().mockResolvedValue({}),
       createAccessGroup: jest.fn().mockResolvedValue({}),
       deleteAccessGroup: jest.fn().mockResolvedValue({}),
+      createAccessRule: jest.fn().mockResolvedValue({}),
+      // Healthy echo: the mount target created during deploy (issue #234 M4).
+      listMountTargets: jest
+        .fn()
+        .mockResolvedValue([{ mountTargetDomain: 'fs-123.cn-hangzhou.nas.aliyuncs.com' }]),
     },
     rds: {
       createDBInstance: jest.fn().mockResolvedValue({ body: { DBInstanceId: 'rds-123' } }),
@@ -286,6 +296,10 @@ export const createMockAliyunClient = (): MockAliyunClient => {
         .mockResolvedValue({ body: { SecurityGroups: { SecurityGroup: [] } } }),
       deleteSecurityGroup: jest.fn().mockResolvedValue({}),
       getSecurityGroupByName: jest.fn().mockResolvedValue({ securityGroupId: 'sg-123' }),
+      // Healthy echo: the desired rule set from the function config (issue #234 M2).
+      getSecurityGroupRules: jest.fn().mockResolvedValue({ ingressRules: [], egressRules: [] }),
+      authorizeSecurityGroupRules: jest.fn().mockResolvedValue(undefined),
+      revokeSecurityGroupRules: jest.fn().mockResolvedValue(undefined),
     },
     sls: {
       createProject: jest.fn().mockResolvedValue({ projectName: 'test-project' }),
@@ -454,6 +468,7 @@ export type MockVolcengineClient = {
     deleteProject: jest.Mock;
     createTopic: jest.Mock;
     getTopic: jest.Mock;
+    modifyTopic: jest.Mock;
     deleteTopic: jest.Mock;
     createIndex: jest.Mock;
     deleteIndex: jest.Mock;
@@ -565,6 +580,7 @@ export const createMockVolcengineClient = (): MockVolcengineClient => ({
       topicName: 'test-topic',
       status: 'Running',
     }),
+    modifyTopic: jest.fn().mockResolvedValue(undefined),
     deleteTopic: jest.fn().mockResolvedValue(undefined),
     createIndex: jest.fn().mockResolvedValue(undefined),
     deleteIndex: jest.fn().mockResolvedValue(undefined),

--- a/tests/service/nested-drift-repair.spec.test.ts
+++ b/tests/service/nested-drift-repair.spec.test.ts
@@ -1,0 +1,394 @@
+import path from 'node:path';
+import fs from 'node:fs/promises';
+import { deploy } from '../../src/commands/deploy';
+import {
+  createMockAliyunClient,
+  createMockVolcengineClient,
+  type MockAliyunClient,
+  type MockVolcengineClient,
+} from './mockCloudClient';
+
+jest.mock('../../src/common/aliyunClient', () => ({
+  createAliyunClient: jest.fn(),
+}));
+
+jest.mock('../../src/common/tencentClient', () => ({
+  createTencentClient: jest.fn(),
+}));
+
+jest.mock('../../src/common/volcengineClient', () => ({
+  createVolcengineClient: jest.fn(),
+}));
+
+jest.mock('../../src/common/imsClient', () => ({
+  getIamInfo: jest.fn().mockResolvedValue({
+    accountId: '123456789012',
+    displayName: 'Test User',
+    userId: 'test-user-id',
+  }),
+}));
+
+jest.mock('../../src/common/logger', () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+jest.mock('../../src/lang', () => ({
+  lang: {
+    __: (key: string) => key,
+  },
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const mockCreateAliyunClient = require('../../src/common/aliyunClient')
+  .createAliyunClient as jest.Mock;
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const mockCreateTencentClient = require('../../src/common/tencentClient')
+  .createTencentClient as jest.Mock;
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const mockCreateVolcengineClient = require('../../src/common/volcengineClient')
+  .createVolcengineClient as jest.Mock;
+
+const stateFilePathFor = (app: string, service: string): string =>
+  path.join(process.cwd(), '.serverlessinsight', `state-${app}-${service}.json`);
+
+const NESTED_STATE_FILE = stateFilePathFor('nested-drift-app', 'nested-drift-service');
+const TENCENT_LOG_STATE_FILE = stateFilePathFor('insight-poc-app-log', 'insight-poc-tencent-log');
+const VOLC_LOG_STATE_FILE = stateFilePathFor('insight-volc-app', 'insight-volc');
+
+// Healthy live SG rule echo: the exact canonical tuples si's create writes
+// (issue #234 M2). Single ports appear in Aliyun wire format `n/n`.
+const healthySecurityGroupRules = (): {
+  ingressRules: Array<{
+    ipProtocol: string;
+    portRange: string;
+    sourceCidrIp?: string;
+    destCidrIp?: string;
+  }>;
+  egressRules: Array<{ ipProtocol: string; portRange: string; destCidrIp?: string }>;
+} => ({
+  ingressRules: [{ ipProtocol: 'TCP', portRange: '8080/8080', sourceCidrIp: '0.0.0.0/0' }],
+  egressRules: [{ ipProtocol: 'TCP', portRange: '443/443', destCidrIp: '0.0.0.0/0' }],
+});
+
+const MOUNT_TARGET_DOMAIN = 'fs-123.cn-hangzhou.nas.aliyuncs.com';
+
+describe('Nested drift repair deploy flows (issue #234 M2-M5)', () => {
+  describe('aliyun FC3 security-group rules and NAS mount target (M2 + M4)', () => {
+    const deployOptions = {
+      location: path.join(__dirname, '../fixtures/serverless-insight-aliyun-nested.yml'),
+      stage: 'dev',
+      autoApprove: true,
+      region: 'cn-hangzhou',
+      provider: 'aliyun',
+    };
+    let mockClient: MockAliyunClient;
+
+    beforeEach(async () => {
+      jest.clearAllMocks();
+      mockClient = createMockAliyunClient();
+      // Operation-shaped overrides: the generic SDK-shaped defaults above don't
+      // match what the executor reads back (issue #234 M2/M4 flows).
+      mockClient.ecs.createSecurityGroup.mockResolvedValue({
+        securityGroupId: 'sg-123',
+        securityGroupName: 'nested-drift-sg',
+      });
+      mockClient.nas.createFileSystem.mockResolvedValue({ fileSystemId: 'fs-123' });
+      mockClient.nas.createMountTarget.mockResolvedValue({
+        mountTargetDomain: MOUNT_TARGET_DOMAIN,
+      });
+      mockClient.nas.listMountTargets.mockResolvedValue([
+        { mountTargetDomain: MOUNT_TARGET_DOMAIN },
+      ]);
+      mockClient.ecs.getSecurityGroupRules.mockResolvedValue(healthySecurityGroupRules());
+      mockCreateAliyunClient.mockReturnValue(mockClient);
+      await fs.rm(NESTED_STATE_FILE, { force: true }).catch(() => {});
+    });
+
+    afterEach(async () => {
+      await fs.rm(NESTED_STATE_FILE, { force: true }).catch(() => {});
+    });
+
+    it('repairs drifted security-group rules on the next deploy (issue #234 M2)', async () => {
+      await deploy(deployOptions);
+      expect(mockClient.ecs.createSecurityGroup).toHaveBeenCalledTimes(1);
+
+      // Console drift: the desired ingress rule was revoked and an extra
+      // out-of-band rule appeared.
+      const tampered = healthySecurityGroupRules();
+      tampered.ingressRules = [
+        { ipProtocol: 'TCP', portRange: '22/22', sourceCidrIp: '0.0.0.0/0' },
+      ];
+      mockClient.ecs.getSecurityGroupRules.mockResolvedValue(tampered);
+      mockClient.ecs.authorizeSecurityGroupRules.mockClear();
+      mockClient.ecs.revokeSecurityGroupRules.mockClear();
+
+      await deploy(deployOptions);
+
+      expect(mockClient.ecs.authorizeSecurityGroupRules).toHaveBeenCalledWith(
+        'sg-123',
+        'ingress',
+        expect.arrayContaining([expect.objectContaining({ cidr: '0.0.0.0/0', portRange: '8080' })]),
+      );
+      expect(mockClient.ecs.revokeSecurityGroupRules).toHaveBeenCalledWith(
+        'sg-123',
+        'ingress',
+        expect.arrayContaining([expect.objectContaining({ portRange: '22/22' })]),
+      );
+
+      // Healthy again → noop (no further repair writes).
+      mockClient.ecs.getSecurityGroupRules.mockResolvedValue(healthySecurityGroupRules());
+      mockClient.ecs.authorizeSecurityGroupRules.mockClear();
+      mockClient.ecs.revokeSecurityGroupRules.mockClear();
+
+      await deploy(deployOptions);
+
+      expect(mockClient.ecs.authorizeSecurityGroupRules).not.toHaveBeenCalled();
+      expect(mockClient.ecs.revokeSecurityGroupRules).not.toHaveBeenCalled();
+    });
+
+    it('recreates a console-deleted NAS mount target on the next deploy (issue #234 M4)', async () => {
+      await deploy(deployOptions);
+      expect(mockClient.nas.createMountTarget).toHaveBeenCalledTimes(1);
+
+      // Console drift: the mount target was deleted out-of-band.
+      mockClient.nas.listMountTargets.mockResolvedValue([]);
+      mockClient.nas.createMountTarget.mockClear();
+
+      await deploy(deployOptions);
+
+      expect(mockClient.nas.createMountTarget).toHaveBeenCalledWith(
+        'fs-123',
+        'nested-drift-fn-dev-nas-access-mnt-data',
+        'vpc-123',
+        'vsw-123',
+      );
+
+      // Healthy again → noop (no further repair writes).
+      mockClient.nas.listMountTargets.mockResolvedValue([
+        { mountTargetDomain: MOUNT_TARGET_DOMAIN },
+      ]);
+      mockClient.nas.createMountTarget.mockClear();
+
+      await deploy(deployOptions);
+
+      expect(mockClient.nas.createMountTarget).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('tencent SCF CLS topic attributes (M3)', () => {
+    const deployOptions = {
+      location: path.join(__dirname, '../fixtures/serverless-insight-tencent-log.yml'),
+      stage: 'default',
+      autoApprove: true,
+      region: 'ap-guangzhou',
+      provider: 'tencent',
+    };
+
+    // Operation-shaped tencent mock with a stateful shared logset/topic, so
+    // repeated deploys see a realistic cloud (create → reuse → reconcile).
+    // The shared logset only exists after createLogset writes it — including
+    // the ownership tag the ensure flow verifies on later deploys.
+    const buildTencentClient = () => {
+      let logset: {
+        LogsetId: string;
+        LogsetName: string;
+        Tags: Array<{ Key: string; Value: string }>;
+      } | null = null;
+      let topic: Record<string, unknown> | null = null;
+      // Echo contract: GetFunction returns the created function only after
+      // CreateFunction — the planner probe (pre-create) and the executor's
+      // post-create state refresh observe different worlds, like the real API.
+      let remoteFn: Record<string, unknown> | null = null;
+      return {
+        scf: {
+          createFunction: jest.fn().mockImplementation(async () => {
+            remoteFn = {
+              FunctionName: 'test-log-fn',
+              Runtime: 'Nodejs18.15',
+              Handler: 'index.handler',
+              MemorySize: 512,
+              Timeout: 10,
+              Status: 'Active',
+              Environment: { Variables: [] },
+              Tags: [],
+            };
+            return { FunctionName: 'test-log-fn' };
+          }),
+          getFunction: jest.fn().mockImplementation(async () => remoteFn),
+          updateFunctionConfiguration: jest.fn().mockResolvedValue({}),
+          updateFunctionCode: jest.fn().mockResolvedValue({}),
+          deleteFunction: jest.fn().mockResolvedValue({}),
+          createTrigger: jest.fn().mockResolvedValue({}),
+          deleteTrigger: jest.fn().mockResolvedValue({}),
+          createCustomDomain: jest.fn().mockResolvedValue({}),
+          getCustomDomain: jest.fn().mockResolvedValue(null),
+          deleteCustomDomain: jest.fn().mockResolvedValue({}),
+        },
+        cls: {
+          getLogsetByName: jest.fn().mockImplementation(async () => logset),
+          getLogsetNameById: jest.fn().mockResolvedValue('insight-poc-app-log-default-tls'),
+          listTopicsByLogset: jest.fn().mockResolvedValue([]),
+          getTopicByName: jest.fn().mockImplementation(async () => topic),
+          getTopicById: jest.fn().mockImplementation(async () => topic),
+          createLogset: jest.fn().mockImplementation(async (logsetName: string, tags) => {
+            logset = {
+              LogsetId: 'logset-1',
+              LogsetName: logsetName,
+              Tags: (tags ?? []).map((t: { key: string; value: string }) => ({
+                Key: t.key,
+                Value: t.value,
+              })),
+            };
+            return { logsetId: 'logset-1' };
+          }),
+          createTopic: jest
+            .fn()
+            .mockImplementation(
+              async (
+                _logsetId: string,
+                topicName: string,
+                opts?: { tags?: Array<{ key: string; value: string }> },
+              ) => {
+                topic = {
+                  TopicId: 'topic-1',
+                  TopicName: topicName,
+                  StorageType: 'hot',
+                  Period: 30,
+                  // The real CreateTopic persists the ownership tags the ensure
+                  // flow verifies on later deploys.
+                  Tags: (opts?.tags ?? []).map((t) => ({ Key: t.key, Value: t.value })),
+                };
+                return { topicId: 'topic-1' };
+              },
+            ),
+          modifyTopic: jest
+            .fn()
+            .mockImplementation(
+              async (_topicId: string, attrs: { period?: number; storageType?: string }) => {
+                topic = { ...topic, Period: attrs.period, StorageType: attrs.storageType };
+                return undefined;
+              },
+            ),
+          createFulltextIndex: jest.fn().mockResolvedValue(undefined),
+          waitForTopic: jest.fn().mockResolvedValue(undefined),
+          deleteTopic: jest.fn().mockResolvedValue(undefined),
+          deleteLogset: jest.fn().mockResolvedValue(undefined),
+          deleteIndex: jest.fn().mockResolvedValue(undefined),
+        },
+      };
+    };
+
+    type TencentLogClient = ReturnType<typeof buildTencentClient>;
+    let client: TencentLogClient;
+
+    beforeEach(async () => {
+      jest.clearAllMocks();
+      client = buildTencentClient();
+      mockCreateTencentClient.mockReturnValue(client);
+      await fs.rm(TENCENT_LOG_STATE_FILE, { force: true }).catch(() => {});
+    });
+
+    afterEach(async () => {
+      await fs.rm(TENCENT_LOG_STATE_FILE, { force: true }).catch(() => {});
+    });
+
+    it('repairs drifted CLS topic attributes on the next deploy (issue #234 M3)', async () => {
+      await deploy(deployOptions);
+      expect(client.cls.createTopic).toHaveBeenCalledTimes(1);
+
+      // Console drift: the topic switched to cold storage with a 1-day period.
+      client.cls.getTopicById.mockResolvedValue({
+        TopicId: 'topic-1',
+        StorageType: 'cold',
+        Period: 1,
+      });
+      client.cls.modifyTopic.mockClear();
+
+      await deploy(deployOptions);
+
+      expect(client.cls.modifyTopic).toHaveBeenCalledWith('topic-1', {
+        period: 30,
+        storageType: 'hot',
+      });
+
+      // Healthy again → noop (no further repair writes).
+      client.cls.getTopicById.mockResolvedValue({
+        TopicId: 'topic-1',
+        StorageType: 'hot',
+        Period: 30,
+      });
+      client.cls.modifyTopic.mockClear();
+
+      await deploy(deployOptions);
+
+      expect(client.cls.modifyTopic).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('volcengine veFaaS TLS topic ttl (M5)', () => {
+    const deployOptions = {
+      location: path.join(__dirname, '../fixtures/serverless-insight-volcengine-log.yml'),
+      stage: 'dev',
+      autoApprove: true,
+      region: 'cn-beijing',
+      provider: 'volcengine',
+    };
+    let mockClient: MockVolcengineClient;
+
+    const healthyTopic = (): Record<string, unknown> => ({
+      topicId: 'topic-123',
+      topicName: 'insight-volc-dev-insight_poc_fn-fn-logs',
+      status: 'Running',
+      ttl: 30,
+    });
+
+    beforeEach(async () => {
+      jest.clearAllMocks();
+      mockClient = createMockVolcengineClient();
+      mockCreateVolcengineClient.mockReturnValue(mockClient);
+      await fs.rm(VOLC_LOG_STATE_FILE, { force: true }).catch(() => {});
+    });
+
+    afterEach(async () => {
+      await fs.rm(VOLC_LOG_STATE_FILE, { force: true }).catch(() => {});
+    });
+
+    it('repairs a drifted TLS topic ttl on the next deploy (issue #234 M5)', async () => {
+      // First deploy: nothing remote yet → create.
+      mockClient.vefaas.getFunction.mockResolvedValue(null);
+      mockClient.tls.getTopic.mockResolvedValue(null);
+      await deploy(deployOptions);
+      expect(mockClient.tls.createTopic).toHaveBeenCalledTimes(1);
+
+      // Console drift: the topic ttl was shrunk out-of-band.
+      mockClient.vefaas.getFunction.mockResolvedValue({
+        functionId: 'func-123',
+        functionName: 'insight-poc-fn',
+        runtime: 'node20/v1',
+        handler: 'index.handler',
+        memoryMb: 128,
+        requestTimeout: 30,
+        status: 'Active',
+      });
+      mockClient.tls.getTopic.mockResolvedValue({ ...healthyTopic(), ttl: 1 });
+      mockClient.tls.modifyTopic.mockClear();
+
+      await deploy(deployOptions);
+
+      expect(mockClient.tls.modifyTopic).toHaveBeenCalledWith('topic-123', 30);
+
+      // Healthy again → noop (no further repair writes).
+      mockClient.tls.getTopic.mockResolvedValue(healthyTopic());
+      mockClient.tls.modifyTopic.mockClear();
+
+      await deploy(deployOptions);
+
+      expect(mockClient.tls.modifyTopic).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/service/nested-drift-repair.spec.test.ts
+++ b/tests/service/nested-drift-repair.spec.test.ts
@@ -76,6 +76,7 @@ const healthySecurityGroupRules = (): {
 });
 
 const MOUNT_TARGET_DOMAIN = 'fs-123.cn-hangzhou.nas.aliyuncs.com';
+const REPAIRED_MOUNT_TARGET_DOMAIN = 'fs-123.repaired.cn-hangzhou.nas.aliyuncs.com';
 
 describe('Nested drift repair deploy flows (issue #234 M2-M5)', () => {
   describe('aliyun FC3 security-group rules and NAS mount target (M2 + M4)', () => {
@@ -155,8 +156,12 @@ describe('Nested drift repair deploy flows (issue #234 M2-M5)', () => {
       await deploy(deployOptions);
       expect(mockClient.nas.createMountTarget).toHaveBeenCalledTimes(1);
 
-      // Console drift: the mount target was deleted out-of-band.
+      // Console drift: the mount target was deleted out-of-band. The provider
+      // assigns a NEW domain to the recreated target.
       mockClient.nas.listMountTargets.mockResolvedValue([]);
+      mockClient.nas.createMountTarget.mockResolvedValue({
+        mountTargetDomain: REPAIRED_MOUNT_TARGET_DOMAIN,
+      });
       mockClient.nas.createMountTarget.mockClear();
 
       await deploy(deployOptions);
@@ -168,15 +173,53 @@ describe('Nested drift repair deploy flows (issue #234 M2-M5)', () => {
         'vsw-123',
       );
 
-      // Healthy again → noop (no further repair writes).
+      // The function mounts the recreated target, not the stale recorded one.
+      expect(mockClient.fc3.updateFunctionConfiguration).toHaveBeenCalledWith(
+        expect.objectContaining({
+          nasConfig: {
+            userId: -1,
+            groupId: -1,
+            mountPoints: [
+              { serverAddr: `${REPAIRED_MOUNT_TARGET_DOMAIN}:/`, mountDir: '/mnt/data' },
+            ],
+          },
+        }),
+      );
+
+      // The recreated target replaces the stale instance in state, so later
+      // deploys and destroy track the target that actually exists.
+      const savedState = JSON.parse(await fs.readFile(NESTED_STATE_FILE, 'utf-8')) as {
+        stages: Record<
+          string,
+          { resources: Record<string, { instances: Array<{ type: string; id: string }> }> }
+        >;
+      };
+      const mountTargetInstance = savedState.stages.dev.resources[
+        'functions.nested_fn'
+      ].instances.find((i) => i.type === 'ALIYUN_NAS_MOUNT_TARGET');
+      expect(mountTargetInstance?.id).toBe(`fs-123/${REPAIRED_MOUNT_TARGET_DOMAIN}`);
+
+      // Healthy again (the repaired target exists) → no repair writes. The
+      // planner may still force a config push (unrelated probes flag drift in
+      // this mock environment), but it must converge on the repaired domain —
+      // never reverting to the stale deleted one.
       mockClient.nas.listMountTargets.mockResolvedValue([
-        { mountTargetDomain: MOUNT_TARGET_DOMAIN },
+        { mountTargetDomain: REPAIRED_MOUNT_TARGET_DOMAIN },
       ]);
       mockClient.nas.createMountTarget.mockClear();
+      mockClient.fc3.updateFunctionConfiguration.mockClear();
 
       await deploy(deployOptions);
 
       expect(mockClient.nas.createMountTarget).not.toHaveBeenCalled();
+      const healthyConfigCalls = mockClient.fc3.updateFunctionConfiguration.mock.calls as Array<
+        Array<{ nasConfig?: { mountPoints?: Array<{ serverAddr?: string }> } }>
+      >;
+      for (const [config] of healthyConfigCalls) {
+        expect(config.nasConfig?.mountPoints?.[0]?.serverAddr).toBe(
+          `${REPAIRED_MOUNT_TARGET_DOMAIN}:/`,
+        );
+      }
     });
   });
 

--- a/tests/service/nested-drift-repair.spec.test.ts
+++ b/tests/service/nested-drift-repair.spec.test.ts
@@ -58,7 +58,10 @@ const stateFilePathFor = (app: string, service: string): string =>
 
 const NESTED_STATE_FILE = stateFilePathFor('nested-drift-app', 'nested-drift-service');
 const TENCENT_LOG_STATE_FILE = stateFilePathFor('insight-poc-app-log', 'insight-poc-tencent-log');
-const VOLC_LOG_STATE_FILE = stateFilePathFor('insight-volc-app', 'insight-volc');
+// Dedicated app/service identity: the state file must not be shared with other
+// volcengine suites — jest runs suites in parallel workers and a shared file
+// makes deploys observe each other's state mid-flight.
+const VOLC_LOG_STATE_FILE = stateFilePathFor('insight-volc-nested-app', 'insight-volc-nested');
 
 // Healthy live SG rule echo: the exact canonical tuples si's create writes
 // (issue #234 M2). Single ports appear in Aliyun wire format `n/n`.
@@ -375,7 +378,7 @@ describe('Nested drift repair deploy flows (issue #234 M2-M5)', () => {
 
   describe('volcengine veFaaS TLS topic ttl (M5)', () => {
     const deployOptions = {
-      location: path.join(__dirname, '../fixtures/serverless-insight-volcengine-log.yml'),
+      location: path.join(__dirname, '../fixtures/serverless-insight-volcengine-nested.yml'),
       stage: 'dev',
       autoApprove: true,
       region: 'cn-beijing',
@@ -385,7 +388,7 @@ describe('Nested drift repair deploy flows (issue #234 M2-M5)', () => {
 
     const healthyTopic = (): Record<string, unknown> => ({
       topicId: 'topic-123',
-      topicName: 'insight-volc-dev-insight_poc_fn-fn-logs',
+      topicName: 'insight-volc-nested-dev-insight_poc_fn-fn-logs',
       status: 'Running',
       ttl: 30,
     });

--- a/tests/unit/common/nameBuilder.test.ts
+++ b/tests/unit/common/nameBuilder.test.ts
@@ -1,4 +1,8 @@
-import { buildConstrainedName, CONSTRAINT_NAME_LIMITS } from '../../../src/common/nameBuilder';
+import {
+  buildConstrainedName,
+  buildNasAccessGroupName,
+  CONSTRAINT_NAME_LIMITS,
+} from '../../../src/common/nameBuilder';
 import { buildAliyunApigwApiName, generateApiKey } from '../../../src/common/providerNames';
 
 describe('buildConstrainedName', () => {
@@ -115,5 +119,29 @@ describe('providerNames', () => {
       expect(name.length).toBeLessThanOrEqual(CONSTRAINT_NAME_LIMITS.ALIYUN_CREATE_API_NAME);
       expect(name).toMatch(/^[A-Za-z0-9_]+$/);
     });
+  });
+});
+
+describe('buildNasAccessGroupName', () => {
+  it('derives the same group name the create path always produced', () => {
+    expect(buildNasAccessGroupName('test-function', 'default', '/mnt/data')).toBe(
+      'test-function-default-nas-access-mnt-data',
+    );
+  });
+
+  it('flattens deeply nested mount paths and trims the leading dash', () => {
+    expect(buildNasAccessGroupName('fn', 'dev', '/mnt/nas/data/v2')).toBe(
+      'fn-dev-nas-access-mnt-nas-data-v2',
+    );
+  });
+
+  it('keeps an already-flat path verbatim', () => {
+    expect(buildNasAccessGroupName('fn', 'dev', 'mnt')).toBe('fn-dev-nas-access-mnt');
+  });
+
+  it('is stable for repeated derivations (create vs repair)', () => {
+    const first = buildNasAccessGroupName('svc-fn', 'prod', '/data');
+    const second = buildNasAccessGroupName('svc-fn', 'prod', '/data');
+    expect(first).toBe(second);
   });
 });

--- a/tests/unit/stack/aliyunStack/fc3Resource.test.ts
+++ b/tests/unit/stack/aliyunStack/fc3Resource.test.ts
@@ -1177,7 +1177,7 @@ describe('Fc3Resource', () => {
 
       expect(mockedNasOperations.createMountTarget).toHaveBeenCalledWith(
         'fs-1',
-        'test-function-default-nas-access-/mnt/data',
+        'test-function-default-nas-access-mnt-data',
         'vpc-123',
         'vsw-123',
       );


### PR DESCRIPTION
## Summary

Closes the last acceptance gap of the #234 epic: the M1–M5 nested-repair milestones each required a three-stage service test (create → console tamper → deploy repair → noop), but only M1 had one. This PR adds the missing four, fixes two real repair-path defects the new M4 test caught, and hardens test isolation after review.

## Fixes

**`fix(aliyun): bind recreated NAS mount target to the normalized access group name`** — the M4 nested-repair path in `fc3Resource.ts` derived the access group name from the **raw** mount path (`/mnt/data`), while the create path normalizes slashes (`mnt-data`). A console-deleted mount target was therefore rebound to an access group that was never created — the repair could never succeed on a real provider. The pre-existing unit test had baked in the wrong expectation; both are corrected.

**`fix(aliyun): persist recreated NAS mount target via shared name builder`** — two follow-ups to the same repair path:
- The access-group template now lives in exactly one place: `buildNasAccessGroupName` in `src/common/nameBuilder.ts`. Both the create and repair paths derive through it — the raw-path bug above *was* that drift, so it can't recur. Deliberately not routed through `buildConstrainedName` so existing deployments keep byte-identical names (stored-first on rename).
- The repair previously discarded the recreated target's new `mountTargetDomain`: the function kept mounting the stale (deleted) domain and state kept the dead instance id. The repair now applies the live domain to the function's `nasConfig` and rewrites the `ALIYUN_NAS_MOUNT_TARGET` state instance (`withRecreatedMountTargets`), so later deploys and destroy track the target that actually exists.

**`test(service): isolate volcengine nested-repair suite from sibling state file`** — the M5 suite shared `state-insight-volc-app-insight-volc.json` with the volcengine deploy-flow and plan-drift suites; jest runs suites in parallel workers, so concurrent deploys observed each other's state mid-flight and intermittently tripped the TOS ownership check ("Bucket … not owned by this stack") in full runs. The suite now uses a dedicated fixture identity (`insight-volc-nested-app` / `insight-volc-nested`), mirroring the aliyun-nested and tencent-log fixtures.

## Tests (`nested-drift-repair.spec.test.ts`)

Each milestone follows the three-stage structure: create → console tamper → deploy repair → healthy → noop (asserting zero repair writes on a healthy cloud).

- **M2 aliyun**: tampered `DescribeSecurityGroupAttribute` rules → missing desired ingress re-authorized (`authorizeSecurityGroupRules`), extra out-of-band rule revoked (`revokeSecurityGroupRules`); healthy → no repair writes
- **M3 tencent**: CLS topic switched to cold storage / 1-day period → reconciled via `ModifyTopic` back to `hot`/30; healthy → no repair writes
- **M4 aliyun**: mount target deleted out-of-band (`listMountTargets` → `[]`) → recreated bound to the normalized access group; the pushed function config mounts the **new** provider-assigned domain and the state instance id is rewritten to it (destroy and later deploys track the live target); healthy → no repair writes, and any forced config push converges on the repaired domain — never reverting to the deleted one
- **M5 volcengine**: TLS topic ttl shrunk to 1 → reconciled via `ModifyTopic` to 30; healthy → no repair writes

Supporting changes: shared mock clients extended with the probe/repair operations (`ecs.getSecurityGroupRules` / `authorizeSecurityGroupRules` / `revokeSecurityGroupRules`, `nas.createAccessRule` / `listMountTargets`, `tls.modifyTopic`), plus three new fixtures (aliyun function with `network` + `storage.nas`; tencent log-enabled function; volcengine log-enabled function with a dedicated app scope). New unit tests cover `buildNasAccessGroupName` (`tests/unit/common/nameBuilder.test.ts`).

## Verification

- Full suite: **166 suites / 3505 tests green**, coverage gate green (96.6% stmts / 86.4% branch / 97.3% funcs / 97% lines vs the 85% threshold); `tsc` and lint clean
- Note: the `localStack` unit suites are timing-sensitive and intermittently fail on unmodified master as well (observed on both branches); they pass in some runs, including the final full run on this branch

## Context

Epic status audit: Phases 0–3 and M1–M5 all landed on master; #239 fixed via #244; #238 wontfix (binary refresh model kept). Epic body updated accordingly.
