### PR TITLE
feat(plan): live-state diff baseline with field-level Add/Modify/Remove display (issue #246)

### DIFF
--- a/docs/adr/002-resource-import-and-refresh.md
+++ b/docs/adr/002-resource-import-and-refresh.md
@@ -407,3 +407,17 @@ A `si import --plan` mode that shows what would be imported without actually imp
 - [Terraform Refresh Documentation](https://developer.hashicorp.com/terraform/cli/commands/refresh)
 - [Terraform State Management](https://developer.hashicorp.com/terraform/language/state)
 - [ADR-001: SSL/HTTPS Certificate Management](./001-ssl-certificate-management.md)
+
+## Update (2026-09, issue #246): refresh 命令裁撤，两态模型
+
+本 ADR 原规划 Phase 3 交付独立 `si refresh` 命令（`src/commands/refresh.ts`）。#246 复核后裁决**裁撤**该命令，理由与替代设计如下：
+
+### 决策
+
+1. **两态模型**：用户心智中只有 `desired`（YAML 配置）与 `live`（云端现状）两个状态。state 文件降级为实现细节——`ResourceState.definition` 的语义重释为「上次同步的云端快照」（字段名不变，避免 state 文件迁移），不再是用户需要理解的概念。
+2. **读 live 是 diff 的隐式默认行为**：`si plan` / `si deploy` 每次都探测云端并以 live 为 diff 的 `before` 基线（`mergeLiveBefore`：live 值优先，cloud mapper 不产出的键由 stored 快照补齐）。漂移不再是独立"模式"——它就是 live 与 desired 的差异本身，漂移字段以 `revertKeys` 逐字段标注。
+3. **`si refresh` 命令不做**：config 是唯一事实源，"接受云端改动"的正确动作是修改 YAML 后重新 diff。原 `PlanAction 'refresh'` 预留已删除。原 Phase 3 的「读云端 → 写回 state」需求由 deploy 执行后的 state 回写天然覆盖。
+4. **`--no-refresh` 保留**：现命令名与语义（跳过云端探测、基于快照比较、不做漂移判断）自解释，供 CI 加速场景使用，不改名、不加额外离线声明。
+5. **plan 一次执行一次**：`si deploy` 将展示并确认的 plan 直传 deployer（按 resourceType 分区执行），消除展示与执行两次计算可能产生的偏差。
+
+实现落点：`src/common/planCompare.ts`（`mergeLiveBefore`/`computeRevertKeys`）、`src/common/refreshPlanner.ts`（live 基线）、`src/common/planFormatter.ts`（资源范式显示）、各 provider planner。

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -149,7 +149,9 @@ export const deploy = async (options: {
       'deploy',
       async () => {
         try {
-          await deployStack(iac, backend);
+          // Issue #246: execute exactly the plan that was displayed and
+          // approved above — no second plan computation mid-deploy.
+          await deployStack(iac, backend, { items: planResult.items });
         } catch (err) {
           // The deployment FAILED, but the console still needs the plan
           // (what we attempted) + the partial state (what succeeded) to render

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -193,6 +193,49 @@ program
     ),
   );
 
+// Issue #246: `diff` is the primary verb users say — it runs the same plan
+// flow; `plan` stays for compatibility.
+program
+  .command('diff')
+  .description('show changes between your config and the live cloud (alias of plan)')
+  .option('-f, --file <path>', 'specify the yaml file')
+  .option('-s, --stage <stage>', 'specify the stage')
+  .option('-r, --region <region>', 'specify the region')
+  .option('-v, --provider <provider>', 'specify the provider')
+  .option('-k, --accessKeyId <accessKeyId>', 'specify the AccessKeyId')
+  .option('-x, --accessKeySecret <accessKeySecret>', 'specify the AccessKeySecret')
+  .option('-n, --securityToken <securityToken>', 'specify the SecurityToken')
+  .option(
+    '--no-refresh',
+    'skip live cloud probing; diff config against state only (no drift detection)',
+  )
+  .action(
+    actionWrapper(
+      'diff',
+      async ({
+        stage,
+        file,
+        region,
+        provider,
+        accessKeyId,
+        accessKeySecret,
+        securityToken,
+        refresh,
+      }) => {
+        await plan({
+          stage,
+          location: file,
+          region,
+          provider,
+          accessKeyId,
+          accessKeySecret,
+          securityToken,
+          refresh,
+        });
+      },
+    ),
+  );
+
 program
   .command('deploy')
   .description('deploy serverless Iac yaml')

--- a/src/common/planCompare.ts
+++ b/src/common/planCompare.ts
@@ -89,8 +89,10 @@ export const computeRevertKeys = (
   live: Record<string, unknown>,
   desired: Record<string, unknown>,
 ): string[] => {
-  const allKeys = new Set([...Object.keys(live), ...Object.keys(desired)]);
-  return [...allKeys]
+  // Only keys the live read actually carries can claim a cloud-side edit —
+  // a desired-declared key the mapper never emits (codeHash, iam, ...) is an
+  // unreadable dimension, not a revert.
+  return Object.keys(live)
     .filter((key) => {
       const storedMatchesDesired = attributesEqual({ [key]: stored[key] }, { [key]: desired[key] });
       const liveMatchesDesired = attributesEqual({ [key]: live[key] }, { [key]: desired[key] });

--- a/src/common/planCompare.ts
+++ b/src/common/planCompare.ts
@@ -63,3 +63,38 @@ export const jsonDocumentDiffers = (desired: string | null, cloud: unknown): boo
     return false;
   }
 };
+
+/**
+ * Best-known "current live" display baseline (issue #246): the plan diff's
+ * `before` must always be cloud reality, not the stored intent. Live mapper
+ * output covers only the attributes the cloud API exposes, so stored
+ * definition keys the mapper never emits (codeHash, iam, ...) are carried
+ * over from the stored definition — live values win where readable, stored
+ * values fill the unreadable rest.
+ */
+export const mergeLiveBefore = (
+  stored: Record<string, unknown>,
+  live: Record<string, unknown>,
+): Record<string, unknown> => ({ ...stored, ...live });
+
+/**
+ * Field-level drift signature (issue #246): top-level keys where the stored
+ * definition already matches the desired one while the live value does not —
+ * i.e. the difference on that key is entirely a cloud-side edit the config
+ * never asked for. All three sides should be passed through the same
+ * normalization the display uses, so keys line up with the rendered diff.
+ */
+export const computeRevertKeys = (
+  stored: Record<string, unknown>,
+  live: Record<string, unknown>,
+  desired: Record<string, unknown>,
+): string[] => {
+  const allKeys = new Set([...Object.keys(live), ...Object.keys(desired)]);
+  return [...allKeys]
+    .filter((key) => {
+      const storedMatchesDesired = attributesEqual({ [key]: stored[key] }, { [key]: desired[key] });
+      const liveMatchesDesired = attributesEqual({ [key]: live[key] }, { [key]: desired[key] });
+      return storedMatchesDesired && !liveMatchesDesired;
+    })
+    .sort((a, b) => a.localeCompare(b));
+};

--- a/src/common/planFormatter.ts
+++ b/src/common/planFormatter.ts
@@ -29,8 +29,6 @@ const DEFAULT_CONFIG: PlanDisplayConfig = {
   colorize: true,
   indentSize: 4,
   keyAlignWidth: 12,
-  showUnchangedAttributes: false,
-  maxUnchangedHidden: 5,
 };
 
 const isObject = (val: unknown): boolean =>
@@ -174,9 +172,20 @@ const formatAttributeLines = (
   indent: number,
   config: PlanDisplayConfig,
   keyWidth: number,
+  revertKeys?: ReadonlySet<string>,
 ): string[] => {
   const spaces = ' '.repeat(indent);
   const alignedKey = (diff.key + ':').padEnd(keyWidth);
+  // Issue #246: a field whose stored value already matched the config while
+  // the cloud diverged is annotated at the line level — the resource block
+  // stays in place, only this line explains why it appears. Applies to every
+  // leaf action: a cloud-side key deletion shows up as add/remove too.
+  const suffix = (line: string): string =>
+    diff.children && diff.children.length > 0
+      ? line
+      : revertKeys?.has(diff.key)
+        ? `${line} ${colorize(lang.__('PLAN_REVERT_ANNOTATION'), 'CYAN', config.colorize)}`
+        : line;
 
   switch (diff.action) {
     case 'add': {
@@ -192,7 +201,7 @@ const formatAttributeLines = (
       const value = diff.isComputed
         ? colorize(lang.__('PLAN_COMPUTED_VALUE'), 'CYAN', config.colorize)
         : formatValue(diff.after);
-      return [colorize(`${spaces}${alignedKey} ${value}`, 'GREEN', config.colorize)];
+      return [suffix(colorize(`${spaces}${alignedKey} ${value}`, 'GREEN', config.colorize))];
     }
 
     case 'remove': {
@@ -206,7 +215,9 @@ const formatAttributeLines = (
         ];
       }
       return [
-        colorize(`${spaces}${alignedKey} ${formatValue(diff.before)}`, 'RED', config.colorize),
+        suffix(
+          colorize(`${spaces}${alignedKey} ${formatValue(diff.before)}`, 'RED', config.colorize),
+        ),
       ];
     }
 
@@ -223,7 +234,9 @@ const formatAttributeLines = (
       const beforeStr = formatValue(diff.before);
       const afterStr = formatValue(diff.after);
       return [
-        colorize(`${spaces}${alignedKey} ${beforeStr} -> ${afterStr}`, 'YELLOW', config.colorize),
+        suffix(
+          colorize(`${spaces}${alignedKey} ${beforeStr} -> ${afterStr}`, 'YELLOW', config.colorize),
+        ),
       ];
     }
   }
@@ -234,60 +247,76 @@ const ACTION_DESC: Record<string, string> = {
   update: 'PLAN_WILL_UPDATE',
   delete: 'PLAN_WILL_DESTROY',
   noop: 'PLAN_NO_CHANGES',
-  refresh: 'PLAN_WILL_REFRESH',
 };
 
 const ACTION_SYMBOL: Record<string, string> = {
   create: '+',
   update: '~',
   delete: '-',
-  refresh: '↻',
 };
 
 const ACTION_COLOR: Record<string, keyof typeof COLOR> = {
   create: 'GREEN',
   update: 'YELLOW',
   delete: 'RED',
-  refresh: 'CYAN',
 };
+
+/**
+ * A create plan for a resource that also has a recorded `before` is a
+ * recreation (the cloud copy disappeared or was tainted) — rendered as a
+ * single `-/+` block showing the old→new fields, never as two separate
+ * add/remove blocks (issue #246 resource-paradigm invariant).
+ */
+const isRecreate = (item: PlanItem): boolean => item.action === 'create' && !!item.changes?.before;
 
 /* istanbul ignore next */
 export const formatPlanItem = (
   item: PlanItem,
   config: PlanDisplayConfig = DEFAULT_CONFIG,
 ): string => {
-  const descKey = ACTION_DESC[item.action] ?? 'PLAN_NO_CHANGES';
-  const headerLine = `  # ${item.logicalId} ${lang.__(descKey as keyof typeof ACTION_DESC)}`;
-
   if (item.action === 'noop') {
-    return headerLine;
+    // Unchanged resources are not rendered as blocks — they only surface in
+    // the plan summary count (issue #246 display spec).
+    return '';
   }
 
-  const symbol = ACTION_SYMBOL[item.action] ?? ' ';
-  const symbolColor = ACTION_COLOR[item.action] ?? 'RESET';
+  const recreate = isRecreate(item);
+  const descKey = recreate ? 'PLAN_WILL_RECREATE' : (ACTION_DESC[item.action] ?? 'PLAN_NO_CHANGES');
+  const headerLine = `  # ${item.logicalId} ${lang.__(descKey as keyof typeof ACTION_DESC)}`;
+
+  const symbol = recreate ? '-/+' : (ACTION_SYMBOL[item.action] ?? ' ');
+  const symbolColor = recreate ? 'YELLOW' : (ACTION_COLOR[item.action] ?? 'RESET');
   const resourceLine = colorize(`  ${symbol} ${item.logicalId}:`, symbolColor, config.colorize);
 
-  // A drifted update is caused by an out-of-config cloud edit — surface that
-  // so it doesn't read like an ordinary config change.
-  const driftedLine =
-    item.drifted && item.action !== 'delete'
-      ? [colorize(`      # ${lang.__('PLAN_DRIFTED_MARKER')}`, 'CYAN', config.colorize)]
-      : [];
+  // Probe-level drift (role policy, logstore, ...) has no attribute-level
+  // diff to show — each reason becomes its own explanatory line.
+  const reasonLines = (item.driftReasons ?? []).map((reason) =>
+    colorize(`      # ${lang.__(reason as keyof typeof ACTION_DESC)}`, 'CYAN', config.colorize),
+  );
 
   if (!item.changes) {
-    return [headerLine, resourceLine, ...driftedLine].join('\n');
+    // No changes payload at all: the drift marker is the only explanation
+    // available (fallback — planners normally attach changes or reasons).
+    const driftedLine =
+      item.drifted && reasonLines.length === 0
+        ? [colorize(`      # ${lang.__('PLAN_DRIFTED_MARKER')}`, 'CYAN', config.colorize)]
+        : [];
+    return [headerLine, resourceLine, ...reasonLines, ...driftedLine].join('\n');
   }
 
   const { diffs, unchangedCount } = computeAttributeDiffs(item.changes.before, item.changes.after);
   const keyWidth = Math.max(config.keyAlignWidth, computeMaxKeyWidth(diffs, config.indentSize));
+  const revertKeys = new Set(item.revertKeys ?? []);
 
   const attrLines =
     diffs.length > 0
-      ? diffs.flatMap((diff) => formatAttributeLines(diff, config.indentSize, config, keyWidth))
+      ? diffs.flatMap((diff) =>
+          formatAttributeLines(diff, config.indentSize, config, keyWidth, revertKeys),
+        )
       : [];
 
   const hiddenLine =
-    unchangedCount > 0 && !config.showUnchangedAttributes
+    unchangedCount > 0
       ? [
           colorize(
             `      # ${lang.__('PLAN_UNCHANGED_ATTRS', { count: String(unchangedCount) })}`,
@@ -297,7 +326,17 @@ export const formatPlanItem = (
         ]
       : [];
 
-  return [headerLine, resourceLine, ...driftedLine, ...attrLines, ...hiddenLine].join('\n');
+  // Invariant backstop (issue #246): a drifted item must always explain
+  // itself — attribute lines, reasons, or as a last resort the generic
+  // marker. Planners attach at least one of these for every drifted item.
+  const driftedFallback =
+    item.drifted && attrLines.length === 0 && reasonLines.length === 0
+      ? [colorize(`      # ${lang.__('PLAN_DRIFTED_MARKER')}`, 'CYAN', config.colorize)]
+      : [];
+
+  return [headerLine, resourceLine, ...reasonLines, ...attrLines, ...hiddenLine, ...driftedFallback]
+    .filter((line) => line.length > 0)
+    .join('\n');
 };
 
 /* istanbul ignore next */
@@ -309,50 +348,33 @@ export const formatPlan = (
     return lang.__('NO_CHANGES_INFRASTRUCTURE_UP_TO_DATE');
   }
 
-  const createItems = items.filter((i) => i.action === 'create');
-  const updateItems = items.filter((i) => i.action === 'update');
-  const deleteItems = items.filter((i) => i.action === 'delete');
-  const refreshItems = items.filter((i) => i.action === 'refresh');
-  const noopItems = items.filter((i) => i.action === 'noop');
+  // Resource paradigm (issue #246): render blocks in the planner's domain
+  // order, one block per resource, never regrouped by action. Unchanged
+  // resources only surface in the summary count.
+  const unchangedCount = items.filter((i) => i.action === 'noop').length;
+  const itemLines = items
+    .filter((i) => i.action !== 'noop')
+    .flatMap((item) => {
+      const block = formatPlanItem(item, config);
+      return block ? [block, ''] : [];
+    });
 
-  const actionItems = [
-    ...createItems,
-    ...updateItems,
-    ...deleteItems,
-    ...refreshItems,
-    ...noopItems,
-  ];
+  const recreateCount = items.filter(isRecreate).length;
+  const addCount = items.filter((i) => i.action === 'create' && !isRecreate(i)).length;
+  const modifyCount = items.filter((i) => i.action === 'update').length;
+  const removeCount = items.filter((i) => i.action === 'delete').length;
 
-  const header = [
-    `${lang.__('PLAN_HEADER')}\n`,
-    colorize(lang.__('PLAN_LEGEND_CREATE'), 'GREEN', config.colorize),
-    colorize(lang.__('PLAN_LEGEND_UPDATE'), 'YELLOW', config.colorize),
-    colorize(lang.__('PLAN_LEGEND_DESTROY'), 'RED', config.colorize),
-    '',
-  ];
-
-  const itemLines = actionItems.flatMap((item) => [formatPlanItem(item, config), '']);
-
-  const driftedCount = items.filter((i) => i.drifted && i.action !== 'delete').length;
-  const driftedSummary =
-    driftedCount > 0
-      ? [
-          colorize(
-            lang.__('PLAN_DRIFTED_SUMMARY', { driftedCount: String(driftedCount) }),
-            'CYAN',
-            config.colorize,
-          ),
-          '',
-        ]
-      : [];
+  const header = [`${lang.__('PLAN_HEADER')}\n`];
 
   const summary = lang.__('PLAN_SUMMARY', {
-    createCount: String(createItems.length),
-    updateCount: String(updateItems.length),
-    deleteCount: String(deleteItems.length),
+    addCount: String(addCount),
+    modifyCount: String(modifyCount),
+    removeCount: String(removeCount),
+    recreateCount: String(recreateCount),
+    unchangedCount: String(unchangedCount),
   });
 
-  return [...header, ...itemLines, ...driftedSummary, summary].join('\n');
+  return [...header, ...itemLines, summary].join('\n');
 };
 
 /* istanbul ignore next */

--- a/src/common/planFormatter.ts
+++ b/src/common/planFormatter.ts
@@ -178,14 +178,13 @@ const formatAttributeLines = (
   const alignedKey = (diff.key + ':').padEnd(keyWidth);
   // Issue #246: a field whose stored value already matched the config while
   // the cloud diverged is annotated at the line level — the resource block
-  // stays in place, only this line explains why it appears. Applies to every
-  // leaf action: a cloud-side key deletion shows up as add/remove too.
+  // stays in place, only this line explains why it appears. Only leaf lines
+  // reach suffix (parent cases early-return on children), so a revert key
+  // with nested children never carries the annotation.
   const suffix = (line: string): string =>
-    diff.children && diff.children.length > 0
-      ? line
-      : revertKeys?.has(diff.key)
-        ? `${line} ${colorize(lang.__('PLAN_REVERT_ANNOTATION'), 'CYAN', config.colorize)}`
-        : line;
+    revertKeys?.has(diff.key)
+      ? `${line} ${colorize(lang.__('PLAN_REVERT_ANNOTATION'), 'CYAN', config.colorize)}`
+      : line;
 
   switch (diff.action) {
     case 'add': {

--- a/src/common/refreshPlanner.ts
+++ b/src/common/refreshPlanner.ts
@@ -1,17 +1,30 @@
 import { PlanItem, ResourceAttributes, ResourceState } from '../types';
 import { attributesEqual } from './hashUtils';
-import { remoteDiffersFromDesired } from './planCompare';
+import { computeRevertKeys, mergeLiveBefore, remoteDiffersFromDesired } from './planCompare';
+import { logger } from './logger';
+import { lang } from '../lang';
 
 /**
- * Exists-path decision for attribute-refresh planners (issue #234 Phase 3):
- * remote missing → create+drifted; intent-diff or live-attribute drift →
- * update+drifted; extra bookkeeping conditions → update (drifted per flag);
- * otherwise noop. Read failures propagate — callers keep their catch → create
- * fallback. Item construction stays with the caller: before/after
+ * Exists-path decision for attribute-refresh planners (issue #234 Phase 3,
+ * display contract reworked by issue #246): remote missing → create+drifted;
+ * intent-diff or live-attribute drift → update+drifted with the live
+ * attributes carried out so `changes.before` can be cloud reality; extra
+ * bookkeeping conditions → update (drifted per flag, optional probe reason);
+ * otherwise noop. Read failures propagate — callers keep their catch →
+ * create fallback. Item construction stays with the caller: before/after
  * normalization and resource-specific details differ per planner.
  */
 export type RefreshExistsDecision =
-  { action: 'create'; drifted: true } | { action: 'update'; drifted: boolean } | { action: 'noop' };
+  | { action: 'create'; drifted: true }
+  | {
+      action: 'update';
+      drifted: boolean;
+      /** live cloud attributes (post cloudToDefinition + enrich) for the diff baseline */
+      liveAttributes: ResourceAttributes;
+      /** probe-level drift sources (i18n keys) when the update is reason-driven */
+      driftReasons?: string[];
+    }
+  | { action: 'noop' };
 
 export type RefreshExistsArgs<T> = {
   read: () => Promise<T | null>;
@@ -25,10 +38,11 @@ export type RefreshExistsArgs<T> = {
   definitionChanged: boolean;
   /**
    * Extra update sources beyond the two standard diffs (e.g. pending domain
-   * binding). `drifted` controls the flag: intent/live drift set it,
-   * bookkeeping-only conditions do not.
+   * binding, nested topic drift). `drifted` controls the flag: intent/live
+   * drift set it, bookkeeping-only conditions do not. `reason` (an i18n key)
+   * marks probe-level drift that has no attribute-level diff to show.
    */
-  extraUpdate?: () => Promise<{ update: boolean; drifted: boolean }>;
+  extraUpdate?: () => Promise<{ update: boolean; drifted: boolean; reason?: string }>;
 };
 
 export const decideRefreshedExistsAction = async <T>(
@@ -44,11 +58,16 @@ export const decideRefreshedExistsAction = async <T>(
   }
   const remoteDiffers = remoteDiffersFromDesired(attributes, args.desiredDefinition);
   if (args.definitionChanged || remoteDiffers) {
-    return { action: 'update', drifted: true };
+    return { action: 'update', drifted: true, liveAttributes: attributes };
   }
   const extra = await args.extraUpdate?.();
   if (extra?.update) {
-    return { action: 'update', drifted: extra.drifted };
+    return {
+      action: 'update',
+      drifted: extra.drifted,
+      liveAttributes: attributes,
+      ...(extra.reason ? { driftReasons: [extra.reason] } : {}),
+    };
   }
   return { action: 'noop' };
 };
@@ -73,7 +92,7 @@ export type PlanRefreshedResourceArgs<T> = {
   ) => Promise<ResourceAttributes>;
   /** applied to both sides before the intent diff and in changes display */
   normalizeForDisplay?: (definition: ResourceAttributes) => ResourceAttributes;
-  extraUpdate?: () => Promise<{ update: boolean; drifted: boolean }>;
+  extraUpdate?: () => Promise<{ update: boolean; drifted: boolean; reason?: string }>;
   /**
    * When false (CLI --no-refresh): skip the live read and the attribute-drift
    * leg entirely — the decision degenerates to intent-diff only, with no
@@ -87,8 +106,12 @@ export type PlanRefreshedResourceArgs<T> = {
  * no-state-probe / exists-refresh decision chain of the simple planners
  * (buckets, tables, databases). Function and gateway planners keep their
  * custom flows (role probes, trigger reconciliation, config normalization).
- * Read failures on the exists path degrade to a create plan — the pre-existing
- * planner behavior, preserved verbatim.
+ *
+ * Issue #246 display contract: a drift/intent update's `changes.before` is
+ * always cloud reality — live attributes merged over the stored definition
+ * (stored fills the keys the cloud mapper never emits) — so every update
+ * renders a complete live→desired field diff, and `revertKeys` marks the
+ * fields whose difference is purely an out-of-config cloud edit.
  */
 export const planRefreshedResource = async <T>(
   args: PlanRefreshedResourceArgs<T>,
@@ -148,24 +171,38 @@ export const planRefreshedResource = async <T>(
         logicalId,
         action: 'create',
         resourceType,
-        changes: { before: normalize(currentDefinition), after: desiredDefinition },
+        changes: { before: normalizedCurrent, after: desiredDefinition },
         drifted: true,
       };
     }
 
+    const normalizedLive = normalize(decision.liveAttributes);
+    const revertKeys = computeRevertKeys(normalizedCurrent, normalizedLive, normalizedDesired);
     return {
       logicalId,
       action: 'update',
       resourceType,
-      changes: { before: normalizedCurrent, after: normalizedDesired },
+      changes: {
+        before: normalize(mergeLiveBefore(currentDefinition, normalizedLive)),
+        after: normalizedDesired,
+      },
       ...(decision.drifted ? { drifted: true } : {}),
+      ...(revertKeys.length ? { revertKeys } : {}),
+      ...(decision.driftReasons?.length ? { driftReasons: decision.driftReasons } : {}),
     };
-  } catch {
+  } catch (error: unknown) {
+    logger.warn(
+      lang.__('PLAN_LIVE_READ_FAILED', {
+        logicalId,
+        error: error instanceof Error ? error.message : String(error),
+      }),
+    );
     return {
       logicalId,
       action: 'create',
       resourceType,
-      changes: { before: normalize(currentDefinition), after: desiredDefinition },
+      changes: { before: normalizedCurrent, after: normalizedDesired },
+      drifted: true,
     };
   }
 };

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -123,19 +123,37 @@ export const en = {
   PLAN_WILL_CREATE: 'will be created',
   PLAN_WILL_UPDATE: 'will be updated in-place',
   PLAN_WILL_DESTROY: 'will be destroyed',
-  PLAN_WILL_REFRESH: 'will be refreshed',
+  PLAN_WILL_RECREATE: 'will be recreated',
   PLAN_NO_CHANGES: 'no changes',
   PLAN_HEADER: 'ServerlessInsight will perform the following actions:',
-  PLAN_LEGEND_CREATE: '  + create',
-  PLAN_LEGEND_UPDATE: '  ~ update in-place',
-  PLAN_LEGEND_DESTROY: '  - destroy',
   PLAN_SUMMARY:
-    'Plan: {{createCount}} to add, {{updateCount}} to change, {{deleteCount}} to destroy.',
+    'Plan: {{addCount}} add, {{modifyCount}} modify, {{removeCount}} remove, {{recreateCount}} recreate, {{unchangedCount}} unchanged.',
   PLAN_UNCHANGED_ATTRS: '({{count}} unchanged attributes hidden)',
   PLAN_COMPUTED_VALUE: '(known after deploy)',
+  PLAN_REVERT_ANNOTATION: '(changed in the cloud, will be restored to config)',
   PLAN_DRIFTED_MARKER: '(drifted — cloud changed outside of this config, will be reconciled)',
-  PLAN_DRIFTED_SUMMARY:
-    'Drift: {{driftedCount}} resource(s) changed in the cloud outside of this config.',
+  PLAN_LIVE_READ_FAILED:
+    'Failed to read live state for {{logicalId}}; planning a create instead: {{error}}',
+  PLAN_DRIFT_ROLE_MISSING: 'IAM role missing in the cloud',
+  PLAN_DRIFT_ROLE_POLICY: 'IAM role policy changed in the cloud',
+  PLAN_DRIFT_LOGSTORE: 'function log resources changed in the cloud',
+  PLAN_DRIFT_SG_RULES: 'security group rules changed in the cloud',
+  PLAN_DRIFT_NAS_MOUNT: 'NAS mount target deleted in the cloud',
+  PLAN_DRIFT_TLS_TOPIC: 'log topic configuration changed in the cloud',
+  PLAN_DRIFT_CLS_TOPIC: 'log topic configuration changed in the cloud',
+  PLAN_DRIFT_TRIGGERS: 'API triggers changed in the cloud',
+  RESOURCE_EXISTS_NOT_OWNED:
+    '{{resourceType}} {{resourceName}} already exists in provider but is not owned by this stack (missing {{tagKey}} tag). Refusing to create — resolve manually.',
+  RESOURCE_EXISTS_NOT_OWNED_ADOPT:
+    '{{resourceType}} {{resourceName}} already exists in provider but is not owned by this stack (missing {{tagKey}} tag). Refusing to adopt — resolve manually.',
+  TABLESTORE_EXISTS_UNVERIFIABLE:
+    'Table {{tableName}} already exists in provider but ownership cannot be verified (Tablestore does not support table-level tags). Refusing to adopt — resolve manually.',
+  TABLESTORE_EXISTS_UNVERIFIABLE_PROBE:
+    'Table {{tableName}} already exists in provider but ownership cannot be verified (no table-level tags). Refusing to adopt — resolve manually.',
+  TAINTED_RECOVERY_SKIP_CREATE:
+    '{{resourceType}} {{resourceName}} already exists in provider (tainted recovery), skipping create and refreshing state',
+  OWNERSHIP_VERIFYING:
+    '{{resourceType}} {{resourceName}} already exists in provider, verifying ownership tag before adopting',
 
   // TDSQL-C database messages
   TDSQL_CLUSTER_CREATION_INITIATED: 'TDSQL-C cluster creation initiated',

--- a/src/lang/zh-CN.ts
+++ b/src/lang/zh-CN.ts
@@ -120,17 +120,35 @@ export const zhCN = {
   PLAN_WILL_CREATE: '将被创建',
   PLAN_WILL_UPDATE: '将就地更新',
   PLAN_WILL_DESTROY: '将被销毁',
-  PLAN_WILL_REFRESH: '将被刷新',
+  PLAN_WILL_RECREATE: '将被重建',
   PLAN_NO_CHANGES: '无变更',
   PLAN_HEADER: 'ServerlessInsight 将执行以下操作:',
-  PLAN_LEGEND_CREATE: '  + 创建',
-  PLAN_LEGEND_UPDATE: '  ~ 就地更新',
-  PLAN_LEGEND_DESTROY: '  - 销毁',
-  PLAN_SUMMARY: '计划: 新增 {{createCount}} 个，变更 {{updateCount}} 个，销毁 {{deleteCount}} 个。',
+  PLAN_SUMMARY:
+    '计划: 新增 {{addCount}}，变更 {{modifyCount}}，移除 {{removeCount}}，重建 {{recreateCount}}，无变更 {{unchangedCount}}。',
   PLAN_UNCHANGED_ATTRS: '({{count}} 个未变更属性已隐藏)',
   PLAN_COMPUTED_VALUE: '(部署后可知)',
+  PLAN_REVERT_ANNOTATION: '(云端已改，将按配置恢复)',
   PLAN_DRIFTED_MARKER: '（云端已漂移——与本配置不一致，将按配置纠正）',
-  PLAN_DRIFTED_SUMMARY: '漂移: {{driftedCount}} 个资源在云端被本配置之外的变更修改。',
+  PLAN_LIVE_READ_FAILED: '读取 {{logicalId}} 云端状态失败，降级为创建计划: {{error}}',
+  PLAN_DRIFT_ROLE_MISSING: '云端 IAM 角色缺失',
+  PLAN_DRIFT_ROLE_POLICY: '云端 IAM 角色策略被修改',
+  PLAN_DRIFT_LOGSTORE: '云端函数日志资源被修改',
+  PLAN_DRIFT_SG_RULES: '云端安全组规则被修改',
+  PLAN_DRIFT_NAS_MOUNT: '云端 NAS 挂载点被删除',
+  PLAN_DRIFT_TLS_TOPIC: '云端日志主题配置被修改',
+  PLAN_DRIFT_CLS_TOPIC: '云端日志主题配置被修改',
+  PLAN_DRIFT_TRIGGERS: '云端 API 触发器被修改',
+  RESOURCE_EXISTS_NOT_OWNED:
+    '{{resourceType}} {{resourceName}} 已存在于云端但归属本 stack（缺少 {{tagKey}} 标签），拒绝创建——请手动处理。',
+  RESOURCE_EXISTS_NOT_OWNED_ADOPT:
+    '{{resourceType}} {{resourceName}} 已存在于云端但归属本 stack（缺少 {{tagKey}} 标签），拒绝收养——请手动处理。',
+  TABLESTORE_EXISTS_UNVERIFIABLE:
+    '表 {{tableName}} 已存在于云端但无法校验归属（Tablestore 不支持表级标签），拒绝收养——请手动处理。',
+  TABLESTORE_EXISTS_UNVERIFIABLE_PROBE:
+    '表 {{tableName}} 已存在于云端但无法校验归属（无表级标签），拒绝收养——请手动处理。',
+  TAINTED_RECOVERY_SKIP_CREATE:
+    '{{resourceType}} {{resourceName}} 已存在（tainted 恢复），跳过创建并刷新状态',
+  OWNERSHIP_VERIFYING: '{{resourceType}} {{resourceName}} 已存在，正在校验归属标签后收养',
 
   // TDSQL-C 数据库消息
   TDSQL_CLUSTER_CREATION_INITIATED: 'TDSQL-C 集群创建已启动',

--- a/src/stack/aliyunStack/apigwPlanner.ts
+++ b/src/stack/aliyunStack/apigwPlanner.ts
@@ -1,5 +1,6 @@
 import { Context, EventDomain, Plan, PlanItem, StateFile } from '../../types';
 import { createAliyunClient } from '../../common/aliyunClient';
+import { logger } from '../../common/logger';
 import {
   buildAliyunApigwApiName,
   buildEventLogSnapshot,
@@ -13,10 +14,11 @@ import {
 import { getAllResources, getResource } from '../../common/stateManager';
 import { attributesEqual } from '../../common/hashUtils';
 import { getIacDefinition, isFunctionDomain } from '../../common/iacHelper';
-import { remoteDiffersFromDesired } from '../../common/planCompare';
+import { mergeLiveBefore, remoteDiffersFromDesired } from '../../common/planCompare';
 import { cachedRefreshRead } from '../../common/refreshCache';
 import { PLAN_READ_CONCURRENCY, mapWithConcurrency } from '../../common/concurrency';
 import { OWNERSHIP_TAG_KEY, isOwnedByStack } from '../ownershipTag';
+import { lang } from '../../lang';
 
 const DNS_SUB_RESOURCE_SUFFIXES = ['.dns_verification', '.dns_txt_verification'];
 
@@ -108,7 +110,11 @@ export const generateApigwPlan = async (
         if (remoteGroup?.groupId) {
           if (!isOwnedByStack(context, logicalId, remoteGroup.tags)) {
             throw new Error(
-              `API group ${groupConfig.groupName} already exists in provider but is not owned by this stack (missing ${OWNERSHIP_TAG_KEY} tag). Refusing to create — resolve manually.`,
+              lang.__('RESOURCE_EXISTS_NOT_OWNED', {
+                resourceType: 'API group',
+                resourceName: groupConfig.groupName,
+                tagKey: OWNERSHIP_TAG_KEY,
+              }),
             );
           }
           if (!currentState) {
@@ -141,6 +147,10 @@ export const generateApigwPlan = async (
 
         let groupRemoteDiffers = false;
         let triggersDiffer = false;
+        // Issue #246: live group attributes become the diff baseline when the
+        // group was readable; trigger-level drift has no attribute mapping and
+        // is surfaced as a drift reason instead.
+        let liveGroupAttrs: Record<string, unknown> | undefined;
 
         if (groupInstance) {
           const remoteGroup = await cachedRefreshRead(
@@ -165,9 +175,9 @@ export const generateApigwPlan = async (
           // to the group/trigger then surfaces as update + drifted, and a read
           // failure cannot degrade a config-driven update into a create.
           // Domain/log stay existence-only in Phase 0-2 — never compared live.
+          liveGroupAttrs = cloudApigwGroupToDefinition(remoteGroup);
           if (!definitionChanged) {
-            const remoteGroupAttrs = cloudApigwGroupToDefinition(remoteGroup);
-            groupRemoteDiffers = remoteDiffersFromDesired(remoteGroupAttrs, desiredDefinition);
+            groupRemoteDiffers = remoteDiffersFromDesired(liveGroupAttrs, desiredDefinition);
 
             if (event.triggers.length > 0) {
               const desiredApis = new Map<
@@ -239,18 +249,31 @@ export const generateApigwPlan = async (
             logicalId,
             action: 'update',
             resourceType: 'ALIYUN_APIGW',
-            changes: { before: currentDefinition, after: desiredDefinition },
+            changes: {
+              before: liveGroupAttrs
+                ? mergeLiveBefore(currentDefinition, liveGroupAttrs)
+                : currentDefinition,
+              after: desiredDefinition,
+            },
             drifted: true,
+            ...(triggersDiffer ? { driftReasons: ['PLAN_DRIFT_TRIGGERS'] } : {}),
           };
         }
 
         return { logicalId, action: 'noop', resourceType: 'ALIYUN_APIGW' };
-      } catch {
+      } catch (error: unknown) {
+        logger.warn(
+          lang.__('PLAN_LIVE_READ_FAILED', {
+            logicalId,
+            error: error instanceof Error ? error.message : String(error),
+          }),
+        );
         return {
           logicalId,
           action: 'create',
           resourceType: 'ALIYUN_APIGW',
           changes: { before: currentState.definition, after: desiredDefinition },
+          drifted: true,
         };
       }
     },

--- a/src/stack/aliyunStack/databasePlanner.ts
+++ b/src/stack/aliyunStack/databasePlanner.ts
@@ -7,6 +7,7 @@ import {
   StateFile,
   ResourceAttributes,
 } from '../../types';
+import { lang } from '../../lang';
 import { createAliyunClient } from '../../common/aliyunClient';
 import { cachedRefreshRead } from '../../common/refreshCache';
 import { PLAN_READ_CONCURRENCY, mapWithConcurrency } from '../../common/concurrency';
@@ -142,7 +143,11 @@ export const generateDatabasePlan = async (
         isOwned: (remote) => isOwnedByStack(context, logicalId, toOwnershipTagShape(remote.tags)),
         foreignError: () =>
           new Error(
-            `${resourceType} ${database.name} already exists in provider but is not owned by this stack (missing ${OWNERSHIP_TAG_KEY} tag). Refusing to create — resolve manually.`,
+            lang.__('RESOURCE_EXISTS_NOT_OWNED', {
+              resourceType,
+              resourceName: database.name,
+              tagKey: OWNERSHIP_TAG_KEY,
+            }),
           ),
         cloudToDefinition: (remote) =>
           isEs ? cloudEsToDefinition(remote) : cloudRdsToDefinition(remote),

--- a/src/stack/aliyunStack/databaseResource.ts
+++ b/src/stack/aliyunStack/databaseResource.ts
@@ -209,7 +209,11 @@ export const createDatabaseResource = async (
             );
           } else {
             throw new Error(
-              `ES app ${config.appName} already exists in provider but is not owned by this stack (missing ${OWNERSHIP_TAG_KEY} tag). Refusing to adopt — resolve manually.`,
+              lang.__('RESOURCE_EXISTS_NOT_OWNED_ADOPT', {
+                resourceType: 'ES app',
+                resourceName: config.appName,
+                tagKey: OWNERSHIP_TAG_KEY,
+              }),
               { cause: error },
             );
           }
@@ -245,7 +249,11 @@ export const createDatabaseResource = async (
             );
           } else {
             throw new Error(
-              `RDS instance ${config.dbInstanceDescription} already exists in provider but is not owned by this stack (missing ${OWNERSHIP_TAG_KEY} tag). Refusing to adopt — resolve manually.`,
+              lang.__('RESOURCE_EXISTS_NOT_OWNED_ADOPT', {
+                resourceType: 'RDS instance',
+                resourceName: config.dbInstanceDescription,
+                tagKey: OWNERSHIP_TAG_KEY,
+              }),
               { cause: error },
             );
           }

--- a/src/stack/aliyunStack/deployer.ts
+++ b/src/stack/aliyunStack/deployer.ts
@@ -2,6 +2,7 @@ import {
   ServerlessIac,
   ExecutionResult,
   PartialFailureError,
+  Plan,
   PlanItem,
   StateFile,
 } from '../../types';
@@ -95,9 +96,16 @@ export const buildRoleArnResolver = (
   };
 };
 
+// Issue #246: when the approved plan is passed through, the executor runs
+// exactly the displayed items — partitioned by resourceType, no re-probe.
+const partitionPlan = (plan: Plan, types: string[]): Plan => ({
+  items: plan.items.filter((item) => types.includes(item.resourceType)),
+});
+
 export const deployAliyunStack = async (
   iac: ServerlessIac,
   backend: StateBackend,
+  approvedPlan?: Plan,
 ): Promise<void> => {
   const context = getContext();
   // Cache IAC for access throughout the deployment
@@ -108,19 +116,31 @@ export const deployAliyunStack = async (
   const onStateChange = createSaveStateFn(backend, iac, context.stage);
 
   logger.info(lang.__('GENERATING_PLAN'));
-  const functionPlan = await generateFunctionPlan(context, state, iac.functions);
-  const bucketPlan = await generateBucketPlan(context, state, iac.buckets);
-  const databasePlan = await generateDatabasePlan(context, state, iac.databases);
-  const tablePlan = await generateTablePlan(context, state, iac.tables);
-  const eventPlan = await generateApigwPlan(context, state, iac.events, iac.service);
+  const functionPlan = approvedPlan
+    ? partitionPlan(approvedPlan, ['ALIYUN_FC3'])
+    : await generateFunctionPlan(context, state, iac.functions);
+  const bucketPlan = approvedPlan
+    ? partitionPlan(approvedPlan, ['ALIYUN_OSS_BUCKET'])
+    : await generateBucketPlan(context, state, iac.buckets);
+  const databasePlan = approvedPlan
+    ? partitionPlan(approvedPlan, ['ALIYUN_RDS_SERVERLESS', 'ALIYUN_ES_SERVERLESS'])
+    : await generateDatabasePlan(context, state, iac.databases);
+  const tablePlan = approvedPlan
+    ? partitionPlan(approvedPlan, ['ALIYUN_TABLESTORE_TABLE'])
+    : await generateTablePlan(context, state, iac.tables);
+  const eventPlan = approvedPlan
+    ? partitionPlan(approvedPlan, ['ALIYUN_APIGW'])
+    : await generateApigwPlan(context, state, iac.events, iac.service);
 
-  const allItems = [
-    ...functionPlan.items,
-    ...bucketPlan.items,
-    ...databasePlan.items,
-    ...tablePlan.items,
-    ...eventPlan.items,
-  ];
+  const allItems = approvedPlan
+    ? [...approvedPlan.items]
+    : [
+        ...functionPlan.items,
+        ...bucketPlan.items,
+        ...databasePlan.items,
+        ...tablePlan.items,
+        ...eventPlan.items,
+      ];
 
   // Build dependency graph for validation (e.g. cycle detection) and logging
   const dependencyInfo = getDependencyInfo(allItems);

--- a/src/stack/aliyunStack/fc3Planner.ts
+++ b/src/stack/aliyunStack/fc3Planner.ts
@@ -14,7 +14,11 @@ import {
   parseSecurityGroupRule,
 } from '../../common/aliyunClient/ecsOperations';
 import { cachedRefreshRead } from '../../common/refreshCache';
-import { remoteDiffersFromDesired } from '../../common/planCompare';
+import {
+  computeRevertKeys,
+  mergeLiveBefore,
+  remoteDiffersFromDesired,
+} from '../../common/planCompare';
 import { PLAN_READ_CONCURRENCY, mapWithConcurrency } from '../../common/concurrency';
 import {
   Context,
@@ -188,6 +192,8 @@ const parseRolePolicyDocument = (raw: string | undefined): Record<string, unknow
  * - logConfig must be derivable from state: with logging on but no recorded
  *   logstore instance the executor creates one during update and derives the
  *   grant from that new logstore, which the planner cannot know → skip.
+ * Returns an i18n drift-reason key (issue #246) instead of a boolean so the
+ * plan can say WHICH dimension drifted; null means no drift.
  */
 const detectRolePolicyDrift = async (
   context: Context,
@@ -196,13 +202,13 @@ const detectRolePolicyDrift = async (
   currentState: ResourceState,
   roleName: string,
   cloudRole: { assumeRolePolicyDocument?: string } | null,
-): Promise<boolean> => {
+): Promise<string | null> => {
   const client = createAliyunClient(context);
   const logicalId = `functions.${fn.key}`;
 
   const iamRole = fn.iam?.role;
   if (!iamRole || typeof iamRole === 'string') {
-    return false;
+    return null;
   }
 
   const roleInstance = currentState.instances?.find(
@@ -212,7 +218,7 @@ const detectRolePolicyDrift = async (
       !(i as { external?: boolean }).external,
   );
   if (!roleInstance) {
-    return false;
+    return null;
   }
 
   // Conservative ownership scan (mirrors collectRolePeers semantics without
@@ -230,7 +236,7 @@ const detectRolePolicyDrift = async (
       ),
   );
   if (sharedRole) {
-    return false;
+    return null;
   }
 
   let logConfig: { project: string; logstore: string } | undefined;
@@ -239,7 +245,7 @@ const detectRolePolicyDrift = async (
       (i) => (i as { type?: string }).type === 'ALIYUN_SLS_LOGSTORE',
     ) as { id?: string } | undefined;
     if (!logstoreInstance?.id) {
-      return false;
+      return null;
     }
     const [project, logstore] = logstoreInstance.id.split('/');
     logConfig = { project, logstore };
@@ -260,7 +266,7 @@ const detectRolePolicyDrift = async (
     ],
   };
   if (cloudTrust && !attributesEqual(cloudTrust, desiredTrust)) {
-    return true;
+    return 'PLAN_DRIFT_ROLE_POLICY';
   }
 
   // b. execution + custom policy (the `<roleName>-policy` custom document). An
@@ -280,7 +286,7 @@ const detectRolePolicyDrift = async (
     !desiredPolicyDocument ||
     !attributesEqual(cloudPolicy, desiredPolicyDocument)
   ) {
-    return true;
+    return 'PLAN_DRIFT_ROLE_POLICY';
   }
 
   // c. managed (system) policies as sorted name sets; desired ARNs strip the
@@ -295,10 +301,10 @@ const detectRolePolicyDrift = async (
   );
   const asSortedSetKey = (names: string[]): string => [...names].sort().join(',');
   if (asSortedSetKey(desiredManagedNames) !== asSortedSetKey(cloudManagedNames ?? [])) {
-    return true;
+    return 'PLAN_DRIFT_ROLE_POLICY';
   }
 
-  return false;
+  return null;
 };
 
 /**
@@ -306,13 +312,14 @@ const detectRolePolicyDrift = async (
  * presence for functions that declare logging. The logstore is per-function
  * (buildFunctionLogstoreName), so this lives in the function flow. Aliyun
  * cannot shrink shards, so only a shard deficit counts as drift.
+ * Returns an i18n drift-reason key (issue #246); null means no drift.
  */
 const detectFunctionNestedDrift = async (
   context: Context,
   client: ReturnType<typeof createAliyunClient>,
   fn: FunctionDomain,
   currentState: ResourceState,
-): Promise<boolean> => {
+): Promise<string | null> => {
   // Each declared dimension contributes its own probe; undeclared dimensions
   // fall through so later dimensions still run.
   if (fn.log) {
@@ -328,14 +335,14 @@ const detectFunctionNestedDrift = async (
           () => client.sls.getLogstore(projectName, logstoreName),
         );
         if (!logstore) {
-          return true; // logstore deleted out-of-band
+          return 'PLAN_DRIFT_LOGSTORE'; // logstore deleted out-of-band
         }
         if (logstore.ttl !== SLS_LOGSTORE_TTL) {
-          return true;
+          return 'PLAN_DRIFT_LOGSTORE';
         }
         // Aliyun cannot shrink shards — only a deficit counts as drift.
         if ((logstore.shardCount ?? 0) < SLS_LOGSTORE_SHARDS) {
-          return true;
+          return 'PLAN_DRIFT_LOGSTORE';
         }
 
         const index = await cachedRefreshRead(
@@ -344,7 +351,7 @@ const detectFunctionNestedDrift = async (
           () => client.sls.getIndex(projectName, logstoreName),
         );
         if (!index) {
-          return true; // index deleted out-of-band
+          return 'PLAN_DRIFT_LOGSTORE'; // index deleted out-of-band
         }
       }
     }
@@ -394,7 +401,7 @@ const detectFunctionNestedDrift = async (
         desired.egress.some((d) => !liveEgress.includes(d)) ||
         liveEgress.some((l) => !desired.egress.includes(l))
       ) {
-        return true;
+        return 'PLAN_DRIFT_SG_RULES';
       }
     }
   }
@@ -414,12 +421,12 @@ const detectFunctionNestedDrift = async (
         client.nas.listMountTargets(fsId),
       );
       if (!targets || targets.length === 0) {
-        return true; // mount target deleted out-of-band
+        return 'PLAN_DRIFT_NAS_MOUNT'; // mount target deleted out-of-band
       }
     }
   }
 
-  return false;
+  return null;
 };
 
 export const generateFunctionPlan = async (
@@ -462,7 +469,11 @@ export const generateFunctionPlan = async (
         );
         if (remoteFunction && !isOwnedByStack(context, logicalId, remoteFunction.tags)) {
           throw new Error(
-            `Function ${fn.name} already exists in provider but is not owned by this stack (missing ${OWNERSHIP_TAG_KEY} tag). Refusing to create — resolve manually.`,
+            lang.__('RESOURCE_EXISTS_NOT_OWNED', {
+              resourceType: 'Function',
+              resourceName: fn.name,
+              tagKey: OWNERSHIP_TAG_KEY,
+            }),
           );
         }
 
@@ -515,16 +526,28 @@ export const generateFunctionPlan = async (
         // (memory/timeout/env/...). One-directional: only mapper-emitted keys
         // the desired definition declares are compared, so cloud-only extras
         // the config never asked for are ignored (desired-declared contract).
+        // Issue #246: the diff baseline is cloud reality — live attributes
+        // merged over the stored definition — and revertKeys marks the fields
+        // whose difference is purely an out-of-config cloud edit.
         const remoteAttributes = cloudFc3ToDefinition(remoteFunction);
         const remoteDiffers = remoteDiffersFromDesired(remoteAttributes, desiredDefinition);
+        const liveBefore = normalizeDefinitionForComparison(
+          mergeLiveBefore(currentState.definition || {}, remoteAttributes),
+        );
+        const revertKeys = computeRevertKeys(
+          normalizedCurrent,
+          normalizeDefinitionForComparison(remoteAttributes),
+          normalizedDesired,
+        );
 
         if (definitionChanged || remoteDiffers) {
           return {
             logicalId,
             action: 'update',
             resourceType: 'ALIYUN_FC3',
-            changes: { before: normalizedCurrent, after: normalizedDesired },
+            changes: { before: liveBefore, after: normalizedDesired },
             drifted: true,
+            ...(revertKeys.length ? { revertKeys } : {}),
           };
         }
 
@@ -547,11 +570,12 @@ export const generateFunctionPlan = async (
                 logicalId,
                 action: 'update',
                 resourceType: 'ALIYUN_FC3',
-                changes: { before: normalizedCurrent, after: normalizedDesired },
+                changes: { before: liveBefore, after: normalizedDesired },
                 drifted: true,
+                driftReasons: ['PLAN_DRIFT_ROLE_MISSING'],
               };
             }
-            const rolePolicyDrifted = await detectRolePolicyDrift(
+            const roleDriftReason = await detectRolePolicyDrift(
               context,
               state,
               fn,
@@ -559,13 +583,14 @@ export const generateFunctionPlan = async (
               roleProbe.roleName,
               cloudRole,
             );
-            if (rolePolicyDrifted) {
+            if (roleDriftReason) {
               return {
                 logicalId,
                 action: 'update',
                 resourceType: 'ALIYUN_FC3',
-                changes: { before: normalizedCurrent, after: normalizedDesired },
+                changes: { before: liveBefore, after: normalizedDesired },
                 drifted: true,
+                driftReasons: [roleDriftReason],
               };
             }
           } catch (error: unknown) {
@@ -582,14 +607,20 @@ export const generateFunctionPlan = async (
         // Issue #234 M1/M2: nested drift probe — the probe itself skips
         // dimensions the config does not declare.
         try {
-          const nestedDrifted = await detectFunctionNestedDrift(context, client, fn, currentState);
-          if (nestedDrifted) {
+          const nestedDriftReason = await detectFunctionNestedDrift(
+            context,
+            client,
+            fn,
+            currentState,
+          );
+          if (nestedDriftReason) {
             return {
               logicalId,
               action: 'update',
               resourceType: 'ALIYUN_FC3',
-              changes: { before: normalizedCurrent, after: normalizedDesired },
+              changes: { before: liveBefore, after: normalizedDesired },
               drifted: true,
+              driftReasons: [nestedDriftReason],
             };
           }
         } catch (error: unknown) {
@@ -602,7 +633,13 @@ export const generateFunctionPlan = async (
         }
 
         return { logicalId, action: 'noop', resourceType: 'ALIYUN_FC3' };
-      } catch {
+      } catch (error: unknown) {
+        logger.warn(
+          lang.__('PLAN_LIVE_READ_FAILED', {
+            logicalId,
+            error: error instanceof Error ? error.message : String(error),
+          }),
+        );
         return {
           logicalId,
           action: 'create',
@@ -611,6 +648,7 @@ export const generateFunctionPlan = async (
             before: normalizeDefinitionForComparison(currentState.definition),
             after: normalizeDefinitionForComparison(desiredDefinition),
           },
+          drifted: true,
         };
       }
     },

--- a/src/stack/aliyunStack/fc3Resource.ts
+++ b/src/stack/aliyunStack/fc3Resource.ts
@@ -890,7 +890,7 @@ export const createResource = async (
   const existingFunctionOnRetry = isTainted ? await client.fc3.getFunction(fn.name) : null;
   if (existingFunctionOnRetry) {
     logger.info(
-      `Function ${fn.name} already exists in provider (tainted recovery), skipping create and refreshing state`,
+      lang.__('TAINTED_RECOVERY_SKIP_CREATE', { resourceType: 'Function', resourceName: fn.name }),
     );
   }
 
@@ -958,7 +958,11 @@ export const createResource = async (
         throw new PartialResourceError(
           stateAfterDependents,
           new Error(
-            `Function ${fn.name} already exists in provider but is not owned by this stack (missing ${OWNERSHIP_TAG_KEY} tag). Refusing to adopt — resolve manually.`,
+            lang.__('RESOURCE_EXISTS_NOT_OWNED_ADOPT', {
+              resourceType: 'Function',
+              resourceName: fn.name,
+              tagKey: OWNERSHIP_TAG_KEY,
+            }),
           ),
         );
       }

--- a/src/stack/aliyunStack/ossPlanner.ts
+++ b/src/stack/aliyunStack/ossPlanner.ts
@@ -1,4 +1,5 @@
 import path from 'node:path';
+import { lang } from '../../lang';
 import { Context, BucketDomain, Plan, PlanItem, StateFile, ResourceAttributes } from '../../types';
 import { createAliyunClient } from '../../common/aliyunClient';
 import { cachedRefreshRead } from '../../common/refreshCache';
@@ -80,7 +81,11 @@ export const generateBucketPlan = async (
         isOwned: (remote) => isOwnedByStack(context, logicalId, toOwnershipTags(remote.tags)),
         foreignError: () =>
           new Error(
-            `Bucket ${bucket.name} already exists in provider but is not owned by this stack (missing ${OWNERSHIP_TAG_KEY} tag). Refusing to create — resolve manually.`,
+            lang.__('RESOURCE_EXISTS_NOT_OWNED', {
+              resourceType: 'Bucket',
+              resourceName: bucket.name,
+              tagKey: OWNERSHIP_TAG_KEY,
+            }),
           ),
         cloudToDefinition: cloudOssToDefinition,
         normalizeForDisplay: normalizeDefinitionForDisplay,

--- a/src/stack/aliyunStack/ossResource.ts
+++ b/src/stack/aliyunStack/ossResource.ts
@@ -261,7 +261,10 @@ export const createBucketResource = async (
 
   if (existingBucketOnRetry) {
     logger.info(
-      `Bucket ${config.bucketName} already exists in provider (tainted recovery), skipping create`,
+      lang.__('TAINTED_RECOVERY_SKIP_CREATE', {
+        resourceType: 'Bucket',
+        resourceName: config.bucketName,
+      }),
     );
   }
 
@@ -290,7 +293,11 @@ export const createBucketResource = async (
 
   const refuseAdoptionError = (): Error =>
     new Error(
-      `Bucket ${config.bucketName} already exists in provider but is not owned by this stack (missing ${OWNERSHIP_TAG_KEY} tag). Refusing to adopt — resolve manually.`,
+      lang.__('RESOURCE_EXISTS_NOT_OWNED_ADOPT', {
+        resourceType: 'Bucket',
+        resourceName: config.bucketName,
+        tagKey: OWNERSHIP_TAG_KEY,
+      }),
     );
 
   try {

--- a/src/stack/aliyunStack/tablestorePlanner.ts
+++ b/src/stack/aliyunStack/tablestorePlanner.ts
@@ -1,4 +1,5 @@
 import { Context, TableDomain, Plan, PlanItem, StateFile, ResourceAttributes } from '../../types';
+import { lang } from '../../lang';
 import { createAliyunClient } from '../../common/aliyunClient';
 import { cachedRefreshRead } from '../../common/refreshCache';
 import { PLAN_READ_CONCURRENCY, mapWithConcurrency } from '../../common/concurrency';
@@ -60,7 +61,7 @@ export const generateTablePlan = async (
         isOwned: () => false,
         foreignError: () =>
           new Error(
-            `Table ${config.tableName} already exists in provider but ownership cannot be verified (no table-level tags). Refusing to adopt — resolve manually.`,
+            lang.__('TABLESTORE_EXISTS_UNVERIFIABLE_PROBE', { tableName: config.tableName }),
           ),
         cloudToDefinition: cloudTableStoreToDefinition,
         refresh: context.refresh,

--- a/src/stack/aliyunStack/tablestoreResource.ts
+++ b/src/stack/aliyunStack/tablestoreResource.ts
@@ -1,4 +1,5 @@
 import { createAliyunClient } from '../../common/aliyunClient';
+import { lang } from '../../lang';
 import { TableStoreTableInfo } from '../../common/aliyunClient/tablestoreOperations';
 import { setResource, removeResource, buildSid } from '../../common';
 import { Context, TableDomain, PartialResourceError, ResourceState, StateFile } from '../../types';
@@ -176,9 +177,7 @@ export const createTableResource = async (
       if (existingTable) {
         throw new PartialResourceError(
           stateAfterDependents,
-          new Error(
-            `Table ${config.tableName} already exists in provider but ownership cannot be verified (Tablestore does not support table-level tags). Refusing to adopt — resolve manually.`,
-          ),
+          new Error(lang.__('TABLESTORE_EXISTS_UNVERIFIABLE', { tableName: config.tableName })),
         );
       }
     }

--- a/src/stack/deploy.ts
+++ b/src/stack/deploy.ts
@@ -1,4 +1,4 @@
-import { ServerlessIac } from '../types';
+import { ServerlessIac, Plan } from '../types';
 import { ProviderEnum } from '../common';
 import { StateBackend } from '../common/stateBackend';
 import { deployTencentStack } from './scfStack';
@@ -13,14 +13,20 @@ const deployHuawei = async (): Promise<void> => {
   );
 };
 
-export const deployStack = async (iac: ServerlessIac, backend: StateBackend) => {
+/**
+ * `plan` (issue #246): the exact plan shown to the user for approval is the
+ * plan executed — deployers partition its items by resourceType instead of
+ * re-probing the cloud and re-deciding. Omit it to fall back to per-provider
+ * plan generation (legacy path kept for direct deployer callers).
+ */
+export const deployStack = async (iac: ServerlessIac, backend: StateBackend, plan?: Plan) => {
   if (iac.provider.name === ProviderEnum.TENCENT) {
-    await deployTencentStack(iac, backend);
+    await deployTencentStack(iac, backend, plan);
   } else if (iac.provider.name === ProviderEnum.ALIYUN) {
-    await deployAliyunStack(iac, backend);
+    await deployAliyunStack(iac, backend, plan);
   } else if (iac.provider.name === ProviderEnum.HUAWEI) {
     await deployHuawei();
   } else if (iac.provider.name === ProviderEnum.VOLCENGINE) {
-    await deployVolcengineStack(iac, backend);
+    await deployVolcengineStack(iac, backend, plan);
   }
 };

--- a/src/stack/scfStack/cosPlanner.ts
+++ b/src/stack/scfStack/cosPlanner.ts
@@ -1,4 +1,5 @@
 import { Context, BucketDomain, Plan, PlanItem, StateFile, ResourceAttributes } from '../../types';
+import { lang } from '../../lang';
 import { createTencentClient } from '../../common/tencentClient';
 import { cachedRefreshRead } from '../../common/refreshCache';
 import { PLAN_READ_CONCURRENCY, mapWithConcurrency } from '../../common/concurrency';
@@ -58,7 +59,11 @@ export const generateBucketPlan = async (
         isOwned: (remote) => isOwnedByStack(context, logicalId, remote.Tags),
         foreignError: () =>
           new Error(
-            `Bucket ${bucket.name} already exists in provider but is not owned by this stack (missing ${OWNERSHIP_TAG_KEY} tag). Refusing to create — resolve manually.`,
+            lang.__('RESOURCE_EXISTS_NOT_OWNED', {
+              resourceType: 'Bucket',
+              resourceName: bucket.name,
+              tagKey: OWNERSHIP_TAG_KEY,
+            }),
           ),
         cloudToDefinition: cloudCosToDefinition,
         extraUpdate: async () => {

--- a/src/stack/scfStack/cosResource.ts
+++ b/src/stack/scfStack/cosResource.ts
@@ -338,7 +338,7 @@ export const createBucketResource = async (
         throw error;
       }
       logger.info(
-        `Bucket ${bucket.name} already exists in provider, verifying ownership tag before adopting`,
+        lang.__('OWNERSHIP_VERIFYING', { resourceType: 'Bucket', resourceName: bucket.name }),
       );
     }
 
@@ -356,7 +356,11 @@ export const createBucketResource = async (
       throw new PartialResourceError(
         stateAfterDependents,
         new Error(
-          `Bucket ${bucket.name} already exists in provider but is not owned by this stack (missing ${OWNERSHIP_TAG_KEY} tag). Refusing to adopt — resolve manually.`,
+          lang.__('RESOURCE_EXISTS_NOT_OWNED_ADOPT', {
+            resourceType: 'Bucket',
+            resourceName: bucket.name,
+            tagKey: OWNERSHIP_TAG_KEY,
+          }),
         ),
       );
     }

--- a/src/stack/scfStack/deployer.ts
+++ b/src/stack/scfStack/deployer.ts
@@ -2,6 +2,7 @@ import {
   ServerlessIac,
   ExecutionResult,
   PartialFailureError,
+  Plan,
   PlanItem,
   StateFile,
 } from '../../types';
@@ -41,9 +42,16 @@ const handlePartialFailure = (failure: PartialFailureError): never => {
 const collectSuccessfulItems = (results: Array<ExecutionResult>): Array<PlanItem> =>
   results.flatMap((result) => result.partialFailure?.successfulItems ?? []);
 
+// Issue #246: when the approved plan is passed through, the executor runs
+// exactly the displayed items — partitioned by resourceType, no re-probe.
+const partitionPlan = (plan: Plan, types: string[]): Plan => ({
+  items: plan.items.filter((item) => types.includes(item.resourceType)),
+});
+
 export const deployTencentStack = async (
   iac: ServerlessIac,
   backend: StateBackend,
+  approvedPlan?: Plan,
 ): Promise<void> => {
   const context = getContext();
   logger.info(lang.__('DEPLOYING_STACK_PUBLISHING_ASSETS'));
@@ -52,13 +60,23 @@ export const deployTencentStack = async (
   const onStateChange = createSaveStateFn(backend, iac, context.stage);
 
   logger.info(lang.__('GENERATING_PLAN'));
-  const functionPlan = await generateFunctionPlan(context, state, iac.functions);
-  const bucketPlan = await generateBucketPlan(context, state, iac.buckets);
-  const databasePlan = await generateDatabasePlan(context, state, iac.databases);
-  const esPlan = await generateEsPlan(context, state, iac.databases);
+  const functionPlan = approvedPlan
+    ? partitionPlan(approvedPlan, ['SCF'])
+    : await generateFunctionPlan(context, state, iac.functions);
+  const bucketPlan = approvedPlan
+    ? partitionPlan(approvedPlan, ['COS_BUCKET'])
+    : await generateBucketPlan(context, state, iac.buckets);
+  const databasePlan = approvedPlan
+    ? partitionPlan(approvedPlan, ['TDSQL_C_SERVERLESS'])
+    : await generateDatabasePlan(context, state, iac.databases);
+  const esPlan = approvedPlan
+    ? partitionPlan(approvedPlan, ['TENCENT_ES_SERVERLESS'])
+    : await generateEsPlan(context, state, iac.databases);
 
   const combinedPlan = {
-    items: [...functionPlan.items, ...bucketPlan.items, ...databasePlan.items, ...esPlan.items],
+    items: approvedPlan
+      ? [...approvedPlan.items]
+      : [...functionPlan.items, ...bucketPlan.items, ...databasePlan.items, ...esPlan.items],
   };
 
   logger.info(`${lang.__('PLAN_GENERATED')}: ${combinedPlan.items.length} ${lang.__('ACTIONS')}`);

--- a/src/stack/scfStack/esServerlessPlanner.ts
+++ b/src/stack/scfStack/esServerlessPlanner.ts
@@ -7,6 +7,7 @@ import {
   StateFile,
   ResourceAttributes,
 } from '../../types';
+import { lang } from '../../lang';
 import { createTencentClient } from '../../common/tencentClient';
 import { cachedRefreshRead } from '../../common/refreshCache';
 import { PLAN_READ_CONCURRENCY, mapWithConcurrency } from '../../common/concurrency';
@@ -77,7 +78,11 @@ export const generateEsPlan = async (
         isOwned: (remote) => isOwnedByStack(context, logicalId, remote.Tags),
         foreignError: () =>
           new Error(
-            `ES space ${config.SpaceName} already exists in provider but is not owned by this stack (missing ${OWNERSHIP_TAG_KEY} tag). Refusing to create — resolve manually.`,
+            lang.__('RESOURCE_EXISTS_NOT_OWNED', {
+              resourceType: 'ES space',
+              resourceName: config.SpaceName,
+              tagKey: OWNERSHIP_TAG_KEY,
+            }),
           ),
         cloudToDefinition: cloudTencentEsToDefinition,
         refresh: context.refresh,

--- a/src/stack/scfStack/esServerlessResource.ts
+++ b/src/stack/scfStack/esServerlessResource.ts
@@ -142,7 +142,11 @@ export const createEsResource = async (
       throw new PartialResourceError(
         stateAfterDependents,
         new Error(
-          `ES space ${config.SpaceName} already exists in provider but is not owned by this stack (missing ${OWNERSHIP_TAG_KEY} tag). Refusing to adopt — resolve manually.`,
+          lang.__('RESOURCE_EXISTS_NOT_OWNED_ADOPT', {
+            resourceType: 'ES space',
+            resourceName: config.SpaceName,
+            tagKey: OWNERSHIP_TAG_KEY,
+          }),
         ),
       );
     }

--- a/src/stack/scfStack/scfPlanner.ts
+++ b/src/stack/scfStack/scfPlanner.ts
@@ -63,47 +63,6 @@ export const generateFunctionPlan = async (
 
       const client = createTencentClient(context);
 
-      // Issue #234 M3: nested topic drift — probed only when logging is
-      // declared; unresolvable/unreadable topics are not drift.
-      if (
-        currentState &&
-        currentState.status !== 'tainted' &&
-        fn.log &&
-        context.refresh !== false
-      ) {
-        const topicInstance = currentState.instances?.find(
-          (i) => (i as { type?: string }).type === 'TENCENT_CLS_TOPIC',
-        ) as { id?: string } | undefined;
-        if (topicInstance?.id) {
-          const topicId = topicInstance.id;
-          try {
-            const liveTopic = await cachedRefreshRead(context, `cls.getTopicById:${topicId}`, () =>
-              client.cls.getTopicById(topicId),
-            );
-            const topicDrifted =
-              !liveTopic ||
-              liveTopic.StorageType !== CLS_TOPIC_STORAGE_TYPE ||
-              liveTopic.Period !== CLS_TOPIC_PERIOD;
-            if (topicDrifted) {
-              return {
-                logicalId,
-                action: 'update',
-                resourceType: 'SCF',
-                changes: { before: currentState.definition || {}, after: desiredDefinition },
-                drifted: true,
-              };
-            }
-          } catch (error: unknown) {
-            logger.warn(
-              lang.__('PLAN_FUNCTION_NESTED_PROBE_FAILED', {
-                functionName: fn.name,
-                error: String(error),
-              }),
-            );
-          }
-        }
-      }
-
       return planRefreshedResource({
         logicalId,
         resourceType: 'SCF',
@@ -116,8 +75,45 @@ export const generateFunctionPlan = async (
         isOwned: (remote) => isOwnedByStack(context, logicalId, remote.Tags),
         foreignError: () =>
           new Error(
-            `Function ${fn.name} already exists in provider but is not owned by this stack (missing ${OWNERSHIP_TAG_KEY} tag). Refusing to create — resolve manually.`,
+            lang.__('RESOURCE_EXISTS_NOT_OWNED', {
+              resourceType: 'Function',
+              resourceName: fn.name,
+              tagKey: OWNERSHIP_TAG_KEY,
+            }),
           ),
+        extraUpdate: async () => {
+          // Issue #234 M3: nested topic drift — probed only when logging is
+          // declared; unresolvable/unreadable topics are not drift. Runs via
+          // the skeleton's extraUpdate hook (issue #246) so a topic-only
+          // drift gets the live→desired diff baseline too.
+          const topicInstance = currentState?.instances?.find(
+            (i) => (i as { type?: string }).type === 'TENCENT_CLS_TOPIC',
+          ) as { id?: string } | undefined;
+          if (!fn.log || !topicInstance?.id) {
+            return { update: false, drifted: false };
+          }
+          const topicId = topicInstance.id;
+          try {
+            const liveTopic = await cachedRefreshRead(context, `cls.getTopicById:${topicId}`, () =>
+              client.cls.getTopicById(topicId),
+            );
+            const topicDrifted =
+              !liveTopic ||
+              liveTopic.StorageType !== CLS_TOPIC_STORAGE_TYPE ||
+              liveTopic.Period !== CLS_TOPIC_PERIOD;
+            return topicDrifted
+              ? { update: true, drifted: true, reason: 'PLAN_DRIFT_CLS_TOPIC' }
+              : { update: false, drifted: false };
+          } catch (error: unknown) {
+            logger.warn(
+              lang.__('PLAN_FUNCTION_NESTED_PROBE_FAILED', {
+                functionName: fn.name,
+                error: String(error),
+              }),
+            );
+            return { update: false, drifted: false };
+          }
+        },
         cloudToDefinition: cloudScfToDefinition,
         enrichRemoteAttributes: async (remote, attributes) => {
           // Resolve cloud CLS ids back to the stable names the desired

--- a/src/stack/scfStack/scfResource.ts
+++ b/src/stack/scfStack/scfResource.ts
@@ -684,7 +684,7 @@ export const createResource = async (
 
   if (existingFunctionOnRetry) {
     logger.info(
-      `Function ${fn.name} already exists in provider (tainted recovery), skipping create and refreshing state`,
+      lang.__('TAINTED_RECOVERY_SKIP_CREATE', { resourceType: 'Function', resourceName: fn.name }),
     );
   }
 
@@ -727,7 +727,11 @@ export const createResource = async (
         throw new PartialResourceError(
           stateAfterDependents,
           new Error(
-            `Function ${fn.name} already exists in provider but is not owned by this stack (missing ${OWNERSHIP_TAG_KEY} tag). Refusing to adopt — resolve manually.`,
+            lang.__('RESOURCE_EXISTS_NOT_OWNED_ADOPT', {
+              resourceType: 'Function',
+              resourceName: fn.name,
+              tagKey: OWNERSHIP_TAG_KEY,
+            }),
           ),
         );
       }

--- a/src/stack/scfStack/tdsqlcPlanner.ts
+++ b/src/stack/scfStack/tdsqlcPlanner.ts
@@ -7,6 +7,7 @@ import {
   StateFile,
   ResourceAttributes,
 } from '../../types';
+import { lang } from '../../lang';
 import { createTencentClient } from '../../common/tencentClient';
 import { cachedRefreshRead } from '../../common/refreshCache';
 import { PLAN_READ_CONCURRENCY, mapWithConcurrency } from '../../common/concurrency';
@@ -85,7 +86,11 @@ export const generateDatabasePlan = async (
           isOwnedByStack(context, logicalId, tdsqlcTagsToOwnershipTags(remote.ResourceTags)),
         foreignError: () =>
           new Error(
-            `Cluster ${database.name} already exists in provider but is not owned by this stack (missing ${OWNERSHIP_TAG_KEY} tag). Refusing to create — resolve manually.`,
+            lang.__('RESOURCE_EXISTS_NOT_OWNED', {
+              resourceType: 'Cluster',
+              resourceName: database.name,
+              tagKey: OWNERSHIP_TAG_KEY,
+            }),
           ),
         cloudToDefinition: cloudTdsqlcToDefinition,
         extraUpdate: async () => {

--- a/src/stack/scfStack/tdsqlcResource.ts
+++ b/src/stack/scfStack/tdsqlcResource.ts
@@ -180,7 +180,11 @@ export const createDatabaseResource = async (
           throw new PartialResourceError(
             stateAfterDependents,
             new Error(
-              `Cluster ${database.name} already exists in provider but is not owned by this stack (missing ${OWNERSHIP_TAG_KEY} tag). Refusing to adopt — resolve manually.`,
+              lang.__('RESOURCE_EXISTS_NOT_OWNED_ADOPT', {
+                resourceType: 'Cluster',
+                resourceName: database.name,
+                tagKey: OWNERSHIP_TAG_KEY,
+              }),
             ),
           );
         }

--- a/src/stack/volcengineStack/apigwPlanner.ts
+++ b/src/stack/volcengineStack/apigwPlanner.ts
@@ -67,7 +67,11 @@ export const generateApigwPlan = async (
         );
         if (remoteGateway?.gatewayId && !isOwnedByStack(context, logicalId, remoteGateway.tags)) {
           throw new Error(
-            `API Gateway ${buildGatewayName(serviceName, context.stage)} already exists in provider but is not owned by this stack (missing ${OWNERSHIP_TAG_KEY} tag). Refusing to create — resolve manually.`,
+            lang.__('RESOURCE_EXISTS_NOT_OWNED', {
+              resourceType: 'API Gateway',
+              resourceName: buildGatewayName(serviceName, context.stage),
+              tagKey: OWNERSHIP_TAG_KEY,
+            }),
           );
         }
 

--- a/src/stack/volcengineStack/deployer.ts
+++ b/src/stack/volcengineStack/deployer.ts
@@ -1,4 +1,4 @@
-import { ServerlessIac } from '../../types';
+import { ServerlessIac, Plan } from '../../types';
 import { getContext, logger } from '../../common';
 import { StateBackend } from '../../common/stateBackend';
 import { lang } from '../../lang';
@@ -33,7 +33,17 @@ const formatApiError = (error: Error): string => {
   return parts.join(' | ');
 };
 
-export const deployVolcengineStack = async (iac: ServerlessIac, backend: StateBackend) => {
+// Issue #246: when the approved plan is passed through, the executor runs
+// exactly the displayed items — partitioned by resourceType, no re-probe.
+const partitionPlan = (plan: Plan, types: string[]): Plan => ({
+  items: plan.items.filter((item) => types.includes(item.resourceType)),
+});
+
+export const deployVolcengineStack = async (
+  iac: ServerlessIac,
+  backend: StateBackend,
+  approvedPlan?: Plan,
+) => {
   const context = getContext();
   logger.info(lang.__('DEPLOYING_STACK'));
 
@@ -46,9 +56,15 @@ export const deployVolcengineStack = async (iac: ServerlessIac, backend: StateBa
 
   logger.info(lang.__('GENERATING_PLAN'));
 
-  const functionPlan = await generateFunctionPlan(context, state, iac.functions);
-  const bucketPlan = await generateBucketPlan(context, state, iac.buckets);
-  const apigwPlan = await generateApigwPlan(context, state, iac.events, iac.service);
+  const functionPlan = approvedPlan
+    ? partitionPlan(approvedPlan, ['VOLCENGINE_VEFAAS'])
+    : await generateFunctionPlan(context, state, iac.functions);
+  const bucketPlan = approvedPlan
+    ? partitionPlan(approvedPlan, ['VOLCENGINE_TOS_BUCKET'])
+    : await generateBucketPlan(context, state, iac.buckets);
+  const apigwPlan = approvedPlan
+    ? partitionPlan(approvedPlan, ['VOLCENGINE_APIGW'])
+    : await generateApigwPlan(context, state, iac.events, iac.service);
 
   const bucketResult = await executeBucketPlan(
     context,

--- a/src/stack/volcengineStack/tosPlanner.ts
+++ b/src/stack/volcengineStack/tosPlanner.ts
@@ -1,4 +1,5 @@
 import path from 'node:path';
+import { lang } from '../../lang';
 import { Context, BucketDomain, Plan, PlanItem, StateFile, ResourceAttributes } from '../../types';
 import { createVolcengineClient } from '../../common/volcengineClient';
 import { cachedRefreshRead } from '../../common/refreshCache';
@@ -62,7 +63,11 @@ export const generateBucketPlan = async (
         isOwned: (remote) => isOwnedByStack(context, logicalId, remote.Tags),
         foreignError: () =>
           new Error(
-            `Bucket ${bucket.name} already exists in provider but is not owned by this stack (missing ${OWNERSHIP_TAG_KEY} tag). Refusing to create — resolve manually.`,
+            lang.__('RESOURCE_EXISTS_NOT_OWNED', {
+              resourceType: 'Bucket',
+              resourceName: bucket.name,
+              tagKey: OWNERSHIP_TAG_KEY,
+            }),
           ),
         cloudToDefinition: cloudTosToDefinition,
         extraUpdate: async () => {

--- a/src/stack/volcengineStack/tosResource.ts
+++ b/src/stack/volcengineStack/tosResource.ts
@@ -94,7 +94,10 @@ export const createResource = async (
 
   if (existingBucketOnRetry) {
     logger.info(
-      `Bucket ${bucket.name} already exists in provider (tainted recovery), skipping create`,
+      lang.__('TAINTED_RECOVERY_SKIP_CREATE', {
+        resourceType: 'Bucket',
+        resourceName: bucket.name,
+      }),
     );
   }
 
@@ -135,7 +138,7 @@ export const createResource = async (
           throw error;
         }
         logger.info(
-          `Bucket ${bucket.name} already exists in provider, verifying ownership tag before adopting`,
+          lang.__('OWNERSHIP_VERIFYING', { resourceType: 'Bucket', resourceName: bucket.name }),
         );
       }
 
@@ -151,7 +154,11 @@ export const createResource = async (
         throw new PartialResourceError(
           stateAfterDependents,
           new Error(
-            `Bucket ${bucket.name} already exists in provider but is not owned by this stack (missing ${OWNERSHIP_TAG_KEY} tag). Refusing to adopt — resolve manually.`,
+            lang.__('RESOURCE_EXISTS_NOT_OWNED_ADOPT', {
+              resourceType: 'Bucket',
+              resourceName: bucket.name,
+              tagKey: OWNERSHIP_TAG_KEY,
+            }),
           ),
         );
       }

--- a/src/stack/volcengineStack/vefaasPlanner.ts
+++ b/src/stack/volcengineStack/vefaasPlanner.ts
@@ -2,6 +2,11 @@ import { attributesEqual, computeZipContentHash, getResource, logger } from '../
 import { getAllResources, getSharedResource } from '../../common/stateManager';
 import { createVolcengineClient } from '../../common/volcengineClient';
 import { cachedRefreshRead } from '../../common/refreshCache';
+import {
+  computeRevertKeys,
+  mergeLiveBefore,
+  remoteDiffersFromDesired,
+} from '../../common/planCompare';
 import { PLAN_READ_CONCURRENCY, mapWithConcurrency } from '../../common/concurrency';
 import {
   Context,
@@ -120,7 +125,11 @@ export const generateFunctionPlan = async (
         );
         if (remoteFunction && !isOwnedByStack(context, logicalId, remoteFunction.Tags)) {
           throw new Error(
-            `Function ${fn.name} already exists in provider but is not owned by this stack (missing ${OWNERSHIP_TAG_KEY} tag). Refusing to create — resolve manually.`,
+            lang.__('RESOURCE_EXISTS_NOT_OWNED', {
+              resourceType: 'Function',
+              resourceName: fn.name,
+              tagKey: OWNERSHIP_TAG_KEY,
+            }),
           );
         }
 
@@ -173,6 +182,11 @@ export const generateFunctionPlan = async (
         // function's actual attributes (runtime/handler/memory/timeout/env)
         // against the desired definition. Console edits would otherwise go
         // undetected — definitionChanged only sees local-vs-desired.
+        // One-directional desired-declared contract (issue #246 fix: this
+        // planner previously used a full two-directional equality, so
+        // cloud-only values within mapped keys phantom-drifted every plan).
+        // Mapper-emitted shapes are subset-normalized to the definition the
+        // config writes, so nested comparisons stay apples-to-apples.
         // Not refreshable (issue #234 phase 2): the IAM custom policy document
         // (volcengine IAM has no GetPolicy read) and dependent TLS topics
         // (existence-only by design decision 5) stay covered by the executor's
@@ -182,26 +196,39 @@ export const generateFunctionPlan = async (
           handler: remoteFunction.handler,
           memorySize: remoteFunction.memoryMb,
           timeout: remoteFunction.requestTimeout,
-          environment: remoteFunction.environmentVariables,
+          environment: remoteFunction.environmentVariables ?? {},
           // Provider responses carry `null` for unset fields while the desired
           // definition carries `undefined` — normalize null → undefined so the
           // comparison ignores the representation difference.
           description: remoteFunction.description ?? undefined,
           role: remoteFunction.role ?? undefined,
-          vpcConfig: remoteFunction.vpcConfig ?? undefined,
+          vpcConfig: remoteFunction.vpcConfig
+            ? {
+                vpcId: remoteFunction.vpcConfig.vpcId ?? undefined,
+                subnetIds: remoteFunction.vpcConfig.subnetIds ?? [],
+                securityGroupIds: remoteFunction.vpcConfig.securityGroupIds ?? [],
+              }
+            : undefined,
           logConfig: remoteFunction.logConfig
             ? { project: remoteFunction.logConfig.project, topic: remoteFunction.logConfig.topic }
             : undefined,
         };
-        const remoteMatchesDesired = attributesEqual(remoteAttributes, desiredDefinition);
+        const remoteDiffers = remoteDiffersFromDesired(remoteAttributes, desiredDefinition);
+        const liveBefore = mergeLiveBefore(currentDefinition, remoteAttributes);
+        const revertKeys = computeRevertKeys(
+          currentDefinition,
+          remoteAttributes,
+          desiredDefinition,
+        );
 
-        if (definitionChanged || !remoteMatchesDesired) {
+        if (definitionChanged || remoteDiffers) {
           return {
             logicalId,
             action: 'update',
             resourceType: 'VOLCENGINE_VEFAAS',
-            changes: { before: currentDefinition, after: desiredDefinition },
+            changes: { before: liveBefore, after: desiredDefinition },
             drifted: true,
+            ...(revertKeys.length ? { revertKeys } : {}),
           };
         }
 
@@ -223,8 +250,9 @@ export const generateFunctionPlan = async (
                 logicalId,
                 action: 'update',
                 resourceType: 'VOLCENGINE_VEFAAS',
-                changes: { before: currentDefinition, after: desiredDefinition },
+                changes: { before: liveBefore, after: desiredDefinition },
                 drifted: true,
+                driftReasons: ['PLAN_DRIFT_ROLE_MISSING'],
               };
             }
             let cloudTrust: unknown;
@@ -247,8 +275,9 @@ export const generateFunctionPlan = async (
                 logicalId,
                 action: 'update',
                 resourceType: 'VOLCENGINE_VEFAAS',
-                changes: { before: currentDefinition, after: desiredDefinition },
+                changes: { before: liveBefore, after: desiredDefinition },
                 drifted: true,
+                driftReasons: ['PLAN_DRIFT_ROLE_POLICY'],
               };
             }
             const desiredManaged = (
@@ -266,8 +295,9 @@ export const generateFunctionPlan = async (
                 logicalId,
                 action: 'update',
                 resourceType: 'VOLCENGINE_VEFAAS',
-                changes: { before: currentDefinition, after: desiredDefinition },
+                changes: { before: liveBefore, after: desiredDefinition },
                 drifted: true,
+                driftReasons: ['PLAN_DRIFT_ROLE_POLICY'],
               };
             }
           } catch (error: unknown) {
@@ -302,8 +332,9 @@ export const generateFunctionPlan = async (
                     logicalId,
                     action: 'update',
                     resourceType: 'VOLCENGINE_VEFAAS',
-                    changes: { before: currentDefinition, after: desiredDefinition },
+                    changes: { before: liveBefore, after: desiredDefinition },
                     drifted: true,
+                    driftReasons: ['PLAN_DRIFT_TLS_TOPIC'],
                   };
                 }
               }
@@ -319,7 +350,13 @@ export const generateFunctionPlan = async (
         }
 
         return { logicalId, action: 'noop', resourceType: 'VOLCENGINE_VEFAAS' };
-      } catch {
+      } catch (error: unknown) {
+        logger.warn(
+          lang.__('PLAN_LIVE_READ_FAILED', {
+            logicalId,
+            error: error instanceof Error ? error.message : String(error),
+          }),
+        );
         return {
           logicalId,
           action: 'create',
@@ -328,6 +365,7 @@ export const generateFunctionPlan = async (
             before: currentState.definition,
             after: desiredDefinition,
           },
+          drifted: true,
         };
       }
     },

--- a/src/stack/volcengineStack/vefaasResource.ts
+++ b/src/stack/volcengineStack/vefaasResource.ts
@@ -580,7 +580,11 @@ export const createResource = async (
         throw new PartialResourceError(
           stateAfterDependents,
           new Error(
-            `Function ${fn.name} already exists in provider but is not owned by this stack (missing ${OWNERSHIP_TAG_KEY} tag). Refusing to adopt — resolve manually.`,
+            lang.__('RESOURCE_EXISTS_NOT_OWNED_ADOPT', {
+              resourceType: 'Function',
+              resourceName: fn.name,
+              tagKey: OWNERSHIP_TAG_KEY,
+            }),
           ),
         );
       }

--- a/src/types/domains/state.ts
+++ b/src/types/domains/state.ts
@@ -92,7 +92,7 @@ export type StateFile = {
  */
 export type PersistedStateFile = Omit<StateFile, 'resources'>;
 
-export type PlanAction = 'create' | 'update' | 'delete' | 'noop' | 'refresh';
+export type PlanAction = 'create' | 'update' | 'delete' | 'noop';
 
 export type PlanItem = {
   logicalId: string;
@@ -103,6 +103,18 @@ export type PlanItem = {
     after?: Record<string, unknown>;
   };
   drifted?: boolean;
+  /**
+   * Top-level keys whose stored value already matches the desired definition
+   * while the live cloud value does not — the field-level signature of an
+   * out-of-config cloud edit. Rendered as a per-field revert annotation.
+   */
+  revertKeys?: string[];
+  /**
+   * Probe-level drift sources that cannot map to attributes (role policy,
+   * logstore, security-group rules, ...). Values are i18n message keys,
+   * resolved at display time.
+   */
+  driftReasons?: string[];
 };
 
 export type Plan = {
@@ -122,8 +134,6 @@ export type PlanDisplayConfig = {
   colorize: boolean;
   indentSize: number;
   keyAlignWidth: number;
-  showUnchangedAttributes: boolean;
-  maxUnchangedHidden: number;
 };
 
 export type SaveStateFn = (state: StateFile) => Promise<void>;

--- a/tests/unit/common/planCompare.test.ts
+++ b/tests/unit/common/planCompare.test.ts
@@ -1,4 +1,9 @@
-import { remoteDiffersFromDesired, jsonDocumentDiffers } from '../../../src/common/planCompare';
+import {
+  remoteDiffersFromDesired,
+  jsonDocumentDiffers,
+  mergeLiveBefore,
+  computeRevertKeys,
+} from '../../../src/common/planCompare';
 
 describe('remoteDiffersFromDesired', () => {
   it('returns false when every declared desired value matches the remote', () => {
@@ -93,5 +98,46 @@ describe('jsonDocumentDiffers', () => {
 
   it('returns false on unparseable input instead of fabricating drift', () => {
     expect(jsonDocumentDiffers('not-json', { a: 1 })).toBe(false);
+  });
+});
+
+describe('mergeLiveBefore (issue #246)', () => {
+  it('lets live values win over stored ones', () => {
+    expect(mergeLiveBefore({ memory: 128, codeHash: 'old' }, { memory: 64 })).toEqual({
+      memory: 64,
+      codeHash: 'old',
+    });
+  });
+
+  it('keeps a live null so the diff shows the cloud cleared the field', () => {
+    expect(mergeLiveBefore({ logConfig: { a: 1 } }, { logConfig: null })).toEqual({
+      logConfig: null,
+    });
+  });
+});
+
+describe('computeRevertKeys (issue #246)', () => {
+  it('marks keys where stored matches desired but live diverged', () => {
+    const stored = { memory: 256, timeout: 30 };
+    const live = { memory: 128, timeout: 30 };
+    const desired = { memory: 256, timeout: 30 };
+
+    expect(computeRevertKeys(stored, live, desired)).toEqual(['memory']);
+  });
+
+  it('does not mark keys the config itself changed', () => {
+    const stored = { memory: 256 };
+    const live = { memory: 128 };
+    const desired = { memory: 512 };
+
+    expect(computeRevertKeys(stored, live, desired)).toEqual([]);
+  });
+
+  it('treats null and undefined as equal representations of unset', () => {
+    const stored = { vpcConfig: null };
+    const live = { vpcConfig: { vpcId: 'vpc-1' } };
+    const desired = { vpcConfig: undefined };
+
+    expect(computeRevertKeys(stored, live, desired)).toEqual(['vpcConfig']);
   });
 });

--- a/tests/unit/common/planFormatter.test.ts
+++ b/tests/unit/common/planFormatter.test.ts
@@ -260,6 +260,46 @@ describe('planFormatter', () => {
       expect(output).toContain('(changed in the cloud, will be restored to config)');
     });
 
+    it('expands non-simple revert keys into children without a parent annotation', () => {
+      const item: PlanItem = {
+        logicalId: 'functions.notify',
+        action: 'update',
+        resourceType: 'ALIYUN_FC3',
+        drifted: true,
+        revertKeys: ['vpcConfig'],
+        changes: {
+          before: { vpcConfig: { vSwitchIds: ['vsw-1'] } },
+          after: { vpcConfig: { vSwitchIds: ['vsw-2'] } },
+        },
+      };
+
+      const output = formatPlanItem(item, config);
+
+      expect(output).toContain('vpcConfig:');
+      expect(output).toContain('vSwitchIds: ["vsw-1"] -> ["vsw-2"]');
+      expect(output).not.toContain('(changed in the cloud, will be restored to config)');
+    });
+
+    it('does not annotate a revert key whose diff expands into children', () => {
+      const item: PlanItem = {
+        logicalId: 'functions.notify',
+        action: 'update',
+        resourceType: 'ALIYUN_FC3',
+        drifted: true,
+        revertKeys: ['environment'],
+        changes: {
+          before: { environment: { LOG_LEVEL: 'info' } },
+          after: { environment: { LOG_LEVEL: 'debug' } },
+        },
+      };
+
+      const output = formatPlanItem(item, config);
+
+      expect(output).toContain('environment:');
+      expect(output).toContain('LOG_LEVEL: "info" -> "debug"');
+      expect(output).not.toContain('(changed in the cloud, will be restored to config)');
+    });
+
     it('renders a recreate (create with recorded before) as a single -/+ block', () => {
       const item: PlanItem = {
         logicalId: 'databases.order-db',

--- a/tests/unit/common/planFormatter.test.ts
+++ b/tests/unit/common/planFormatter.test.ts
@@ -93,8 +93,6 @@ describe('planFormatter', () => {
       colorize: false,
       indentSize: 4,
       keyAlignWidth: 12,
-      showUnchangedAttributes: false,
-      maxUnchangedHidden: 5,
     };
 
     it('should format create action', () => {
@@ -179,17 +177,14 @@ describe('planFormatter', () => {
       expect(output).toContain('- functions.old:');
     });
 
-    it('should format noop action', () => {
+    it('renders unchanged resources as empty (count-only summary)', () => {
       const item: PlanItem = {
         logicalId: 'functions.unchanged',
         action: 'noop',
         resourceType: 'ALIYUN_FC3_FUNCTION',
       };
 
-      const output = formatPlanItem(item, config);
-
-      expect(output).toContain('# functions.unchanged no changes');
-      expect(output).not.toContain('functions.unchanged:');
+      expect(formatPlanItem(item, config)).toBe('');
     });
 
     it('should show unchanged count', () => {
@@ -207,6 +202,145 @@ describe('planFormatter', () => {
 
       expect(output).toContain('(4 unchanged attributes hidden)');
     });
+
+    it('renders a mixed Modify block with field-level add/change/remove markers', () => {
+      const item: PlanItem = {
+        logicalId: 'functions.order',
+        action: 'update',
+        resourceType: 'ALIYUN_FC3',
+        changes: {
+          before: { memory: 512, description: 'legacy order service' },
+          after: { memory: 2048, tags: { team: 'pay' } },
+        },
+      };
+
+      const output = formatPlanItem(item, config);
+
+      expect(output).toContain('~ functions.order:');
+      expect(output).toContain('memory:      512 -> 2048');
+      expect(output).toContain('tags:');
+      expect(output).toContain('description:');
+    });
+
+    it('annotates revert fields with the cloud-changed marker', () => {
+      const item: PlanItem = {
+        logicalId: 'functions.notify',
+        action: 'update',
+        resourceType: 'ALIYUN_FC3',
+        drifted: true,
+        revertKeys: ['logTtl'],
+        changes: {
+          before: { logTtl: 7 },
+          after: { logTtl: 30 },
+        },
+      };
+
+      const output = formatPlanItem(item, config);
+
+      expect(output).toContain('logTtl:      7 -> 30');
+      expect(output).toContain('(changed in the cloud, will be restored to config)');
+    });
+
+    it('annotates revert fields that surface as added keys (cloud deleted them)', () => {
+      const item: PlanItem = {
+        logicalId: 'functions.notify',
+        action: 'update',
+        resourceType: 'ALIYUN_FC3',
+        drifted: true,
+        revertKeys: ['logConfig'],
+        changes: {
+          before: { memory: 512 },
+          after: { memory: 512, logConfig: { enabled: true } },
+        },
+      };
+
+      const output = formatPlanItem(item, config);
+
+      expect(output).toContain('logConfig:');
+      expect(output).toContain('(changed in the cloud, will be restored to config)');
+    });
+
+    it('renders a recreate (create with recorded before) as a single -/+ block', () => {
+      const item: PlanItem = {
+        logicalId: 'databases.order-db',
+        action: 'create',
+        resourceType: 'ALIYUN_RDS_SERVERLESS',
+        drifted: true,
+        changes: {
+          before: { instanceName: 'old-name' },
+          after: { instanceName: 'new-name' },
+        },
+      };
+
+      const output = formatPlanItem(item, config);
+
+      expect(output).toContain('# databases.order-db will be recreated');
+      expect(output).toContain('-/+ databases.order-db:');
+      expect(output).toContain('instanceName: "old-name" -> "new-name"');
+    });
+
+    it('renders pure adds (no before) with the plain + symbol', () => {
+      const item: PlanItem = {
+        logicalId: 'functions.pay',
+        action: 'create',
+        resourceType: 'ALIYUN_FC3',
+        changes: {
+          after: { runtime: 'nodejs20', codeHash: 'abc' },
+        },
+      };
+
+      const output = formatPlanItem(item, config);
+
+      expect(output).toContain('+ functions.pay:');
+      expect(output).not.toContain('-/+');
+      expect(output).toContain('(known after deploy)');
+    });
+
+    it('renders drift reasons as explanatory lines', () => {
+      const item: PlanItem = {
+        logicalId: 'functions.notify',
+        action: 'update',
+        resourceType: 'ALIYUN_FC3',
+        drifted: true,
+        driftReasons: ['PLAN_DRIFT_ROLE_POLICY'],
+        changes: {
+          before: { memory: 512 },
+          after: { memory: 512 },
+        },
+      };
+
+      const output = formatPlanItem(item, config);
+
+      expect(output).toContain('# IAM role policy changed in the cloud');
+      expect(output).not.toContain('cloud changed outside of this config');
+    });
+
+    it('falls back to the generic drift marker when a drifted item has no other explanation', () => {
+      const item: PlanItem = {
+        logicalId: 'functions.mystery',
+        action: 'update',
+        resourceType: 'ALIYUN_FC3',
+        drifted: true,
+        changes: { before: { memory: 512 }, after: { memory: 512 } },
+      };
+
+      const output = formatPlanItem(item, config);
+
+      expect(output).toContain('cloud changed outside of this config');
+    });
+
+    it('does not mark undrifted updates with the drift marker', () => {
+      const item: PlanItem = {
+        logicalId: 'functions.a',
+        action: 'update',
+        resourceType: 'ALIYUN_FC3',
+        changes: { before: { memory: 128 }, after: { memory: 256 } },
+      };
+
+      const output = formatPlanItem(item, config);
+
+      expect(output).not.toContain('cloud changed outside of this config');
+    });
   });
 
   describe('formatPlan', () => {
@@ -214,8 +348,6 @@ describe('planFormatter', () => {
       colorize: false,
       indentSize: 4,
       keyAlignWidth: 12,
-      showUnchangedAttributes: false,
-      maxUnchangedHidden: 5,
     };
 
     it('should return no changes message for empty items', () => {
@@ -223,7 +355,7 @@ describe('planFormatter', () => {
       expect(output).toBe('No changes. Infrastructure is up to date.');
     });
 
-    it('should format multiple items with summary', () => {
+    it('should format multiple items with a full summary', () => {
       const items: PlanItem[] = [
         {
           logicalId: 'functions.hello',
@@ -248,91 +380,69 @@ describe('planFormatter', () => {
       const output = formatPlan(items, config);
 
       expect(output).toContain('ServerlessInsight will perform the following actions');
-      expect(output).toContain('+ create');
-      expect(output).toContain('~ update in-place');
-      expect(output).toContain('- destroy');
-      expect(output).toContain('Plan: 1 to add, 1 to change, 1 to destroy.');
+      expect(output).toContain('+ functions.hello:');
+      expect(output).toContain('~ functions.api:');
+      expect(output).toContain('- functions.old:');
+      expect(output).toContain('Plan: 1 add, 1 modify, 1 remove, 0 recreate, 0 unchanged.');
     });
 
-    it('should group items by action type', () => {
+    it('preserves the given (domain) order instead of regrouping by action', () => {
       const items: PlanItem[] = [
         {
-          logicalId: 'functions.b',
-          action: 'create',
-          resourceType: 'ALIYUN_FC3_FUNCTION',
-          changes: { after: { name: 'b' } },
+          logicalId: 'buckets.assets',
+          action: 'delete',
+          resourceType: 'ALIYUN_OSS_BUCKET',
+          changes: { before: { bucketName: 'assets' } },
         },
         {
           logicalId: 'functions.a',
           action: 'create',
-          resourceType: 'ALIYUN_FC3_FUNCTION',
+          resourceType: 'ALIYUN_FC3',
           changes: { after: { name: 'a' } },
         },
       ];
 
       const output = formatPlan(items, config);
 
-      const aIndex = output.indexOf('functions.a');
-      const bIndex = output.indexOf('functions.b');
-      expect(aIndex).toBeGreaterThan(-1);
-      expect(bIndex).toBeGreaterThan(-1);
+      expect(output.indexOf('buckets.assets')).toBeLessThan(output.indexOf('functions.a'));
     });
 
-    it('marks drifted updates with the drift marker line', () => {
+    it('counts unchanged and recreate resources in the summary', () => {
       const items: PlanItem[] = [
         {
-          logicalId: 'functions.a',
-          action: 'update',
+          logicalId: 'functions.api',
+          action: 'noop',
           resourceType: 'ALIYUN_FC3',
-          drifted: true,
-          changes: { before: { memory: 128 }, after: { memory: 256 } },
-        },
-      ];
-
-      const output = formatPlanItem(items[0], config);
-
-      expect(output).toContain('cloud changed outside of this config');
-    });
-
-    it('does not mark undrifted updates with the drift marker', () => {
-      const items: PlanItem[] = [
-        {
-          logicalId: 'functions.a',
-          action: 'update',
-          resourceType: 'ALIYUN_FC3',
-          changes: { before: { memory: 128 }, after: { memory: 256 } },
-        },
-      ];
-
-      const output = formatPlanItem(items[0], config);
-
-      expect(output).not.toContain('cloud changed outside of this config');
-    });
-
-    it('summarizes drifted resources when any item drifted', () => {
-      const items: PlanItem[] = [
-        {
-          logicalId: 'functions.a',
-          action: 'update',
-          resourceType: 'ALIYUN_FC3',
-          drifted: true,
-          changes: { before: { memory: 128 }, after: { memory: 256 } },
         },
         {
-          logicalId: 'functions.b',
+          logicalId: 'buckets.static',
+          action: 'noop',
+          resourceType: 'ALIYUN_OSS_BUCKET',
+        },
+        {
+          logicalId: 'databases.order-db',
           action: 'create',
-          resourceType: 'ALIYUN_FC3',
-          changes: { after: { name: 'b' } },
+          resourceType: 'ALIYUN_RDS_SERVERLESS',
+          drifted: true,
+          changes: { before: { instanceName: 'old' }, after: { instanceName: 'new' } },
         },
       ];
 
       const output = formatPlan(items, config);
 
-      expect(output).toContain('Drift: 1 resource(s)');
+      expect(output).not.toContain('functions.api:');
+      expect(output).toContain('Plan: 0 add, 0 modify, 0 remove, 1 recreate, 2 unchanged.');
     });
 
-    it('omits the drift summary when nothing drifted', () => {
+    it('summarizes drifted resources without a separate drift section', () => {
       const items: PlanItem[] = [
+        {
+          logicalId: 'functions.a',
+          action: 'update',
+          resourceType: 'ALIYUN_FC3',
+          drifted: true,
+          changes: { before: { memory: 128 }, after: { memory: 256 } },
+        },
         {
           logicalId: 'functions.b',
           action: 'create',
@@ -344,6 +454,73 @@ describe('planFormatter', () => {
       const output = formatPlan(items, config);
 
       expect(output).not.toContain('Drift:');
+      expect(output).toContain('~ functions.a:');
+    });
+
+    // Issue #246 invariant: every non-unchanged plan item must render at
+    // least one attribute line or one explanation line under its resource
+    // header — an action block with nothing under it is the empty-drift-diff
+    // regression this issue fixes.
+    it('renders at least one field or explanation line for every non-noop item', () => {
+      const items: PlanItem[] = [
+        {
+          logicalId: 'functions.create',
+          action: 'create',
+          resourceType: 'ALIYUN_FC3',
+          changes: { after: { name: 'n' } },
+        },
+        {
+          logicalId: 'functions.recreate',
+          action: 'create',
+          resourceType: 'ALIYUN_FC3',
+          drifted: true,
+          changes: { before: { name: 'old' }, after: { name: 'new' } },
+        },
+        {
+          logicalId: 'functions.update',
+          action: 'update',
+          resourceType: 'ALIYUN_FC3',
+          drifted: true,
+          changes: { before: { memory: 1 }, after: { memory: 2 } },
+        },
+        {
+          logicalId: 'functions.reason-only',
+          action: 'update',
+          resourceType: 'ALIYUN_FC3',
+          drifted: true,
+          driftReasons: ['PLAN_DRIFT_LOGSTORE'],
+          changes: { before: { memory: 1 }, after: { memory: 1 } },
+        },
+        {
+          logicalId: 'functions.marker-fallback',
+          action: 'update',
+          resourceType: 'ALIYUN_FC3',
+          drifted: true,
+          changes: { before: { memory: 1 }, after: { memory: 1 } },
+        },
+        {
+          logicalId: 'buckets.gone',
+          action: 'delete',
+          resourceType: 'ALIYUN_OSS_BUCKET',
+          changes: { before: { bucketName: 'gone' } },
+        },
+        {
+          logicalId: 'functions.no-changes-payload',
+          action: 'update',
+          resourceType: 'ALIYUN_FC3',
+          drifted: true,
+        },
+      ];
+
+      for (const item of items) {
+        const lines = formatPlanItem(item, config)
+          .split('\n')
+          .map((line) => line.trim())
+          .filter(Boolean);
+        // lines[0] = `# logicalId ...`, lines[1] = `<symbol> logicalId:`
+        const bodyLines = lines.slice(2);
+        expect(bodyLines.length).toBeGreaterThan(0);
+      }
     });
   });
 });

--- a/tests/unit/common/refreshPlanner.test.ts
+++ b/tests/unit/common/refreshPlanner.test.ts
@@ -99,6 +99,18 @@ describe('planRefreshedResource', () => {
     expect(item).toMatchObject({ action: 'create', drifted: true });
   });
 
+  it('stringifies non-Error read failures in the degradation warning', async () => {
+    const warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => {});
+    const read = jest.fn().mockRejectedValue('raw provider failure');
+    const item = await planRefreshedResource(args({ read }));
+
+    expect(item).toMatchObject({ action: 'create', drifted: true });
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to read live state for buckets.test'),
+    );
+    warnSpy.mockRestore();
+  });
+
   it('degrades a failed live read to a drifted create with a warning', async () => {
     const warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => {});
     const read = jest.fn().mockRejectedValue(new Error('throttled'));

--- a/tests/unit/common/refreshPlanner.test.ts
+++ b/tests/unit/common/refreshPlanner.test.ts
@@ -1,5 +1,6 @@
 import { planRefreshedResource } from '../../../src/common/refreshPlanner';
 import type { PlanRefreshedResourceArgs } from '../../../src/common/refreshPlanner';
+import { logger } from '../../../src/common/logger';
 import type { ResourceState } from '../../../src/types';
 
 type Remote = { name: string; memory: number };
@@ -42,11 +43,70 @@ describe('planRefreshedResource', () => {
     expect(item).toMatchObject({ action: 'update', drifted: true });
   });
 
+  // Issue #246: the diff baseline for a drift update is cloud reality.
+  it('uses the live attributes as changes.before and marks revert keys', async () => {
+    const read = jest.fn().mockResolvedValue({ name: 'test', memory: 64 });
+    const item = await planRefreshedResource(args({ read }));
+
+    expect(item.changes?.before).toEqual({ name: 'test', memory: 64 });
+    expect(item.changes?.after).toEqual({ name: 'test', memory: 128 });
+    expect(item.revertKeys).toEqual(['memory']);
+  });
+
+  it('does not mark revert keys when the config itself changed the field', async () => {
+    const read = jest.fn().mockResolvedValue({ name: 'test', memory: 64 });
+    const item = await planRefreshedResource(
+      args({ read, desiredDefinition: { name: 'test', memory: 256 } }),
+    );
+
+    expect(item.changes?.before).toEqual({ name: 'test', memory: 64 });
+    expect(item.revertKeys).toBeUndefined();
+  });
+
+  it('carries stored keys the cloud mapper never emits into the diff baseline', async () => {
+    const storedWithHash: ResourceState = {
+      ...currentState,
+      definition: { name: 'test', memory: 128, codeHash: 'old-hash' },
+    };
+    const read = jest.fn().mockResolvedValue({ name: 'test', memory: 128 });
+    const item = await planRefreshedResource(
+      args({
+        currentState: storedWithHash,
+        read,
+        desiredDefinition: { name: 'test', memory: 256 },
+      }),
+    );
+
+    // live memory (128) wins over stored memory for the diff baseline, while
+    // the stored codeHash fills the dimension the cloud mapper never emits.
+    expect(item.changes?.before).toEqual({ name: 'test', memory: 128, codeHash: 'old-hash' });
+  });
+
+  it('surfaces probe-level drift reasons from extraUpdate', async () => {
+    const item = await planRefreshedResource(
+      args({
+        extraUpdate: () => Promise.resolve({ update: true, drifted: true, reason: 'PLAN_DRIFT_X' }),
+      }),
+    );
+
+    expect(item).toMatchObject({ action: 'update', drifted: true, driftReasons: ['PLAN_DRIFT_X'] });
+  });
+
   it('flags create+drifted when the remote is gone', async () => {
     const read = jest.fn().mockResolvedValue(null);
     const item = await planRefreshedResource(args({ read }));
 
     expect(item).toMatchObject({ action: 'create', drifted: true });
+  });
+
+  it('degrades a failed live read to a drifted create with a warning', async () => {
+    const warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => {});
+    const read = jest.fn().mockRejectedValue(new Error('throttled'));
+    const item = await planRefreshedResource(args({ read }));
+
+    expect(item).toMatchObject({ action: 'create', drifted: true });
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
   });
 
   it('throws on the probe path when a foreign same-named remote exists', async () => {

--- a/tests/unit/stack/aliyunStack/apigwPlanner.test.ts
+++ b/tests/unit/stack/aliyunStack/apigwPlanner.test.ts
@@ -622,6 +622,62 @@ describe('Apigw Planner', () => {
       expect(plan.items[0].changes?.after).toBeDefined();
     });
 
+    it('degrades to a drifted create when the live group read rejects with a non-Error', async () => {
+      let state = loadState('aliyun', 'test-app', 'test-service', 'default', testDir);
+      state = setResource(state, 'events.test_api', {
+        mode: 'managed',
+        region: 'cn-hangzhou',
+        definition: {
+          groupName: 'test-service-default-test-api-agw-group',
+          description: 'API Gateway group for test-service',
+          basePath: null,
+          triggers: [{ method: 'GET', path: '/users', backend: 'userFunction' }],
+          domain: null,
+        },
+        instances: [
+          {
+            type: 'ALIYUN_APIGW_GROUP',
+            sid: 'si:aliyun:apigateway:default:group-123',
+            id: 'group-123',
+            groupName: 'test-service-default-test-api-agw-group',
+          },
+        ],
+        lastUpdated: new Date().toISOString(),
+      });
+
+      mockApigwOperations.getApiGroup.mockRejectedValue('apigw exploded');
+
+      const plan = await generateApigwPlan(mockContext, state, [testEvent], 'test-service');
+
+      expect(plan.items).toHaveLength(1);
+      expect(plan.items[0]).toMatchObject({ action: 'create', drifted: true });
+    });
+
+    it('uses the stored definition as before when no group instance is recorded', async () => {
+      // definitionChanged with no group instance: the live baseline is
+      // unavailable, so changes.before falls back to the stored definition.
+      let state = loadState('aliyun', 'test-app', 'test-service', 'default', testDir);
+      state = setResource(state, 'events.test_api', {
+        mode: 'managed',
+        region: 'cn-hangzhou',
+        definition: {
+          groupName: 'test-service-default-test-api-agw-group',
+          description: 'older description',
+          basePath: null,
+          triggers: [{ method: 'GET', path: '/users', backend: 'userFunction' }],
+          domain: null,
+        },
+        instances: [],
+        lastUpdated: new Date().toISOString(),
+      });
+
+      const plan = await generateApigwPlan(mockContext, state, [testEvent], 'test-service');
+
+      expect(plan.items).toHaveLength(1);
+      expect(plan.items[0]).toMatchObject({ action: 'update' });
+      expect(plan.items[0].changes?.before).toMatchObject({ description: 'older description' });
+    });
+
     it('degrades to a drifted create when the live group read fails', async () => {
       // Issue #246: a failed live read must warn and fall back honestly
       // (drifted create), not silently look like a routine plan.

--- a/tests/unit/stack/aliyunStack/apigwPlanner.test.ts
+++ b/tests/unit/stack/aliyunStack/apigwPlanner.test.ts
@@ -334,6 +334,57 @@ describe('Apigw Planner', () => {
       });
     });
 
+    it('skips non-event resources in the deletion scan while events match', async () => {
+      // Issue #246 patch coverage: the deletion filter's early `return false`
+      // for logicalIds outside the events.* namespace.
+      let state = loadState('aliyun', 'test-app', 'test-service', 'default', testDir);
+      state = setResource(state, 'functions.userFunction', {
+        mode: 'managed',
+        region: 'cn-hangzhou',
+        definition: { functionName: 'user-function' },
+        instances: [
+          {
+            type: 'ALIYUN_FC3_FUNCTION',
+            sid: 'si:aliyun:fc3:default:user-function',
+            id: 'user-function',
+          },
+        ],
+        lastUpdated: new Date().toISOString(),
+      });
+      state = setResource(state, 'events.test_api', {
+        mode: 'managed',
+        region: 'cn-hangzhou',
+        definition: {
+          groupName: 'test-service-default-test-api-agw-group',
+          description: 'API Gateway group for test-service',
+          basePath: null,
+          triggers: [{ method: 'GET', path: '/users', backend: 'userFunction' }],
+          domain: null,
+        },
+        instances: [
+          {
+            type: 'ALIYUN_APIGW_GROUP',
+            sid: 'si:aliyun:apigateway:default:group-123',
+            id: 'group-123',
+            groupName: 'test-service-default-test-api-agw-group',
+          },
+        ],
+        lastUpdated: new Date().toISOString(),
+      });
+
+      mockApigwOperations.getApiGroup.mockResolvedValue({
+        groupId: 'group-123',
+        groupName: 'test-service-default-test-api-agw-group',
+        description: 'API Gateway group for test-service',
+      });
+      mockMatchingApis();
+
+      const plan = await generateApigwPlan(mockContext, state, [testEvent], 'test-service');
+
+      expect(plan.items).toHaveLength(1);
+      expect(plan.items[0]).toMatchObject({ logicalId: 'events.test_api', action: 'noop' });
+    });
+
     it('should plan to update when definition changes', async () => {
       // Add event to state with different definition
       let state = loadState('aliyun', 'test-app', 'test-service', 'default', testDir);
@@ -569,6 +620,39 @@ describe('Apigw Planner', () => {
         drifted: true,
       });
       expect(plan.items[0].changes?.after).toBeDefined();
+    });
+
+    it('degrades to a drifted create when the live group read fails', async () => {
+      // Issue #246: a failed live read must warn and fall back honestly
+      // (drifted create), not silently look like a routine plan.
+      let state = loadState('aliyun', 'test-app', 'test-service', 'default', testDir);
+      state = setResource(state, 'events.test_api', {
+        mode: 'managed',
+        region: 'cn-hangzhou',
+        definition: {
+          groupName: 'test-service-default-test-api-agw-group',
+          description: 'API Gateway group for test-service',
+          basePath: null,
+          triggers: [{ method: 'GET', path: '/users', backend: 'userFunction' }],
+          domain: null,
+        },
+        instances: [
+          {
+            type: 'ALIYUN_APIGW_GROUP',
+            sid: 'si:aliyun:apigateway:default:group-123',
+            id: 'group-123',
+            groupName: 'test-service-default-test-api-agw-group',
+          },
+        ],
+        lastUpdated: new Date().toISOString(),
+      });
+
+      mockApigwOperations.getApiGroup.mockRejectedValue(new Error('apigw throttled'));
+
+      const plan = await generateApigwPlan(mockContext, state, [testEvent], 'test-service');
+
+      expect(plan.items).toHaveLength(1);
+      expect(plan.items[0]).toMatchObject({ action: 'create', drifted: true });
     });
 
     it('should plan update+drifted when the live group description drifted from the config', async () => {

--- a/tests/unit/stack/aliyunStack/databaseResource.test.ts
+++ b/tests/unit/stack/aliyunStack/databaseResource.test.ts
@@ -578,7 +578,7 @@ describe('DatabaseResource', () => {
         createDatabaseResource(mockContext, esDatabase, initialState),
       ).rejects.toMatchObject({
         name: 'PartialResourceError',
-        cause: { message: expect.stringContaining('not owned by this stack') },
+        cause: { message: expect.stringContaining('RESOURCE_EXISTS_NOT_OWNED_ADOPT') },
       });
     });
 
@@ -648,7 +648,7 @@ describe('DatabaseResource', () => {
         createDatabaseResource(mockContext, rdsDatabase, initialState),
       ).rejects.toMatchObject({
         name: 'PartialResourceError',
-        cause: { message: expect.stringContaining('not owned by this stack') },
+        cause: { message: expect.stringContaining('RESOURCE_EXISTS_NOT_OWNED_ADOPT') },
       });
     });
 

--- a/tests/unit/stack/aliyunStack/fc3Planner.test.ts
+++ b/tests/unit/stack/aliyunStack/fc3Planner.test.ts
@@ -955,6 +955,29 @@ describe('FC3 Planner', () => {
       expect(mockRamOperations.listAttachedRolePolicies).toHaveBeenCalledWith('test-managed-role');
     });
 
+    it('skips role-policy compare when no managed role instance is recorded in state', async () => {
+      // resolveManagedRoleProbe still probes by the derived name, but
+      // detectRolePolicyDrift returns early without a recorded role instance
+      // (issue #246 patch coverage: early-return path).
+      const fn: FunctionDomain = {
+        ...testFunction,
+        iam: { role: { name: 'test-managed-role' } },
+      };
+      const state = buildState(fn, [fc3Instance]);
+      mockFc3Operations.getFunction.mockResolvedValue(remoteFunctionMatch);
+      mockRamOperations.getRole.mockResolvedValue({
+        roleName: 'test-managed-role',
+        assumeRolePolicyDocument: FC_TRUST_FC_ONLY,
+      });
+      mockRamOperations.getExecutionPolicyDocument.mockResolvedValue(EXEC_BASELINE_DOC);
+      mockRamOperations.listAttachedRolePolicies.mockResolvedValue([]);
+
+      const plan = await generateFunctionPlan(mockContext, state, [fn]);
+
+      expect(plan.items[0]).toMatchObject({ action: 'noop', resourceType: 'ALIYUN_FC3' });
+      expect(mockRamOperations.getExecutionPolicyDocument).not.toHaveBeenCalled();
+    });
+
     it('stays noop (never create) when the role probe read fails transiently', async () => {
       const fn: FunctionDomain = {
         ...testFunction,
@@ -1020,6 +1043,30 @@ describe('FC3 Planner', () => {
         const plan = await generateFunctionPlan(mockContext, buildLogState(), [fnWithLog]);
 
         expect(plan.items[0]).toMatchObject({ action: 'update', drifted: true });
+      });
+
+      it('flags the logstore drift reason when the logstore was deleted out-of-band', async () => {
+        mockSlsOperations.getLogstore.mockResolvedValue(null);
+
+        const plan = await generateFunctionPlan(mockContext, buildLogState(), [fnWithLog]);
+
+        expect(plan.items[0]).toMatchObject({
+          action: 'update',
+          drifted: true,
+          driftReasons: ['PLAN_DRIFT_LOGSTORE'],
+        });
+      });
+
+      it('flags update+drifted when live shards fall below the baseline (deficit)', async () => {
+        mockSlsOperations.getLogstore.mockResolvedValue({ ttl: 30, shardCount: 1 });
+
+        const plan = await generateFunctionPlan(mockContext, buildLogState(), [fnWithLog]);
+
+        expect(plan.items[0]).toMatchObject({
+          action: 'update',
+          drifted: true,
+          driftReasons: ['PLAN_DRIFT_LOGSTORE'],
+        });
       });
 
       it('ignores shard growth (aliyun cannot shrink shards)', async () => {

--- a/tests/unit/stack/aliyunStack/fc3Planner.test.ts
+++ b/tests/unit/stack/aliyunStack/fc3Planner.test.ts
@@ -802,6 +802,54 @@ describe('FC3 Planner', () => {
       });
     });
 
+    it('omits revertKeys when the config itself changed the drifted field', async () => {
+      // stored 256 -> desired 512 -> live 256: the difference is intent, not
+      // a cloud-side revert, so no field is annotated.
+      const fn = { ...testFunction, memory: 512 };
+      const state = buildState({ ...fn, memory: 256 }, [fc3Instance]);
+      mockFc3Operations.getFunction.mockResolvedValue({ ...remoteFunctionMatch, memorySize: 256 });
+
+      const plan = await generateFunctionPlan(mockContext, state, [fn]);
+
+      expect(plan.items[0]).toMatchObject({ action: 'update', drifted: true });
+      expect(plan.items[0].revertKeys).toBeUndefined();
+    });
+
+    it('falls back to an empty stored baseline when the state definition is missing', async () => {
+      const fn = testFunction;
+      const resource = buildState(fn, [fc3Instance]).resources['functions.test_fn'];
+      const state = setResource(initalState, 'functions.test_fn', {
+        ...resource,
+        definition: undefined as unknown as Record<string, unknown>,
+      });
+      mockFc3Operations.getFunction.mockResolvedValue({ ...remoteFunctionMatch, memorySize: 256 });
+
+      const plan = await generateFunctionPlan(mockContext, state, [fn]);
+
+      expect(plan.items[0]).toMatchObject({ action: 'update', drifted: true });
+      expect(plan.items[0].changes?.before).toBeDefined();
+    });
+
+    it('degrades to a drifted create when the live read fails with an Error', async () => {
+      const fn = testFunction;
+      const state = buildState(fn, [fc3Instance]);
+      mockFc3Operations.getFunction.mockRejectedValue(new Error('fc3 throttled'));
+
+      const plan = await generateFunctionPlan(mockContext, state, [fn]);
+
+      expect(plan.items[0]).toMatchObject({ action: 'create', drifted: true });
+    });
+
+    it('degrades to a drifted create when the live read rejects with a non-Error', async () => {
+      const fn = testFunction;
+      const state = buildState(fn, [fc3Instance]);
+      mockFc3Operations.getFunction.mockRejectedValue('fc3 api exploded');
+
+      const plan = await generateFunctionPlan(mockContext, state, [fn]);
+
+      expect(plan.items[0]).toMatchObject({ action: 'create', drifted: true });
+    });
+
     it('flags update+drifted when the live timeout/environment drifted', async () => {
       const fn = testFunction;
       const state = buildState(fn, [fc3Instance]);

--- a/tests/unit/stack/deploy.test.ts
+++ b/tests/unit/stack/deploy.test.ts
@@ -84,7 +84,7 @@ describe('Unit tests for Aliyun stack deployment', () => {
 
     await deployStack(minimumIac, mockBackend);
 
-    expect(mockedDeployAliyunStack).toHaveBeenCalledWith(minimumIac, mockBackend);
+    expect(mockedDeployAliyunStack).toHaveBeenCalledWith(minimumIac, mockBackend, undefined);
   });
 
   it('should generate and execute function plan for FC functions', async () => {
@@ -92,7 +92,7 @@ describe('Unit tests for Aliyun stack deployment', () => {
 
     await deployStack(oneFcIac, mockBackend);
 
-    expect(mockedDeployAliyunStack).toHaveBeenCalledWith(oneFcIac, mockBackend);
+    expect(mockedDeployAliyunStack).toHaveBeenCalledWith(oneFcIac, mockBackend, undefined);
   });
 
   it('should save state after execution', async () => {
@@ -100,7 +100,7 @@ describe('Unit tests for Aliyun stack deployment', () => {
 
     await deployStack(oneFcIac, mockBackend);
 
-    expect(mockedDeployAliyunStack).toHaveBeenCalledWith(oneFcIac, mockBackend);
+    expect(mockedDeployAliyunStack).toHaveBeenCalledWith(oneFcIac, mockBackend, undefined);
   });
 
   it('should dispatch Tencent deployments to the Tencent stack', async () => {
@@ -111,7 +111,7 @@ describe('Unit tests for Aliyun stack deployment', () => {
 
     await deployStack(tencentIac, mockBackend);
 
-    expect(mockedDeployTencentStack).toHaveBeenCalledWith(tencentIac, mockBackend);
+    expect(mockedDeployTencentStack).toHaveBeenCalledWith(tencentIac, mockBackend, undefined);
   });
 
   it('should report that Huawei deployment is not implemented', async () => {

--- a/tests/unit/stack/scfStack/cosPlanner.test.ts
+++ b/tests/unit/stack/scfStack/cosPlanner.test.ts
@@ -427,7 +427,7 @@ describe('cosPlanner', () => {
       });
 
       await expect(generateBucketPlan(mockContext, initialState, [testBucket])).rejects.toThrow(
-        'not owned by this stack',
+        'RESOURCE_EXISTS_NOT_OWNED',
       );
     });
 
@@ -472,7 +472,7 @@ describe('cosPlanner', () => {
       });
 
       await expect(generateBucketPlan(mockContext, initialState, [testBucket])).rejects.toThrow(
-        'not owned by this stack',
+        'RESOURCE_EXISTS_NOT_OWNED',
       );
     });
   });

--- a/tests/unit/stack/scfStack/esServerlessPlanner.test.ts
+++ b/tests/unit/stack/scfStack/esServerlessPlanner.test.ts
@@ -187,7 +187,7 @@ describe('esServerlessPlanner', () => {
       });
 
       await expect(generateEsPlan(mockContext, initialState, [testDatabase])).rejects.toThrow(
-        'not owned by this stack',
+        'RESOURCE_EXISTS_NOT_OWNED',
       );
     });
 
@@ -245,7 +245,7 @@ describe('esServerlessPlanner', () => {
       });
 
       await expect(generateEsPlan(mockContext, initialState, [testDatabase])).rejects.toThrow(
-        'not owned by this stack',
+        'RESOURCE_EXISTS_NOT_OWNED',
       );
     });
 

--- a/tests/unit/stack/scfStack/esServerlessResource.test.ts
+++ b/tests/unit/stack/scfStack/esServerlessResource.test.ts
@@ -494,7 +494,7 @@ describe('EsServerlessResource', () => {
         createEsResource(mockContext, createTestDatabase('test_es'), initialState),
       ).rejects.toMatchObject({
         name: 'PartialResourceError',
-        cause: { message: expect.stringContaining('not owned by this stack') },
+        cause: { message: expect.stringContaining('RESOURCE_EXISTS_NOT_OWNED_ADOPT') },
       });
     });
   });

--- a/tests/unit/stack/scfStack/tdsqlcPlanner.test.ts
+++ b/tests/unit/stack/scfStack/tdsqlcPlanner.test.ts
@@ -431,7 +431,9 @@ describe('TdsqlcPlanner', () => {
       const result = await generateDatabasePlan(mockContext, mockState, [mockDatabase]);
 
       expect(result.items[0]).toMatchObject({ action: 'create' });
-      expect(result.items[0]).not.toHaveProperty('drifted');
+      // Issue #246: a read-failure fallback create is honest about not
+      // knowing the cloud state — it carries the drifted flag.
+      expect(result.items[0]).toHaveProperty('drifted', true);
       expect(result.items[0].changes?.before).toEqual(expectedDefinition);
     });
 

--- a/tests/unit/stack/volcengineStack/apigwPlanner.test.ts
+++ b/tests/unit/stack/volcengineStack/apigwPlanner.test.ts
@@ -136,7 +136,7 @@ describe('apigwPlanner', () => {
 
     await expect(
       generateApigwPlan(mockContext, emptyState, [mockEvent], 'test-service'),
-    ).rejects.toThrow('not owned by this stack');
+    ).rejects.toThrow('RESOURCE_EXISTS_NOT_OWNED');
   });
 
   it('plans noop when state matches the desired definition', async () => {

--- a/tests/unit/stack/volcengineStack/tosPlanner.test.ts
+++ b/tests/unit/stack/volcengineStack/tosPlanner.test.ts
@@ -117,7 +117,7 @@ describe('tosPlanner', () => {
       });
 
       await expect(generateBucketPlan(mockContext, mockState, buckets)).rejects.toThrow(
-        'not owned by this stack',
+        'RESOURCE_EXISTS_NOT_OWNED',
       );
     });
 
@@ -192,7 +192,7 @@ describe('tosPlanner', () => {
       });
 
       await expect(generateBucketPlan(mockContext, stateWithTainted, buckets)).rejects.toThrow(
-        'not owned by this stack',
+        'RESOURCE_EXISTS_NOT_OWNED',
       );
     });
 

--- a/tests/unit/stack/volcengineStack/tosResource.test.ts
+++ b/tests/unit/stack/volcengineStack/tosResource.test.ts
@@ -530,7 +530,7 @@ describe('tosResource', () => {
 
       await expect(createResource(mockContext, bucket, mockState)).rejects.toMatchObject({
         name: 'PartialResourceError',
-        cause: { message: expect.stringContaining('not owned by this stack') },
+        cause: { message: expect.stringContaining('RESOURCE_EXISTS_NOT_OWNED_ADOPT') },
       });
     });
 
@@ -549,7 +549,7 @@ describe('tosResource', () => {
 
       await expect(createResource(mockContext, bucket, mockState)).rejects.toMatchObject({
         name: 'PartialResourceError',
-        cause: { message: expect.stringContaining('not owned by this stack') },
+        cause: { message: expect.stringContaining('RESOURCE_EXISTS_NOT_OWNED_ADOPT') },
       });
     });
   });

--- a/tests/unit/stack/volcengineStack/vefaasPlanner.test.ts
+++ b/tests/unit/stack/volcengineStack/vefaasPlanner.test.ts
@@ -205,7 +205,7 @@ describe('vefaasPlanner', () => {
       });
 
       await expect(generateFunctionPlan(mockContext, mockState, [mockFunction])).rejects.toThrow(
-        'not owned by this stack',
+        'RESOURCE_EXISTS_NOT_OWNED',
       );
     });
 
@@ -268,7 +268,7 @@ describe('vefaasPlanner', () => {
       });
 
       await expect(generateFunctionPlan(mockContext, taintedState, [mockFunction])).rejects.toThrow(
-        'not owned by this stack',
+        'RESOURCE_EXISTS_NOT_OWNED',
       );
     });
 
@@ -305,6 +305,60 @@ describe('vefaasPlanner', () => {
 
       expect(result.items).toHaveLength(1);
       expect(result.items[0].action).toBe('update');
+    });
+
+    // Issue #246 regression: the cloud returns null environmentVariables and
+    // vpcConfig objects carrying provider-only fields (enableVpc, ...) — the
+    // one-directional desired-declared compare must not phantom-drift on them
+    // (the old two-directional attributesEqual did, on every plan).
+    it('stays noop when the cloud returns null env vars and provider-only vpc fields', async () => {
+      const stateWithFunction: StateFile = {
+        ...mockState,
+        resources: {
+          'functions.test_fn': {
+            mode: 'managed',
+            region: 'cn-beijing',
+            definition: {
+              functionName: 'test-function',
+              runtime: 'nodejs16',
+              handler: 'index.handler',
+              memorySize: 128,
+              timeout: 30,
+              environment: {},
+              codeHash: 'test-hash',
+            },
+            instances: [
+              { sid: 'test-sid', id: 'test-function', type: 'VOLCENGINE_VEFAAS_FUNCTION' },
+            ],
+            lastUpdated: '2024-01-01T00:00:00Z',
+          },
+        },
+      };
+
+      mockVefaasClient.vefaas.getFunction.mockResolvedValueOnce({
+        functionName: 'test-function',
+        runtime: 'nodejs16',
+        handler: 'index.handler',
+        memoryMb: 128,
+        requestTimeout: 30,
+        environmentVariables: null,
+        vpcConfig: {
+          vpcId: 'vpc-1',
+          subnetIds: ['subnet-1'],
+          securityGroupIds: [],
+          enableVpc: true,
+          enableSharedInternetAccess: false,
+        },
+      });
+
+      jest
+        .spyOn(stateManager, 'getResource')
+        .mockReturnValue(stateWithFunction.resources['functions.test_fn']);
+
+      const result = await generateFunctionPlan(mockContext, stateWithFunction, [mockFunction]);
+
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0].action).toBe('noop');
     });
 
     it('should generate noop plan when function unchanged', async () => {

--- a/tests/unit/stack/volcengineStack/vefaasPlanner.test.ts
+++ b/tests/unit/stack/volcengineStack/vefaasPlanner.test.ts
@@ -52,6 +52,10 @@ describe('vefaasPlanner', () => {
       getTopic: jest.fn(),
       modifyTopic: jest.fn(),
     },
+    iam: {
+      getRole: jest.fn(),
+      listAttachedRolePolicies: jest.fn(),
+    },
   };
 
   const mockFunction: FunctionDomain = {
@@ -86,6 +90,7 @@ describe('vefaasPlanner', () => {
     let mockVefaasClient: {
       vefaas: { getFunction: jest.Mock };
       tls: { getTopic: jest.Mock; modifyTopic: jest.Mock };
+      iam: { getRole: jest.Mock; listAttachedRolePolicies: jest.Mock };
     };
 
     beforeEach(() => {
@@ -96,6 +101,10 @@ describe('vefaasPlanner', () => {
         tls: {
           getTopic: jest.fn(),
           modifyTopic: jest.fn(),
+        },
+        iam: {
+          getRole: jest.fn(),
+          listAttachedRolePolicies: jest.fn(),
         },
       };
       (createVolcengineClient as jest.Mock).mockReturnValue(mockVefaasClient);
@@ -742,6 +751,99 @@ describe('vefaasPlanner', () => {
             logConfig: { project: 'test-app-dev-tls', topic: 'test-service-dev-test_fn-fn-logs' },
           },
         },
+      });
+    });
+
+    // Issue #246: live role drift surfaces as a drift reason, not a bare flag.
+    const buildRoleState = (): StateFile => ({
+      ...mockState,
+      resources: {
+        'functions.test_fn': {
+          mode: 'managed',
+          region: 'cn-beijing',
+          definition: {
+            functionName: 'test-function',
+            runtime: 'nodejs16',
+            handler: 'index.handler',
+            memorySize: 128,
+            timeout: 30,
+            environment: {},
+            codeHash: 'test-hash',
+          },
+          instances: [
+            { sid: 'test-sid', id: 'test-function', type: 'VOLCENGINE_VEFAAS_FUNCTION' },
+            { sid: 'role-sid', id: 'role-1', type: 'VOLCENGINE_IAM_ROLE' },
+          ],
+          lastUpdated: '2024-01-01T00:00:00Z',
+        },
+      },
+    });
+
+    const matchingRemote = (): void => {
+      mockVefaasClient.vefaas.getFunction.mockResolvedValue({
+        functionName: 'test-function',
+        runtime: 'nodejs16',
+        handler: 'index.handler',
+        memoryMb: 128,
+        requestTimeout: 30,
+        environmentVariables: null,
+      });
+    };
+
+    it('flags the role-missing drift reason when the cloud role is gone', async () => {
+      jest
+        .spyOn(hashUtils, 'attributesEqual')
+        .mockImplementation((a, b) => JSON.stringify(a) === JSON.stringify(b));
+      const state = buildRoleState();
+      matchingRemote();
+      mockVefaasClient.iam.getRole.mockResolvedValue(null);
+
+      const plan = await generateFunctionPlan(mockContext, state, [mockFunction]);
+
+      expect(plan.items[0]).toMatchObject({
+        action: 'update',
+        drifted: true,
+        driftReasons: ['PLAN_DRIFT_ROLE_MISSING'],
+      });
+    });
+
+    it('flags the role-policy drift reason when the trust policy drifted', async () => {
+      jest
+        .spyOn(hashUtils, 'attributesEqual')
+        .mockImplementation((a, b) => JSON.stringify(a) === JSON.stringify(b));
+      const state = buildRoleState();
+      matchingRemote();
+      mockVefaasClient.iam.getRole.mockResolvedValue({
+        roleId: 'role-1',
+        trustPolicyDocument: '{"Statement":[{"Effect":"Deny"}]}',
+      });
+
+      const plan = await generateFunctionPlan(mockContext, state, [mockFunction]);
+
+      expect(plan.items[0]).toMatchObject({
+        action: 'update',
+        drifted: true,
+        driftReasons: ['PLAN_DRIFT_ROLE_POLICY'],
+      });
+    });
+
+    it('flags the role-policy drift reason when attached managed policies drifted', async () => {
+      jest
+        .spyOn(hashUtils, 'attributesEqual')
+        .mockImplementation((a, b) => JSON.stringify(a) === JSON.stringify(b));
+      const state = buildRoleState();
+      matchingRemote();
+      // No trustPolicyDocument → trust check skipped; managed policy set
+      // mismatch drives the drift.
+      mockVefaasClient.iam.getRole.mockResolvedValue({ roleId: 'role-1' });
+      mockVefaasClient.iam.listAttachedRolePolicies.mockResolvedValue(['unrelated-policy']);
+
+      const plan = await generateFunctionPlan(mockContext, state, [mockFunction]);
+
+      expect(plan.items[0]).toMatchObject({
+        action: 'update',
+        drifted: true,
+        driftReasons: ['PLAN_DRIFT_ROLE_POLICY'],
       });
     });
 

--- a/tests/unit/stack/volcengineStack/vefaasPlanner.test.ts
+++ b/tests/unit/stack/volcengineStack/vefaasPlanner.test.ts
@@ -790,6 +790,69 @@ describe('vefaasPlanner', () => {
       });
     };
 
+    it('omits revertKeys when the config itself changed the drifted field', async () => {
+      // stored 128 -> desired 256 -> live 128: intent-driven, nothing to mark.
+      jest
+        .spyOn(hashUtils, 'attributesEqual')
+        .mockImplementation((a, b) => JSON.stringify(a) === JSON.stringify(b));
+      const desiredFn = { ...mockFunction, memory: 256 };
+      const state = buildRoleState();
+      state.resources['functions.test_fn'].definition = {
+        ...state.resources['functions.test_fn'].definition,
+        memorySize: 128,
+      } as never;
+      mockVefaasClient.vefaas.getFunction.mockResolvedValue({
+        functionName: 'test-function',
+        runtime: 'nodejs16',
+        handler: 'index.handler',
+        memoryMb: 128,
+        requestTimeout: 30,
+        environmentVariables: null,
+      });
+
+      const plan = await generateFunctionPlan(mockContext, state, [desiredFn]);
+
+      expect(plan.items[0]).toMatchObject({ action: 'update', drifted: true });
+      expect(plan.items[0].revertKeys).toBeUndefined();
+    });
+
+    it('normalizes a remote vpcConfig with null subfields without phantom drift', async () => {
+      jest
+        .spyOn(hashUtils, 'attributesEqual')
+        .mockImplementation((a, b) => JSON.stringify(a) === JSON.stringify(b));
+      const state = buildRoleState();
+      mockVefaasClient.vefaas.getFunction.mockResolvedValue({
+        functionName: 'test-function',
+        runtime: 'nodejs16',
+        handler: 'index.handler',
+        memoryMb: 128,
+        requestTimeout: 30,
+        environmentVariables: null,
+        vpcConfig: {
+          vpcId: null,
+          subnetIds: null,
+          securityGroupIds: null,
+          enableVpc: true,
+        },
+      });
+      // The recorded role instance triggers the role probe — satisfy it.
+      mockVefaasClient.iam.getRole.mockResolvedValue({ roleId: 'role-1' });
+      mockVefaasClient.iam.listAttachedRolePolicies.mockResolvedValue(['role-1-policy']);
+
+      const plan = await generateFunctionPlan(mockContext, state, [mockFunction]);
+
+      expect(plan.items[0]).toMatchObject({ action: 'noop' });
+    });
+
+    it('degrades to a drifted create when the live read rejects with a non-Error', async () => {
+      const state = buildRoleState();
+      mockVefaasClient.vefaas.getFunction.mockRejectedValue('vefaas exploded');
+
+      const plan = await generateFunctionPlan(mockContext, state, [mockFunction]);
+
+      expect(plan.items[0]).toMatchObject({ action: 'create', drifted: true });
+    });
+
     it('flags the role-missing drift reason when the cloud role is gone', async () => {
       jest
         .spyOn(hashUtils, 'attributesEqual')

--- a/tests/unit/stack/volcengineStack/vefaasResource.test.ts
+++ b/tests/unit/stack/volcengineStack/vefaasResource.test.ts
@@ -333,7 +333,7 @@ describe('vefaasResource', () => {
 
       await expect(createResource(mockContext, mockFunction, mockState)).rejects.toMatchObject({
         name: 'PartialResourceError',
-        cause: { message: expect.stringContaining('not owned by this stack') },
+        cause: { message: expect.stringContaining('RESOURCE_EXISTS_NOT_OWNED_ADOPT') },
       });
     });
 


### PR DESCRIPTION
Closes #246

## 背景

`si plan`/`si deploy` 的 diff 一直不完整：漂移检测（#234）已经从云端读到了 live 属性，但构建 PlanItem 时只留下一个 boolean，`changes` 仍是 `state.definition → desired`。纯漂移场景（本地没改、云端被人改）下 before === after，用户只看到 `~ logicalId:` + 一行 drifted 标记，看不到漂了哪个字段。此外 vefaas 用双向全量比较造成每次 plan 假漂移。完整 review 结论与设计共识见 #246。

本次按 #246 的三期修复策略完整落地，并采纳 issue 讨论中定稿的显示规范：**资源范式（一个资源一个块一个符号）、字段级 +/~/- 标记、unchanged 只进计数、重建渲染为单块 `-/+`**。

## Phase 1 — diff 基线升级为 live（核心契约）

- `RefreshExistsDecision` 携带 `liveAttributes`；`planRefreshedResource` 的 update 项 `changes.before = mergeLiveBefore(stored, live)`（live 值优先，cloud mapper 不产出的键由 stored 快照补齐）→ **空 diff 问题从结构上消失**
- `planCompare` 新增 `mergeLiveBefore` / `computeRevertKeys`（stored==desired 但 live≠desired 的字段 = 云端单方面修改的字段级签名）
- `PlanItem` 新增 `revertKeys` / `driftReasons`（探针级漂移：角色策略、logstore、SG 规则、NAS 挂载、TLS/CLS topic、API 触发器）
- fc3 / vefaas / apigw 自定义流接入 live before；scf CLS 探测并入骨架 `extraUpdate`
- **vefaas 假漂移修复**：双向 `attributesEqual` → 单向 `remoteDiffersFromDesired`，mapper 子集归一（null env vars、provider-only vpc 字段不再造成每次 plan 假漂移，附回归测试）
- 读失败降级 create：`logger.warn` + `drifted: true`（原先静默、语义不一致）
- 删除死代码：`PlanAction 'refresh'`、`maxUnchangedHidden`、`showUnchangedAttributes`、`PLAN_LEGEND_*`、`PLAN_DRIFTED_SUMMARY`

## Phase 2 — 显示层

- `formatPlan` 保持 planner 域序单遍历渲染，不再按动作分组重排
- 重建（create 且有 before）渲染为单块 `-/+`（will be recreated）；纯 add 保持 `+`；一个 logicalId 永远只出现一次
- revert 字段逐行标注「(云端已改，将按配置恢复)」（change/add/remove 叶子行均覆盖）；driftReasons 渲染为块内解释行；drifted 项必须自我解释（不变式测试兜底）
- unchanged 资源不渲染块，仅进汇总计数；块内保留「(+N 个未变更属性已隐藏)」
- 汇总：`Plan: X add, X modify, X remove, X recreate, X unchanged`
- ownership / tainted-recovery 消息全量 i18n（en + zh-CN）

## Phase 3 — 概念收敛

- `si diff` 作为主推动词（与 plan 同参，plan 保留兼容）
- deploy 单次 plan：展示确认的 plan 直传 `deployStack` → 各 provider deployer 按 resourceType 分区执行，消除展示与执行两次计算的偏差（不传 plan 的旧路径保留）
- ADR-002 追加 #246 决议：refresh 命令裁撤、两态模型（desired vs live）、`state.definition` 重释为「上次同步的云端快照」

## 显示效果

```
ServerlessInsight will perform the following actions:

  # functions.pay will be created
  + functions.pay:
      runtime:        "nodejs20"
      codeHash:       (known after deploy)

  # functions.order will be updated in-place
  ~ functions.order:
      memorySize:     512 -> 2048
      tags:           { "team": "pay" }
      description:    "legacy order service"
      (+2 个未变更属性已隐藏)

  # functions.notify will be updated in-place
  ~ functions.notify:
      logTtl:         7 -> 30 (云端已改，将按配置恢复)

  # databases.order-db will be recreated
  -/+ databases.order-db:
      instanceName:   "old-name" -> "new-name"

Plan: 1 add, 2 modify, 0 remove, 1 recreate, 3 unchanged.
```

## 验证

- `npm test`：165 suites / 3515 tests 全绿，85% 覆盖门禁通过（exit 0）
- `npm run lint:check` / `npm run build`：通过
- 新增测试：不变式（每个非 noop 项 ≥1 行字段或解释）、drift-update live→desired 显示、revert 标注（change 型 + add 型）、recreate `-/+`、vefaas null environment 不假漂移回归、refreshPlanner live-baseline / revertKeys / 降级 warn
- 附带发现：localStack 套件存在偶发 `EADDRINUSE :4567` flaky（干净树可复现，与本 PR 无关），已单开 #247 跟进
